### PR TITLE
Add first Abstraction Interfaces

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 schranz-search
+Copyright (c) 2022 Alexander Schranz
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/SEAL/Adapter/AdapterInterface.php
+++ b/src/SEAL/Adapter/AdapterInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Schranz\Search\SEAL\Adapter;
+
+interface AdapterInterface
+{
+    public function getSchemaManager(): SchemaManagerInterface;
+
+    public function getConnection(): ConnectionInterface;
+}

--- a/src/SEAL/Adapter/ConnectionInterface.php
+++ b/src/SEAL/Adapter/ConnectionInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Schranz\Search\SEAL\Adapter;
+
+use Schranz\Search\SEAL\Schema\Index;
+
+interface ConnectionInterface
+{
+    public function index(Index $index, array $document);
+
+    public function delete(Index $index, string $identifier);
+}

--- a/src/SEAL/Adapter/SchemaManagerInterface.php
+++ b/src/SEAL/Adapter/SchemaManagerInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Schranz\Search\SEAL\Adapter;
+
+use Schranz\Search\SEAL\Schema\Index;
+
+interface SchemaManagerInterface
+{
+    public function existIndex(Index $index): void;
+
+    public function dropIndex(Index $index): void;
+
+    public function createIndex(Index $index): void;
+}

--- a/src/SEAL/Engine.php
+++ b/src/SEAL/Engine.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Schranz\Search\SEAL;
+
+use Schranz\Search\SEAL\Adapter\AdapterInterface;
+use Schranz\Search\SEAL\Schema\Schema;
+
+final class Engine
+{
+    public function __construct(
+        readonly private AdapterInterface $adapter,
+        readonly private Schema $schema,
+    ) {}
+
+    /**
+     * @param array<string, mixed> $document
+     *
+     * @return array<string, mixed>
+     */
+    public function indexDocument(string $index, array $document): array
+    {
+        return $this->adapter->getConnection()->index(
+            $this->schema->indexes[$index],
+            $document
+        );
+    }
+
+    public function deleteDocument(string $index, string $identifier): void
+    {
+        $this->adapter->getConnection()->delete(
+            $this->schema->indexes[$index],
+            $identifier
+        );
+    }
+
+    public function dropIndex(string $index): void
+    {
+        $this->adapter->getSchemaManager()->dropIndex($this->schema->indexes[$index]);
+    }
+
+    public function existIndex(string $index): void
+    {
+        $this->adapter->getSchemaManager()->existIndex($this->schema->indexes[$index]);
+    }
+
+    public function createIndex(string $index): void
+    {
+        $this->adapter->getSchemaManager()->createIndex($this->schema->indexes[$index]);
+    }
+
+    public function createSchema(): void
+    {
+        foreach ($this->schema->indexes as $index) {
+            $this->adapter->getSchemaManager()->createIndex($index);
+        }
+    }
+
+    public function dropSchema(): void
+    {
+        foreach ($this->schema->indexes as $index) {
+            $this->adapter->getSchemaManager()->dropIndex($index);
+        }
+    }
+}

--- a/src/SEAL/README.md
+++ b/src/SEAL/README.md
@@ -1,0 +1,3 @@
+# Schranz Search SEAL
+
+**S**earch **E**ngine **A**bstraction **L**ayer with support to different search engines.

--- a/src/SEAL/Schema/Field.php
+++ b/src/SEAL/Schema/Field.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Schranz\Search\SEAL\Schema;
+
+final class Field
+{
+    /**
+     * @param array<string, mixed> $typeOptions
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly string $normalizedName,
+        public readonly string $type, // TODO enum?
+        public readonly array $typeOptions = [], // TODO object?
+    ) {}
+}

--- a/src/SEAL/Schema/Index.php
+++ b/src/SEAL/Schema/Index.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Schranz\Search\SEAL\Schema;
+
+final class Index
+{
+    /**
+     * @param array<string, Field> $fields
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly string $normalizedName,
+        public readonly array $fields
+    ) {}
+}

--- a/src/SEAL/Schema/Schema.php
+++ b/src/SEAL/Schema/Schema.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Schranz\Search\SEAL\Schema;
+
+final class Schema
+{
+    /**
+     * @param array<string, Index>
+     */
+    public function __construct(
+        public readonly array $indexes
+    ) {}
+}

--- a/src/SEAL/composer.json
+++ b/src/SEAL/composer.json
@@ -1,0 +1,20 @@
+{
+    "name": "schranz-search/seal",
+    "description": "Search Engine Abstraction Layer",
+    "type": "library",
+    "license": "MIT",
+    "autoload": {
+        "psr-4": {
+            "Schranz\\Search\\SEAL\\": ""
+        }
+    },
+    "authors": [
+        {
+            "name": "Alexander Schranz",
+            "email": "alexander@sulu.io"
+        }
+    ],
+    "require": {
+        "php": "^8.1"
+    }
+}

--- a/src/SEAL/composer.lock
+++ b/src/SEAL/composer.lock
@@ -1,0 +1,20 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "6850ada5fccbfb4c163e145ca860bcc8",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "^8.1"
+    },
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
+}


### PR DESCRIPTION
The first interfaces is a mix between the Abstraction of [`Flysystem`](https://github.com/thephpleague/flysystem). Which allows the usage of different adapters over flysystem integration. We will target similar things as each adapter will be an own installable package as it will have requirements to php sdk of specific search engines.

The other orientation is [`Doctrine`](https://github.com/doctrine). The `SEAL` (Search Engine Abstraction Layer) package be seen as an equivalent to `DBAL` which provides a very abstract way of communication with different Platforms. Will work with basic array data. A `SchemaManager` should create or drop Index, a `Connection` to insert or delete documents. What in our case is called Adapter in Doctrine is called Driver, wanted to stick here more with the Flysystem and design pattern name.