### PR TITLE
Rename index document to save document

### DIFF
--- a/src/SEAL/Adapter/ConnectionInterface.php
+++ b/src/SEAL/Adapter/ConnectionInterface.php
@@ -8,7 +8,7 @@ use Schranz\Search\SEAL\Search\Search;
 
 interface ConnectionInterface
 {
-    public function index(Index $index, array $document);
+    public function save(Index $index, array $document);
 
     public function delete(Index $index, string $identifier);
 

--- a/src/SEAL/Engine.php
+++ b/src/SEAL/Engine.php
@@ -20,9 +20,9 @@ final class Engine
      *
      * @return array<string, mixed>
      */
-    public function indexDocument(string $index, array $document): array
+    public function saveDocument(string $index, array $document): array
     {
-        return $this->adapter->getConnection()->index(
+        return $this->adapter->getConnection()->save(
             $this->schema->indexes[$index],
             $document
         );

--- a/src/SEAL/README.md
+++ b/src/SEAL/README.md
@@ -111,11 +111,13 @@ $engine = new Engine(
 
 The engine is the main entry point to interact with the search engine:
 
-#### Indexing a document
+#### Save a document
 
 ```php
-$engine->indexDocument('news', $document);
+$engine->saveDocument('news', $document);
 ```
+
+> Will overwrite existing document if document with same id already exists.
 
 #### Find a document
 

--- a/src/SEAL/Testing/AbstractSchemaManagerTestCase.php
+++ b/src/SEAL/Testing/AbstractSchemaManagerTestCase.php
@@ -5,23 +5,23 @@ namespace Schranz\Search\SEAL\Testing;
 use PHPUnit\Framework\TestCase;
 use Schranz\Search\SEAL\Adapter\SchemaManagerInterface;
 
-class AbstractSchemaManagerTest extends TestCase
+abstract class AbstractSchemaManagerTest extends TestCase
 {
-    protected SchemaManagerInterface $schemaManager;
+    protected static SchemaManagerInterface $schemaManager;
 
     public function testIndex(): void
     {
         $schema = TestingHelper::createSchema();
         $index = $schema->indexes[TestingHelper::INDEX_SIMPLE];
 
-        $this->assertFalse($this->schemaManager->existIndex($index));
+        $this->assertFalse(static::$schemaManager->existIndex($index));
 
-        $this->schemaManager->createIndex($index);
+        static::$schemaManager->createIndex($index);
 
-        $this->assertTrue($this->schemaManager->existIndex($index));
+        $this->assertTrue(static::$schemaManager->existIndex($index));
 
-        $this->schemaManager->dropIndex($index);
+        static::$schemaManager->dropIndex($index);
 
-        $this->assertTrue($this->schemaManager->existIndex($index));
+        $this->assertTrue(static::$schemaManager->existIndex($index));
     }
 }


### PR DESCRIPTION
Rename index document to save document to make things more clear that it will be overwritten when document with same id already exists.