### PR TITLE
Add subtree split

### DIFF
--- a/.github/workflows/publish-subsplits.yml
+++ b/.github/workflows/publish-subsplits.yml
@@ -1,0 +1,39 @@
+---
+name: Sub-Split Publishing
+on:
+  push:
+    branches:
+      - 0.1
+  create:
+    tags:
+      - '*'
+  delete:
+    tags:
+      - '*'
+
+jobs:
+  publish_subsplits:
+    runs-on: ubuntu-latest
+    name: Publish package sub-splits
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+          persist-credentials: 'false'
+      - uses: frankdejonge/use-github-token@1.0.1
+        with:
+          authentication: 'alexander-schranz:${{ secrets.PERSONAL_ACCESS_TOKEN }}'
+          user_name: 'Alexander Schranz'
+          user_email: 'alexander@sulu.io'
+      - name: Cache splitsh-lite
+        id: splitsh-cache
+        uses: actions/cache@v2
+        with:
+          path: './.splitsh'
+          key: '${{ runner.os }}-splitsh'
+      - uses: frankdejonge/use-subsplit-publish@1.0.0-beta.5
+        with:
+          source-branch: '0.1'
+          config-path: './config.subsplit-publish.json'
+          splitsh-path: './.splitsh/splitsh-lite'
+          splitsh-version: 'v1.0.1'

--- a/config.subsplit-publish.json
+++ b/config.subsplit-publish.json
@@ -3,17 +3,17 @@
         {
             "name": "SEAL",
             "directory": "src/SEAL",
-            "target": "git@github.com:schranz-templating/seal.git"
+            "target": "git@github.com:schranz-search/seal.git"
         },
         {
             "name": "SEALReadWriteAdapter",
             "directory": "src/SEAL/Adapter/ReadWrite",
-            "target": "git@github.com:schranz-templating/seal-read-write-adapter.git"
+            "target": "git@github.com:schranz-search/seal-read-write-adapter.git"
         },
         {
             "name": "SEALMultiAdapter",
             "directory": "src/SEAL/Adapter/Multi",
-            "target": "git@github.com:schranz-templating/seal-multi-adapter.git"
+            "target": "git@github.com:schranz-search/seal-multi-adapter.git"
         }
     ]
 }

--- a/config.subsplit-publish.json
+++ b/config.subsplit-publish.json
@@ -1,0 +1,19 @@
+{
+    "sub-splits": [
+        {
+            "name": "SEAL",
+            "directory": "src/SEAL",
+            "target": "git@github.com:schranz-templating/seal.git"
+        },
+        {
+            "name": "SEALReadWriteAdapter",
+            "directory": "src/SEAL/Adapter/ReadWrite",
+            "target": "git@github.com:schranz-templating/seal-read-write-adapter.git"
+        },
+        {
+            "name": "SEALMultiAdapter",
+            "directory": "src/SEAL/Adapter/Multi",
+            "target": "git@github.com:schranz-templating/seal-multi-adapter.git"
+        }
+    ]
+}

--- a/src/SEAL/Testing/TestingHelper.php
+++ b/src/SEAL/Testing/TestingHelper.php
@@ -61,6 +61,13 @@ class TestingHelper
      * @return array<array{
      *     id: string,
      *     title?: string|null,
+     *     article?: string|null,
+     *     blocks?: array<array{
+     *          type: string,
+     *          title?: string|null,
+     *          description?: string|null
+     *          media?: int[]|string,
+     *     }>,
      *     created?: \string|null,
      *     commentsCount?: int|null,
      *     rating?: int|null,


### PR DESCRIPTION
This configuration provides a subtree split for which contains

 - seal
 - seal-read-write-adapter
 - seal-multi-adapter
 
packages. It shoudl allow @pucene to implement there own adapter based on a @schranz-search.