### PR TITLE
Add ReadWrite Adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,10 @@ None open source search engine from MongoDB. It is a cloud based search engine.
 
  - Server: [MongoDB Atlas](https://www.mongodb.com/atlas/search)
  - PHP Client: [MongoDB Atlas PHP Client](https://www.mongodb.com/docs/drivers/php/#connect-to-mongodb-atlas)
+
+## Similar Projects
+
+Following projects in the past target similar problem:
+
+ - [https://github.com/nresni/Ariadne](https://github.com/nresni/Ariadne) (Solr, Elasticsearch, Zendsearch: outdated 12 years ago)
+ - [https://github.com/massiveart/MassiveSearchBundle](https://github.com/massiveart/MassiveSearchBundle) (ZendSearch, Elasticsearch)

--- a/src/SEAL/Adapter/ConnectionInterface.php
+++ b/src/SEAL/Adapter/ConnectionInterface.php
@@ -8,9 +8,12 @@ use Schranz\Search\SEAL\Search\Search;
 
 interface ConnectionInterface
 {
-    public function save(Index $index, array $document);
+    /**
+     * @return array<string, mixed>
+     */
+    public function save(Index $index, array $document): array;
 
-    public function delete(Index $index, string $identifier);
+    public function delete(Index $index, string $identifier): void;
 
     public function search(Search $search): Result;
 }

--- a/src/SEAL/Adapter/ReadWrite/.gitignore
+++ b/src/SEAL/Adapter/ReadWrite/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+/composer.phar
+/phpunit.xml

--- a/src/SEAL/Adapter/ReadWrite/LICENSE
+++ b/src/SEAL/Adapter/ReadWrite/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Alexander Schranz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/SEAL/Adapter/ReadWrite/README.md
+++ b/src/SEAL/Adapter/ReadWrite/README.md
@@ -1,0 +1,36 @@
+# Schranz Search SEAL Read Write Adapter
+
+The `ReadWriteAdapter` allows to use one adapter instance for writing
+and one for reading. This is useful if you want to reindex something.
+
+> This is a subtree split of the `schranz-search/schranz-search` project create issues in the [main repository](https://github.com/schranz-search/schranz-search).
+
+## Usage
+
+To use the adapter an instance of `ReadWriteAdapter` need to be created
+which get a `$readAdapter` and `$writeAdapter` which are instances of the
+`AdapterInterface`.
+
+```php
+<?php
+
+use Schranz\Search\SEAL\Adapter\Elasticsearch\ElasticsearchAdapter;
+use Schranz\Search\SEAL\Adapter\ReadWrite\ReadWriteAdapter;
+use Schranz\Search\SEAL\Engine;
+
+$readAdapter = new ElasticsearchAdapter(/* .. */); // can be any adapter
+$writeAdapter = new ElasticsearchAdapter(/* .. */); // can be any adapter
+
+$engine = new Engine(
+    new ReadWriteAdapter(
+        $readAdapter,
+        $writeAdapter
+    ),
+    $schema,
+);
+```
+
+> **Note**
+> Read a document and partial update it based on the read document should be avoided
+> when using this adapter, as the read document could already be outdated. So always
+> fully update the document and never do based on read documents.

--- a/src/SEAL/Adapter/ReadWrite/ReadWriteAdapter.php
+++ b/src/SEAL/Adapter/ReadWrite/ReadWriteAdapter.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Schranz\Search\SEAL\Adapter\ReadWrite;
+
+use Schranz\Search\SEAL\Adapter\AdapterInterface;
+use Schranz\Search\SEAL\Adapter\ConnectionInterface;
+use Schranz\Search\SEAL\Adapter\SchemaManagerInterface;
+
+final class ReadWriteAdapter implements AdapterInterface
+{
+    private ?ConnectionInterface $connection = null;
+
+    public function __construct(
+        private readonly AdapterInterface $readAdapter,
+        private readonly AdapterInterface $writeAdapter,
+    ) {}
+
+    public function getSchemaManager(): SchemaManagerInterface
+    {
+        return $this->writeAdapter->getSchemaManager();
+    }
+
+    public function getConnection(): ConnectionInterface
+    {
+        if ($this->connection === null) {
+            return new ReadWriteConnection(
+                $this->readAdapter->getConnection(),
+                $this->writeAdapter->getConnection(),
+            );
+        }
+
+        return $this->connection;
+    }
+}

--- a/src/SEAL/Adapter/ReadWrite/ReadWriteConnection.php
+++ b/src/SEAL/Adapter/ReadWrite/ReadWriteConnection.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Schranz\Search\SEAL\Adapter\ReadWrite;
+
+use Schranz\Search\SEAL\Adapter\ConnectionInterface;
+use Schranz\Search\SEAL\Schema\Index;
+use Schranz\Search\SEAL\Search\Result;
+use Schranz\Search\SEAL\Search\Search;
+
+/**
+ * @internal This class should never be needed to be instanced manually.
+ */
+final class ReadWriteConnection implements ConnectionInterface
+{
+    public function __construct(
+        public readonly ConnectionInterface $readConnection,
+        public readonly ConnectionInterface $writeConnection,
+    ) {}
+
+    public function save(Index $index, array $document): array
+    {
+        return $this->writeConnection->save($index, $document);
+    }
+
+    public function delete(Index $index, string $identifier): void
+    {
+        $this->writeConnection->delete($index, $identifier);
+    }
+
+    public function search(Search $search): Result
+    {
+        return $this->readConnection->search($search);
+    }
+
+}

--- a/src/SEAL/Adapter/ReadWrite/composer.json
+++ b/src/SEAL/Adapter/ReadWrite/composer.json
@@ -1,0 +1,21 @@
+{
+    "name": "schranz-search/seal-read-write-adapter",
+    "description": "An adapter to support to split read and write operations for the schranz-search/seal package.",
+    "type": "library",
+    "license": "MIT",
+    "autoload": {
+        "psr-4": {
+            "Schranz\\Search\\SEAL\\Adapter\\ReadWrite\\": ""
+        }
+    },
+    "authors": [
+        {
+            "name": "Alexander Schranz",
+            "email": "alexander@sulu.io"
+        }
+    ],
+    "require": {
+        "php": "^8.1",
+        "schranz-search/seal": "^1.0"
+    }
+}

--- a/src/SEAL/LICENSE
+++ b/src/SEAL/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Alexander Schranz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/SEAL/README.md
+++ b/src/SEAL/README.md
@@ -7,6 +7,8 @@ and [Flysystem](https://github.com/thephpleague/flysystem).
 
 > This package is still in development and no adapters do exist yet.
 
+> This is part of the `schranz-search/schranz-search` project create issues in the [main repository](https://github.com/schranz-search/schranz-search).
+
 ## Usage
 
 ### Example Document
@@ -110,6 +112,11 @@ $engine = new Engine(
 ```
 
 The engine is the main entry point to interact with the search engine:
+
+#### List of adapters
+
+ - [ReadWrite](Adapter/ReadWrite)
+ - ... more coming soon
 
 #### Save a document
 

--- a/src/SEAL/composer.json
+++ b/src/SEAL/composer.json
@@ -6,7 +6,10 @@
     "autoload": {
         "psr-4": {
             "Schranz\\Search\\SEAL\\": ""
-        }
+        },
+        "exclude-from-classmap": [
+            "/Adapter/ReadWrite/"
+        ]
     },
     "authors": [
         {


### PR DESCRIPTION
Add a ReadWriteAdapter which allows to split read and writes from each other. This is commonly used to do a reindex into another instance or indexes to avoid.

Additional a `MultiAdapter` can be used as write adapter to write always into both indexes.