### PR TITLE
Add void to any write action to support async adapters

### DIFF
--- a/packages/seal-algolia-adapter/AlgoliaConnection.php
+++ b/packages/seal-algolia-adapter/AlgoliaConnection.php
@@ -17,7 +17,7 @@ final class AlgoliaConnection implements ConnectionInterface
     ) {
     }
 
-    public function save(Index $index, array $document): array
+    public function save(Index $index, array $document): void
     {
         $identifierField = $index->getIdentifierField();
 
@@ -25,7 +25,7 @@ final class AlgoliaConnection implements ConnectionInterface
 
         $searchIndex->saveObject($document, ['objectIDKey' => $identifierField->name]);
 
-        return $document;
+        // return $document;
     }
 
     public function delete(Index $index, string $identifier): void

--- a/packages/seal-elasticsearch-adapter/ElasticsearchConnection.php
+++ b/packages/seal-elasticsearch-adapter/ElasticsearchConnection.php
@@ -19,7 +19,7 @@ final class ElasticsearchConnection implements ConnectionInterface
     ) {
     }
 
-    public function save(Index $index, array $document): array
+    public function save(Index $index, array $document): void
     {
         $identifierField = $index->getIdentifierField();
 
@@ -41,7 +41,7 @@ final class ElasticsearchConnection implements ConnectionInterface
 
         $document[$identifierField->name] = $response->asArray()['_id'];
 
-        return $document;
+        // return $document;
     }
 
     public function delete(Index $index, string $identifier): void

--- a/packages/seal-meilisearch-adapter/MeilisearchConnection.php
+++ b/packages/seal-meilisearch-adapter/MeilisearchConnection.php
@@ -17,7 +17,7 @@ final class MeilisearchConnection implements ConnectionInterface
     ) {
     }
 
-    public function save(Index $index, array $document): array
+    public function save(Index $index, array $document): void
     {
         $identifierField = $index->getIdentifierField();
 
@@ -30,7 +30,7 @@ final class MeilisearchConnection implements ConnectionInterface
             throw new \RuntimeException('Unexpected error while save document with identifier "' . $identifier . '" into Index "' . $index->name . '".');
         }
 
-        return $document;
+        // return $document;
     }
 
     public function delete(Index $index, string $identifier): void

--- a/packages/seal-memory-adapter/MemoryConnection.php
+++ b/packages/seal-memory-adapter/MemoryConnection.php
@@ -10,9 +10,11 @@ use Schranz\Search\SEAL\Search\Search;
 
 final class MemoryConnection implements ConnectionInterface
 {
-    public function save(Index $index, array $document): array
+    public function save(Index $index, array $document): void
     {
-        return MemoryStorage::save($index, $document);
+        $document = MemoryStorage::save($index, $document);
+
+        // return $document;
     }
 
     public function delete(Index $index, string $identifier): void

--- a/packages/seal-multi-adapter/MultiConnection.php
+++ b/packages/seal-multi-adapter/MultiConnection.php
@@ -19,7 +19,7 @@ final class MultiConnection implements ConnectionInterface
         public readonly iterable $connections,
     ) {}
 
-    public function save(Index $index, array $document): array
+    public function save(Index $index, array $document): void
     {
         $document = null;
         foreach ($this->connections as $connection) {
@@ -30,7 +30,7 @@ final class MultiConnection implements ConnectionInterface
             throw new \LogicException('No connections were available.');
         }
 
-        return $document;
+        // return $document;
     }
 
     public function delete(Index $index, string $identifier): void

--- a/packages/seal-opensearch-adapter/OpensearchConnection.php
+++ b/packages/seal-opensearch-adapter/OpensearchConnection.php
@@ -19,7 +19,7 @@ final class OpensearchConnection implements ConnectionInterface
     ) {
     }
 
-    public function save(Index $index, array $document): array
+    public function save(Index $index, array $document): void
     {
         $identifierField = $index->getIdentifierField();
 
@@ -41,7 +41,7 @@ final class OpensearchConnection implements ConnectionInterface
 
         $document[$identifierField->name] = $data['_id'];
 
-        return $document;
+        // return $document;
     }
 
     public function delete(Index $index, string $identifier): void

--- a/packages/seal-read-write-adapter/ReadWriteConnection.php
+++ b/packages/seal-read-write-adapter/ReadWriteConnection.php
@@ -17,9 +17,9 @@ final class ReadWriteConnection implements ConnectionInterface
         public readonly ConnectionInterface $writeConnection,
     ) {}
 
-    public function save(Index $index, array $document): array
+    public function save(Index $index, array $document): void
     {
-        return $this->writeConnection->save($index, $document);
+        $this->writeConnection->save($index, $document);
     }
 
     public function delete(Index $index, string $identifier): void

--- a/packages/seal/Adapter/ConnectionInterface.php
+++ b/packages/seal/Adapter/ConnectionInterface.php
@@ -10,10 +10,8 @@ interface ConnectionInterface
 {
     /**
      * @param array<string, mixed> $document
-     *
-     * @return array<string, mixed>
      */
-    public function save(Index $index, array $document): array;
+    public function save(Index $index, array $document): void;
 
     public function delete(Index $index, string $identifier): void;
 

--- a/packages/seal/Engine.php
+++ b/packages/seal/Engine.php
@@ -20,9 +20,9 @@ final class Engine
      *
      * @return array<string, mixed>
      */
-    public function saveDocument(string $index, array $document): array
+    public function saveDocument(string $index, array $document): void
     {
-        return $this->adapter->getConnection()->save(
+        $this->adapter->getConnection()->save(
             $this->schema->indexes[$index],
             $document
         );


### PR DESCRIPTION
Some search engines like Agolia, Mellisearch and even new version of Elasticsearch are async. So all write actions should be async by default. First we will create all write actions to be `: void` in the next step it should be changed to `: ?Promise` based on additional parameter we can then return a required promise or not.