### PR TITLE
Add Multi Adapter

### DIFF
--- a/src/SEAL/Adapter/Multi/.gitignore
+++ b/src/SEAL/Adapter/Multi/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+/composer.phar
+/phpunit.xml

--- a/src/SEAL/Adapter/Multi/LICENSE
+++ b/src/SEAL/Adapter/Multi/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Alexander Schranz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/SEAL/Adapter/Multi/MultiAdapter.php
+++ b/src/SEAL/Adapter/Multi/MultiAdapter.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Schranz\Search\SEAL\Adapter\Multi;
+
+use Schranz\Search\SEAL\Adapter\AdapterInterface;
+use Schranz\Search\SEAL\Adapter\ConnectionInterface;
+use Schranz\Search\SEAL\Adapter\ReadWrite\MultiConnection;
+use Schranz\Search\SEAL\Adapter\ReadWrite\MultiSchemaManager;
+use Schranz\Search\SEAL\Adapter\SchemaManagerInterface;
+
+final class MultiAdapter implements AdapterInterface
+{
+    private ?ConnectionInterface $connection = null;
+
+    private ?SchemaManagerInterface $schemaManager = null;
+
+    /**
+     * @param iterable<AdapterInterface> $adapters
+     */
+    public function __construct(
+        private readonly iterable $adapters,
+    ) {}
+
+    public function getSchemaManager(): SchemaManagerInterface
+    {
+        if ($this->schemaManager === null) {
+            $schemaManagers = [];
+            foreach ($this->adapters as $adapter) {
+                $schemaManagers[] = $adapter->getSchemaManager();
+            }
+
+            $this->schemaManager = new MultiSchemaManager($schemaManagers);
+        }
+
+        return $this->schemaManager;
+    }
+
+    public function getConnection(): ConnectionInterface
+    {
+        if ($this->connection === null) {
+            $connections = [];
+            foreach ($this->adapters as $adapter) {
+                $connections[] = $adapter->getConnection();
+            }
+
+            $this->connection = new MultiConnection($connections);
+        }
+
+        return $this->connection;
+    }
+}

--- a/src/SEAL/Adapter/Multi/MultiConnection.php
+++ b/src/SEAL/Adapter/Multi/MultiConnection.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Schranz\Search\SEAL\Adapter\ReadWrite;
+
+use Schranz\Search\SEAL\Adapter\ConnectionInterface;
+use Schranz\Search\SEAL\Schema\Index;
+use Schranz\Search\SEAL\Search\Result;
+use Schranz\Search\SEAL\Search\Search;
+
+/**
+ * @internal This class should never be needed to be instanced manually.
+ */
+final class MultiConnection implements ConnectionInterface
+{
+    /**
+     * @param iterable<ConnectionInterface> $connections
+     */
+    public function __construct(
+        public readonly iterable $connections,
+    ) {}
+
+    public function save(Index $index, array $document): array
+    {
+        $document = null;
+        foreach ($this->connections as $connection) {
+            $document = $connection->save($index, $document);
+        }
+
+        if ($document === null) {
+            throw new \LogicException('No connections were available.');
+        }
+
+        return $document;
+    }
+
+    public function delete(Index $index, string $identifier): void
+    {
+        foreach ($this->connections as $connection) {
+            $connection->delete($index, $identifier);
+        }
+    }
+
+    public function search(Search $search): Result
+    {
+        throw new \LogicException(
+            'Not implemented yet, use the ReadWriteAdapter to define a specific read adapter.'
+        );
+    }
+}

--- a/src/SEAL/Adapter/Multi/MultiSchemaManager.php
+++ b/src/SEAL/Adapter/Multi/MultiSchemaManager.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Schranz\Search\SEAL\Adapter\ReadWrite;
+
+use Schranz\Search\SEAL\Adapter\ConnectionInterface;
+use Schranz\Search\SEAL\Adapter\SchemaManagerInterface;
+use Schranz\Search\SEAL\Schema\Index;
+use Schranz\Search\SEAL\Search\Result;
+use Schranz\Search\SEAL\Search\Search;
+
+/**
+ * @internal This class should never be needed to be instanced manually.
+ */
+final class MultiSchemaManager implements SchemaManagerInterface
+{
+    /**
+     * @param iterable<SchemaManagerInterface> $schemaManagers
+     */
+    public function __construct(
+        public readonly iterable $schemaManagers,
+    ) {}
+
+    public function existIndex(Index $index): bool
+    {
+        $existIndex = true;
+        foreach ($this->schemaManagers as $schemaManager) {
+            $existIndex = $existIndex && $schemaManager->existIndex($index);
+        }
+
+        return $existIndex;
+    }
+
+    public function dropIndex(Index $index): void
+    {
+        foreach ($this->schemaManagers as $schemaManager) {
+            $schemaManager->dropIndex($index);
+        }
+    }
+
+    public function createIndex(Index $index): void
+    {
+        foreach ($this->schemaManagers as $schemaManager) {
+            $schemaManager->createIndex($index);
+        }
+    }
+}

--- a/src/SEAL/Adapter/Multi/README.md
+++ b/src/SEAL/Adapter/Multi/README.md
@@ -1,0 +1,36 @@
+# Schranz Search SEAL Multi Adapter
+
+The `MultiAdater` allows to write into multiple adapters.
+
+> This is a subtree split of the `schranz-search/schranz-search` project create issues in the [main repository](https://github.com/schranz-search/schranz-search).
+
+## Usage
+
+It is mostly used in combination with the `ReadWriteAdapter` to still
+write into both indexes.
+
+```php
+<?php
+
+use Schranz\Search\SEAL\Adapter\Elasticsearch\ElasticsearchAdapter;
+use Schranz\Search\SEAL\Adapter\Multi\MultiAdapter;
+use Schranz\Search\SEAL\Adapter\ReadWrite\ReadWriteAdapter;
+use Schranz\Search\SEAL\Engine;
+
+$readAdapter = new ElasticsearchAdapter(/* .. */); // can be any adapter
+$writeAdapter = new ElasticsearchAdapter(/* .. */); // can be any adapter
+
+$engine = new Engine(
+    new ReadWriteAdapter(
+        $readAdapter,
+        new MultiAdapter(
+            $readAdapter,
+            $writeAdapter,
+        ),
+    ),
+    $schema,
+);
+```
+
+> **Note**
+> Currently the `MultiAdapter` does not support the `search` method and so the `ReadWriteAdapter` is required.

--- a/src/SEAL/Adapter/Multi/composer.json
+++ b/src/SEAL/Adapter/Multi/composer.json
@@ -1,0 +1,21 @@
+{
+    "name": "schranz-search/seal-multi-adapter",
+    "description": "An adapter to support to write into multiple other adapters schranz-search/seal package.",
+    "type": "library",
+    "license": "MIT",
+    "autoload": {
+        "psr-4": {
+            "Schranz\\Search\\SEAL\\Adapter\\Multi\\": ""
+        }
+    },
+    "authors": [
+        {
+            "name": "Alexander Schranz",
+            "email": "alexander@sulu.io"
+        }
+    ],
+    "require": {
+        "php": "^8.1",
+        "schranz-search/seal": "^1.0"
+    }
+}

--- a/src/SEAL/Adapter/ReadWrite/README.md
+++ b/src/SEAL/Adapter/ReadWrite/README.md
@@ -1,7 +1,8 @@
 # Schranz Search SEAL Read Write Adapter
 
-The `ReadWriteAdapter` allows to use one adapter instance for writing
-and one for reading. This is useful if you want to reindex something.
+The `ReadWriteAdapter` allows to use one adapter instance for reading
+and one for writing. This is useful if you want to reindex something
+without a downtime.
 
 > This is a subtree split of the `schranz-search/schranz-search` project create issues in the [main repository](https://github.com/schranz-search/schranz-search).
 
@@ -34,3 +35,4 @@ $engine = new Engine(
 > Read a document and partial update it based on the read document should be avoided
 > when using this adapter, as the read document could already be outdated. So always
 > fully update the document and never do based on read documents.
+> Have a look at the `MultiAdapter` to write into read and write adapter.

--- a/src/SEAL/Adapter/ReadWrite/ReadWriteAdapter.php
+++ b/src/SEAL/Adapter/ReadWrite/ReadWriteAdapter.php
@@ -23,7 +23,7 @@ final class ReadWriteAdapter implements AdapterInterface
     public function getConnection(): ConnectionInterface
     {
         if ($this->connection === null) {
-            return new ReadWriteConnection(
+            $this->connection = new ReadWriteConnection(
                 $this->readAdapter->getConnection(),
                 $this->writeAdapter->getConnection(),
             );

--- a/src/SEAL/composer.json
+++ b/src/SEAL/composer.json
@@ -8,6 +8,7 @@
             "Schranz\\Search\\SEAL\\": ""
         },
         "exclude-from-classmap": [
+            "/Adapter/Multi/",
             "/Adapter/ReadWrite/"
         ]
     },


### PR DESCRIPTION
A multi adapter allows to write inside multiple other adapters. This can be used for migrations or when doing a reindex inside a seperate index / adapter.