### PR TITLE
Add TypedField for block based content management system

### DIFF
--- a/src/SEAL/README.md
+++ b/src/SEAL/README.md
@@ -22,6 +22,24 @@ $document = [
     'id' => '1',
     'title' => 'New Blog',
     'article' => '<article><h2>Some Subtitle</h2><p>A html field with some content</p></article>',
+    'blocks' => [
+        [
+            'type' => 'text',
+            'title' => 'Titel',
+            'description' => '<p>Description</p>',
+            'media' => ['id' => 1, 'displayOption' => 'top'],
+        ],
+        [
+            'type' => 'text',
+            'title' => 'Titel 2',
+            'description' => '<p>Description 2</p>',
+        ],
+        [
+            'type' => 'embed',
+            'title' => 'Video',
+            'media' => 'https://www.youtube.com/watch?v=iYM2zFP3Zn0',
+        ],
+    ],
     'created' => new \DateTimeImmutable('2022-12-24 12:00:00'),
     'commentsCount' => 2,
     'rating' => 3.5,
@@ -74,6 +92,7 @@ $fields = [
     'title' => new Field\TextField('title'),
     'title.raw' => new Field\TextField('title'),
     'article' => new Field\TextField('article'),
+    'blocks' => new Field\CollectionField('blocks', /* TODO */),
     'created' => new Field\DateTimeField('created'),
     'commentsCount' => new Field\IntegerField('commentsCount'),
     'rating' => new Field\FloatField('rating'),

--- a/src/SEAL/README.md
+++ b/src/SEAL/README.md
@@ -27,7 +27,7 @@ $document = [
             'type' => 'text',
             'title' => 'Titel',
             'description' => '<p>Description</p>',
-            'media' => ['id' => 1, 'displayOption' => 'top'],
+            'media' => [3, 4],
         ],
         [
             'type' => 'text',
@@ -74,8 +74,9 @@ A schema can contain multiple indexes. The following field types are available:
 - `INTEGER`: integer to store any PHP int value
 - `DATETIME`: datetime field to store date and date times
 - `OBJECT`: contains other fields nested in it
+- `TYPED`: can define different fields by a type field
 
-With exception to the Identifier all types can be defined as `multiple` to store a list of values.
+With exception to the `Identifier` type all other types can be defined as `multiple` to store a list of values.
 
 Currently, not keep in mind are types like geopoint, date, specific numeric types.
 Specific text types like, url, path, ... should be specified over options in the future.
@@ -92,7 +93,17 @@ $fields = [
     'title' => new Field\TextField('title'),
     'title.raw' => new Field\TextField('title'),
     'article' => new Field\TextField('article'),
-    'blocks' => new Field\CollectionField('blocks', /* TODO */),
+    'blocks' => new Field\TypedField('blocks', 'type', [
+        'text' => [
+            'title' => new Field\TextField('title'),
+            'description' => new Field\TextField('description'),
+            'media' => new Field\IntegerField('media', multiple: true),
+        ],
+        'embed' => [
+            'title' => new Field\TextField('title'),
+            'media' => new Field\TextField('media'),
+        ],
+    ], multiple: true),
     'created' => new Field\DateTimeField('created'),
     'commentsCount' => new Field\IntegerField('commentsCount'),
     'rating' => new Field\FloatField('rating'),

--- a/src/SEAL/README.md
+++ b/src/SEAL/README.md
@@ -182,7 +182,7 @@ $documents = $engine->createSearchBuilder()
     ->getResult();
 ```
 
-> Condition is what in Elasticsearch are Query and Filters.
+> Condition is what in Elasticsearch are Queries and Filters.
 
 #### Create schema
 

--- a/src/SEAL/Schema/Field/TypedField.php
+++ b/src/SEAL/Schema/Field/TypedField.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Schranz\Search\SEAL\Schema\Field;
+
+use Schranz\Search\SEAL\Schema\FieldType;
+
+/**
+ * Type to store any text, options can maybe use to specify it more specific.
+ */
+final class TypedField extends AbstractField
+{
+    /**
+     * @param array<string, array<string, AbstractField>> $types
+     */
+    public function __construct(
+        string $name,
+        public readonly string $typeField,
+        public readonly iterable $types,
+        bool $multiple = false,
+    ) {
+        parent::__construct($name, FieldType::TYPED, $multiple);
+    }
+}

--- a/src/SEAL/Schema/FieldType.php
+++ b/src/SEAL/Schema/FieldType.php
@@ -35,12 +35,12 @@ enum FieldType
     case DATETIME;
 
     /**
-     * Type to store a list of objects.
-     */
-    case COLLECTION;
-
-    /**
      * Type to store fields inside a nested object.
      */
     case OBJECT;
+
+    /**
+     * Type to store fields different based on a type field.
+     */
+    case TYPED;
 }

--- a/src/SEAL/Testing/TestingHelper.php
+++ b/src/SEAL/Testing/TestingHelper.php
@@ -21,6 +21,17 @@ class TestingHelper
             'title' => new Field\TextField('title'),
             'title.raw' => new Field\TextField('title'),
             'article' => new Field\TextField('article'),
+            'blocks' => new Field\TypedField('blocks', 'type', [
+                'text' => [
+                    'title' => new Field\TextField('title'),
+                    'description' => new Field\TextField('description'),
+                    'media' => new Field\IntegerField('media', multiple: true),
+                ],
+                'embed' => [
+                    'title' => new Field\TextField('title'),
+                    'media' => new Field\TextField('media'),
+                ],
+            ], multiple: true),
             'created' => new Field\DateTimeField('created'),
             'commentsCount' => new Field\IntegerField('commentsCount'),
             'rating' => new Field\FloatField('rating'),
@@ -68,6 +79,24 @@ class TestingHelper
                 'id' => '1',
                 'title' => 'New Blog',
                 'article' => '<article><h2>Some Subtitle</h2><p>A html field with some content</p></article>',
+                'blocks' => [
+                    [
+                        'type' => 'text',
+                        'title' => 'Titel',
+                        'description' => '<p>Description</p>',
+                        'media' => [3, 4],
+                    ],
+                    [
+                        'type' => 'text',
+                        'title' => 'Titel 2',
+                        'description' => '<p>Description 2</p>',
+                    ],
+                    [
+                        'type' => 'embed',
+                        'title' => 'Video',
+                        'media' => 'https://www.youtube.com/watch?v=iYM2zFP3Zn0',
+                    ],
+                ],
                 'created' => new \DateTimeImmutable('2022-12-24 12:00:00'),
                 'commentsCount' => 2,
                 'rating' => 3.5,


### PR DESCRIPTION
We need some kind of metadata for type based blocks. The TypedField will allow us this:

```php
    'blocks' => new Field\TypedField('blocks', 'type', [
        'text' => [
            'title' => new Field\TextField('title'),
            'description' => new Field\TextField('description'),
            'media' => new Field\IntegerField('media', multiple: true),
        ],
        'embed' => [
            'title' => new Field\TextField('title'),
            'media' => new Field\TextField('media'),
        ],
    ], multiple: true),
```