### PR TITLE
Remove unnecessary method from adapter and make total a method

### DIFF
--- a/src/SEAL/Adapter/AdapterInterface.php
+++ b/src/SEAL/Adapter/AdapterInterface.php
@@ -2,17 +2,9 @@
 
 namespace Schranz\Search\SEAL\Adapter;
 
-use Schranz\Search\SEAL\Search\Result;
-use Schranz\Search\SEAL\Search\Search;
-
 interface AdapterInterface
 {
     public function getSchemaManager(): SchemaManagerInterface;
 
     public function getConnection(): ConnectionInterface;
-
-    /**
-     * @return iterable<array<string, mixed>>
-     */
-    public function search(Search $searchBuilder): Result;
 }

--- a/src/SEAL/Search/Result.php
+++ b/src/SEAL/Search/Result.php
@@ -2,15 +2,20 @@
 
 namespace Schranz\Search\SEAL\Search;
 
-final class Result extends \IteratorIterator
+class Result extends \IteratorIterator
 {
     /**
      * @param \Generator<array<string, mixed>> $documents
      */
     public function __construct(
         \Generator $documents,
-        readonly public int $total,
+        readonly private int $total,
     ) {
         parent::__construct($documents);
+    }
+
+    public function total(): int
+    {
+        return $this->total;
     }
 }


### PR DESCRIPTION
We make total a method and the Result not longer final as so the total can be lazy if a search engine does not support to get total with the query. Also the  `search` method was removed from the adapter as that method is accessed via the `ConnectionInterface`.