### PR TITLE
Add search interfaces

### DIFF
--- a/src/SEAL/.gitignore
+++ b/src/SEAL/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+/composer.phar
+/phpunit.xml

--- a/src/SEAL/Adapter/AdapterInterface.php
+++ b/src/SEAL/Adapter/AdapterInterface.php
@@ -2,9 +2,17 @@
 
 namespace Schranz\Search\SEAL\Adapter;
 
+use Schranz\Search\SEAL\Search\Result;
+use Schranz\Search\SEAL\Search\Search;
+
 interface AdapterInterface
 {
     public function getSchemaManager(): SchemaManagerInterface;
 
     public function getConnection(): ConnectionInterface;
+
+    /**
+     * @return iterable<array<string, mixed>>
+     */
+    public function search(Search $searchBuilder): Result;
 }

--- a/src/SEAL/Adapter/ConnectionInterface.php
+++ b/src/SEAL/Adapter/ConnectionInterface.php
@@ -3,10 +3,14 @@
 namespace Schranz\Search\SEAL\Adapter;
 
 use Schranz\Search\SEAL\Schema\Index;
+use Schranz\Search\SEAL\Search\Result;
+use Schranz\Search\SEAL\Search\Search;
 
 interface ConnectionInterface
 {
     public function index(Index $index, array $document);
 
     public function delete(Index $index, string $identifier);
+
+    public function search(Search $search): Result;
 }

--- a/src/SEAL/Exception/DocumentNotFoundException.php
+++ b/src/SEAL/Exception/DocumentNotFoundException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Schranz\Search\SEAL\Exception;
+
+final class DocumentNotFoundException extends \Exception
+{
+}

--- a/src/SEAL/Search/Filter/IdentifierFilter.php
+++ b/src/SEAL/Search/Filter/IdentifierFilter.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Schranz\Search\SEAL\Search\Filter;
+
+class IdentifierFilter
+{
+    public function __construct(
+        readonly string $identifier,
+    ) {
+    }
+}

--- a/src/SEAL/Search/Result.php
+++ b/src/SEAL/Search/Result.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Schranz\Search\SEAL\Search;
+
+final class Result extends \IteratorIterator
+{
+    /**
+     * @param \Generator<array<string, mixed>> $documents
+     */
+    public function __construct(
+        \Generator $documents,
+        readonly public int $total,
+    ) {
+        parent::__construct($documents);
+    }
+}

--- a/src/SEAL/Search/Search.php
+++ b/src/SEAL/Search/Search.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Schranz\Search\SEAL\Search;
+
+use Schranz\Search\SEAL\Schema\Index;
+
+final class Search
+{
+    /**
+     * @param array<string, Index>
+     * @param object[]
+     */
+    public function __construct(
+        public readonly array $indexes = [],
+        public readonly array $filters = [],
+        public readonly ?int $limit = null,
+        public readonly  ?int $offset = null,
+    ) {}
+}

--- a/src/SEAL/Search/SearchBuilder.php
+++ b/src/SEAL/Search/SearchBuilder.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Schranz\Search\SEAL\Search;
+
+use Schranz\Search\SEAL\Adapter\ConnectionInterface;
+use Schranz\Search\SEAL\Schema\Index;
+use Schranz\Search\SEAL\Schema\Schema;
+
+final class SearchBuilder
+{
+    /**
+     * @var array<string, Index>
+     */
+    private array $indexes = [];
+
+    /**
+     * @var object[]
+     */
+    private array $filters = [];
+
+    private ?int $limit = null;
+
+    private ?int $offset = null;
+
+    public function __construct(
+        readonly private Schema $schema,
+        readonly private ConnectionInterface $connection,
+    ) {}
+
+    public function addIndex(string $name): static
+    {
+        $this->indexes[$name] = $this->schema->indexes[$name];
+
+        return $this;
+    }
+
+    public function addFilter(object $filter): static
+    {
+        $this->filters[] = $filter;
+
+        return $this;
+    }
+
+    public function offset(int $offset): static
+    {
+        $this->offset = $offset;
+
+        return $this;
+    }
+
+    public function limit(int $limit): static
+    {
+        $this->limit = $limit;
+
+        return $this;
+    }
+
+    public function getResult(): Result
+    {
+        return $this->connection->search(new Search(
+            $this->indexes,
+            $this->filters,
+            $this->limit,
+            $this->offset,
+        ));
+    }
+}


### PR DESCRIPTION
Based on #1 we did implement storing and deleting interfaces. But the search and findDocument was missing. After some research I did go a similar implementation like in doctrine/dbal, but instead of QueryBuilder->getQuery it is directly `SearchBuilder` `getResult` and the `Search` object is just used by the adapter. And the underlaying adapter connection is directly called and by getResult and returns a Result which is forced for performance reasons to be a Generator.