### PR TITLE
Add handling of secrets to CI

### DIFF
--- a/.github/workflows/callable-test.yml
+++ b/.github/workflows/callable-test.yml
@@ -15,6 +15,8 @@ jobs:
         name: "PHP ${{ matrix.php-version }}"
         runs-on: ubuntu-latest
 
+        env: ${{ secrets }}
+
         strategy:
             fail-fast: false
             matrix:
@@ -52,8 +54,10 @@ jobs:
               uses: ramsey/composer-install@v2
               with:
                   working-directory: ${{ inputs.directory }}
-                  dependency-versions: ${{matrix.dependency-versions}}
+                  dependency-versions: ${{ matrix.dependency-versions }}
 
             - name: Run tests
               run: vendor/bin/phpunit
               working-directory: ${{ inputs.directory }}
+              env:
+                  TEST_INDEX_PREFIX: 'test_${{ github.run_number }}_${{ strategy.job-index }}_'

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <h1 align="center">Schranz Search</h1>
 
 <div align="center">
-   <strong>Monorepository for the search abstraction over different search engine..</strong>
+   <strong>Monorepository for the search abstraction over different search engine.</strong>
 </div>
 
 <br />
@@ -20,7 +20,11 @@ It provides a common interface to interact with different search engines.
 
 Read more about it in the [README.md](packages/seal/README.md) of the package.
 
+<div align="center">
+
 ![duffy-duck-investigating](https://user-images.githubusercontent.com/1698337/209232131-8b0a3dcf-8500-45ed-bcc2-1b97a25b1e15.gif)
+
+</div>
 
 ## Research
 
@@ -29,10 +33,10 @@ At current state collect here different search engines which are around and coul
  - [Elasticsearch](#elasticsearch) - [schranz-search/seal-elasticsearch-adapter](packages/seal-elasticsearch-adapter)
  - [Opensearch](#opensearch) - [schranz-search/seal-opensearch-adapter](packages/seal-opensearch-adapter)
  - [Meilisearch](#meilisearch) - [schranz-search/seal-meilisearch-adapter](packages/seal-meilisearch-adapter)
+ - [Algolia](#algolia) - [schranz-search/seal-algolia-adapter](packages/seal-algolia-adapter)
  - [RediSearch](#redisearch)
  - [Zinc Labs](#zinc-labs)
  - [Typesense](#typesense)
- - [Algolia](#algolia)
  - [ZendSearch](#zendsearch)
  - [TnTSearch](#tntsearch)
  - [Solr](#solr)
@@ -74,6 +78,15 @@ A search engine written in Rust:
 
 Implementation: [schranz-search/seal-meilisearch-adapter](packages/seal-meilisearch-adapter)
 
+### Algolia
+
+Is a search as SaaS provided via Rest APIs and SDKs:
+
+- Server: No server only Saas [https://www.algolia.com/](https://www.algolia.com/)
+- PHP Client: [Algolia PHP](https://github.com/algolia/algoliasearch-client-php)
+
+Implementation: [schranz-search/seal-algolia-adapter](packages/seal-algolia-adapter)
+
 ### RediSearch
  
 A search out of the house of the redis labs.
@@ -94,13 +107,6 @@ Describes itself as a alternative to Algolia and Elasticsearch written in C++.
 
  - Server: [Typesense Server](https://github.com/typesense/typesense)
  - PHP Client: [Typesense PHP](https://github.com/typesense/typesense-php)
-
-### Algolia
-
-Is a search as SaaS provided via Rest APIs and SDKs:
-
- - Server: No server only Saas [https://www.algolia.com/](https://www.algolia.com/)
- - PHP Client: [Algolia PHP](https://github.com/algolia/algoliasearch-client-php)
 
 ### ZendSearch
 

--- a/packages/seal-elasticsearch-adapter/Tests/ElasticsearchSchemaManagerTest.php
+++ b/packages/seal-elasticsearch-adapter/Tests/ElasticsearchSchemaManagerTest.php
@@ -28,7 +28,7 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             'index' => $index->name,
         ])->asArray();
 
-        $this->assertTrue(isset($mapping['test_simple']['mappings']['properties']));
+        $this->assertTrue(isset($mapping[$index->name]['mappings']['properties']));
 
         $this->assertSame([
             'id' => [
@@ -37,9 +37,10 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             'title' => [
                 'type' => 'text',
             ],
-        ], $mapping['test_simple']['mappings']['properties']);
+        ], $mapping[$index->name]['mappings']['properties']);
 
         static::$schemaManager->dropIndex($index);
+        static::waitForDropIndex();
     }
 
     public function testComplexElasticsearchMapping(): void
@@ -53,7 +54,7 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             'index' => $index->name,
         ])->asArray();
 
-        $this->assertTrue(isset($mapping['test_complex']['mappings']['properties']));
+        $this->assertTrue(isset($mapping[$index->name]['mappings']['properties']));
 
         $this->assertSame([
             'article' => [
@@ -146,8 +147,9 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             'title' => [
                 'type' => 'text',
             ],
-        ], $mapping['test_complex']['mappings']['properties']);
+        ], $mapping[$index->name]['mappings']['properties']);
 
         static::$schemaManager->dropIndex($index);
+        static::waitForDropIndex();
     }
 }

--- a/packages/seal-opensearch-adapter/Tests/OpensearchSchemaManagerTest.php
+++ b/packages/seal-opensearch-adapter/Tests/OpensearchSchemaManagerTest.php
@@ -21,12 +21,13 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
     {
         $index = $this->schema->indexes[TestingHelper::INDEX_SIMPLE];
         static::$schemaManager->createIndex($index);
+        static::waitForCreateIndex();
 
         $mapping = self::$client->indices()->getMapping([
             'index' => $index->name,
         ]);
 
-        $this->assertTrue(isset($mapping['test_simple']['mappings']['properties']));
+        $this->assertTrue(isset($mapping[$index->name]['mappings']['properties']));
 
         $this->assertSame([
             'id' => [
@@ -35,21 +36,23 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             'title' => [
                 'type' => 'text',
             ],
-        ], $mapping['test_simple']['mappings']['properties']);
+        ], $mapping[$index->name]['mappings']['properties']);
 
         static::$schemaManager->dropIndex($index);
+        static::waitForDropIndex();
     }
 
     public function testComplexOpensearchMapping(): void
     {
         $index = $this->schema->indexes[TestingHelper::INDEX_COMPLEX];
         static::$schemaManager->createIndex($index);
+        static::waitForCreateIndex();
 
         $mapping = self::$client->indices()->getMapping([
             'index' => $index->name,
         ]);
 
-        $this->assertTrue(isset($mapping['test_complex']['mappings']['properties']));
+        $this->assertTrue(isset($mapping[$index->name]['mappings']['properties']));
 
         $this->assertSame([
             'article' => [
@@ -142,8 +145,9 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             'title' => [
                 'type' => 'text',
             ],
-        ], $mapping['test_complex']['mappings']['properties']);
+        ], $mapping[$index->name]['mappings']['properties']);
 
         static::$schemaManager->dropIndex($index);
+        static::waitForDropIndex();
     }
 }

--- a/packages/seal/Testing/TestingHelper.php
+++ b/packages/seal/Testing/TestingHelper.php
@@ -14,8 +14,10 @@ class TestingHelper
 
     private function __construct() {}
 
-    public static function createSchema(string $prefix = 'test_'): Schema
+    public static function createSchema(): Schema
     {
+        $prefix = getenv('TEST_INDEX_PREFIX') ?: $_ENV['TEST_INDEX_PREFIX'] ?? 'test_';
+
         $complexFields = [
             'id' => new Field\IdentifierField('id'),
             'title' => new Field\TextField('title'),


### PR DESCRIPTION
This way we forward the algolia secrets to the reusable github action:

```env
    algolia-adapter:
        name: Algolia Adapter
        uses: ./.github/workflows/callable-test.yml
        with:
            directory: 'packages/seal-algolia-adapter'
            docker: false
        secrets: inherit
```