### PR TITLE
Refractor Index Operations for Optional Task return

### DIFF
--- a/packages/seal-algolia-adapter/AlgoliaConnection.php
+++ b/packages/seal-algolia-adapter/AlgoliaConnection.php
@@ -9,6 +9,8 @@ use Schranz\Search\SEAL\Schema\Index;
 use Schranz\Search\SEAL\Search\Condition\IdentifierCondition;
 use Schranz\Search\SEAL\Search\Result;
 use Schranz\Search\SEAL\Search\Search;
+use Schranz\Search\SEAL\Task\SyncTask;
+use Schranz\Search\SEAL\Task\TaskInterface;
 
 final class AlgoliaConnection implements ConnectionInterface
 {
@@ -17,7 +19,7 @@ final class AlgoliaConnection implements ConnectionInterface
     ) {
     }
 
-    public function save(Index $index, array $document): void
+    public function save(Index $index, array $document, array $options = []): ?TaskInterface
     {
         $identifierField = $index->getIdentifierField();
 
@@ -25,14 +27,24 @@ final class AlgoliaConnection implements ConnectionInterface
 
         $searchIndex->saveObject($document, ['objectIDKey' => $identifierField->name]);
 
-        // return $document;
+        if (true !== ($options['return_slow_promise_result'] ?? false)) {
+            return null;
+        }
+
+        return new SyncTask($document); // TODO wait for the result of the search engine
     }
 
-    public function delete(Index $index, string $identifier): void
+    public function delete(Index $index, string $identifier, array $options = []): ?TaskInterface
     {
         $searchIndex = $this->client->initIndex($index->name);
 
         $searchIndex->deleteObject($identifier);
+
+        if (true !== ($options['return_slow_promise_result'] ?? false)) {
+            return null;
+        }
+
+        return new SyncTask(null); // TODO wait for the result of the search engine
     }
 
     public function search(Search $search): Result

--- a/packages/seal-algolia-adapter/AlgoliaSchemaManager.php
+++ b/packages/seal-algolia-adapter/AlgoliaSchemaManager.php
@@ -5,6 +5,8 @@ namespace Schranz\Search\SEAL\Adapter\Algolia;
 use Algolia\AlgoliaSearch\SearchClient;
 use Schranz\Search\SEAL\Adapter\SchemaManagerInterface;
 use Schranz\Search\SEAL\Schema\Index;
+use Schranz\Search\SEAL\Task\SyncTask;
+use Schranz\Search\SEAL\Task\TaskInterface;
 
 final class AlgoliaSchemaManager implements SchemaManagerInterface
 {
@@ -20,14 +22,20 @@ final class AlgoliaSchemaManager implements SchemaManagerInterface
         return $index->exists();
     }
 
-    public function dropIndex(Index $index): void
+    public function dropIndex(Index $index, array $options = []): ?TaskInterface
     {
-         $index = $this->client->initIndex($index->name);
+        $index = $this->client->initIndex($index->name);
 
-         $index->delete();
+        $index->delete();
+
+        if (true !== ($options['return_slow_promise_result'] ?? false)) {
+            return null;
+        }
+
+        return new SyncTask(null); // TODO wait for index drop
     }
 
-    public function createIndex(Index $index): void
+    public function createIndex(Index $index, array $options = []): ?TaskInterface
     {
         $searchIndex = $this->client->initIndex($index->name);
 
@@ -37,5 +45,11 @@ final class AlgoliaSchemaManager implements SchemaManagerInterface
                 $index->getIdentifierField()->name,
             ],
         ]);
+
+        if (true !== ($options['return_slow_promise_result'] ?? false)) {
+            return null;
+        }
+
+        return new SyncTask(null); // TODO wait for index create
     }
 }

--- a/packages/seal-elasticsearch-adapter/ElasticsearchSchemaManager.php
+++ b/packages/seal-elasticsearch-adapter/ElasticsearchSchemaManager.php
@@ -6,6 +6,8 @@ use Elastic\Elasticsearch\Client;
 use Schranz\Search\SEAL\Adapter\SchemaManagerInterface;
 use Schranz\Search\SEAL\Schema\Field;
 use Schranz\Search\SEAL\Schema\Index;
+use Schranz\Search\SEAL\Task\SyncTask;
+use Schranz\Search\SEAL\Task\TaskInterface;
 
 final class ElasticsearchSchemaManager implements SchemaManagerInterface
 {
@@ -23,14 +25,20 @@ final class ElasticsearchSchemaManager implements SchemaManagerInterface
         return $response->getStatusCode() !== 404;
     }
 
-    public function dropIndex(Index $index): void
+    public function dropIndex(Index $index, array $options = []): ?TaskInterface
     {
-         $this->client->indices()->delete([
+        $this->client->indices()->delete([
             'index' => $index->name,
         ]);
+
+        if (true !== ($options['return_slow_promise_result'] ?? false)) {
+            return null;
+        }
+
+        return new SyncTask(null); // TODO wait for index drop
     }
 
-    public function createIndex(Index $index): void
+    public function createIndex(Index $index, array $options = []): ?TaskInterface
     {
         $properties = $this->createPropertiesMapping($index->fields);
 
@@ -42,6 +50,12 @@ final class ElasticsearchSchemaManager implements SchemaManagerInterface
                 ],
             ],
         ]);
+
+        if (true !== ($options['return_slow_promise_result'] ?? false)) {
+            return null;
+        }
+
+        return new SyncTask(null); // TODO wait for index create
     }
 
     /**

--- a/packages/seal-meilisearch-adapter/MeilisearchSchemaManager.php
+++ b/packages/seal-meilisearch-adapter/MeilisearchSchemaManager.php
@@ -6,6 +6,8 @@ use Meilisearch\Client;
 use Meilisearch\Exceptions\ApiException;
 use Schranz\Search\SEAL\Adapter\SchemaManagerInterface;
 use Schranz\Search\SEAL\Schema\Index;
+use Schranz\Search\SEAL\Task\SyncTask;
+use Schranz\Search\SEAL\Task\TaskInterface;
 
 final class MeilisearchSchemaManager implements SchemaManagerInterface
 {
@@ -29,12 +31,18 @@ final class MeilisearchSchemaManager implements SchemaManagerInterface
         return true;
     }
 
-    public function dropIndex(Index $index): void
+    public function dropIndex(Index $index, array $options = []): ?TaskInterface
     {
          $this->client->deleteIndex($index->name);
+
+        if (true !== ($options['return_slow_promise_result'] ?? false)) {
+            return null;
+        }
+
+        return new SyncTask(null); // TODO wait for index drop
     }
 
-    public function createIndex(Index $index): void
+    public function createIndex(Index $index, array $options = []): ?TaskInterface
     {
         $this->client->createIndex(
             $index->name,
@@ -49,5 +57,11 @@ final class MeilisearchSchemaManager implements SchemaManagerInterface
                     $index->getIdentifierField()->name
                 ],
             ]);
+
+        if (true !== ($options['return_slow_promise_result'] ?? false)) {
+            return null;
+        }
+
+        return new SyncTask(null); // TODO wait for index create
     }
 }

--- a/packages/seal-memory-adapter/MemoryConnection.php
+++ b/packages/seal-memory-adapter/MemoryConnection.php
@@ -7,19 +7,31 @@ use Schranz\Search\SEAL\Schema\Index;
 use Schranz\Search\SEAL\Search\Condition\IdentifierCondition;
 use Schranz\Search\SEAL\Search\Result;
 use Schranz\Search\SEAL\Search\Search;
+use Schranz\Search\SEAL\Task\SyncTask;
+use Schranz\Search\SEAL\Task\TaskInterface;
 
 final class MemoryConnection implements ConnectionInterface
 {
-    public function save(Index $index, array $document): void
+    public function save(Index $index, array $document, array $options = []): ?TaskInterface
     {
         $document = MemoryStorage::save($index, $document);
 
-        // return $document;
+        if (true !== ($options['return_slow_promise_result'] ?? false)) {
+            return null;
+        }
+
+        return new SyncTask($document);
     }
 
-    public function delete(Index $index, string $identifier): void
+    public function delete(Index $index, string $identifier, array $options = []): ?TaskInterface
     {
         MemoryStorage::delete($index, $identifier);
+
+        if (true !== ($options['return_slow_promise_result'] ?? false)) {
+            return null;
+        }
+
+        return new SyncTask(null);
     }
 
     public function search(Search $search): Result

--- a/packages/seal-memory-adapter/MemorySchemaManager.php
+++ b/packages/seal-memory-adapter/MemorySchemaManager.php
@@ -4,6 +4,7 @@ namespace Schranz\Search\SEAL\Adapter\Memory;
 
 use Schranz\Search\SEAL\Adapter\SchemaManagerInterface;
 use Schranz\Search\SEAL\Schema\Index;
+use Schranz\Search\SEAL\Task\TaskInterface;
 
 final class MemorySchemaManager implements SchemaManagerInterface
 {
@@ -13,13 +14,25 @@ final class MemorySchemaManager implements SchemaManagerInterface
         return MemoryStorage::existIndex($index);
     }
 
-    public function dropIndex(Index $index): void
+    public function dropIndex(Index $index, array $options = []): ?TaskInterface
     {
         MemoryStorage::dropIndex($index);
+
+        if (true !== ($options['return_slow_promise_result'] ?? false)) {
+            return null;
+        }
+
+        return new SyncTask(null);
     }
 
-    public function createIndex(Index $index): void
+    public function createIndex(Index $index, array $options = []): ?TaskInterface
     {
         MemoryStorage::createIndex($index);
+
+        if (true !== ($options['return_slow_promise_result'] ?? false)) {
+            return null;
+        }
+
+        return new SyncTask(null);
     }
 }

--- a/packages/seal-opensearch-adapter/OpensearchSchemaManager.php
+++ b/packages/seal-opensearch-adapter/OpensearchSchemaManager.php
@@ -6,6 +6,8 @@ use OpenSearch\Client;
 use Schranz\Search\SEAL\Adapter\SchemaManagerInterface;
 use Schranz\Search\SEAL\Schema\Field;
 use Schranz\Search\SEAL\Schema\Index;
+use Schranz\Search\SEAL\Task\SyncTask;
+use Schranz\Search\SEAL\Task\TaskInterface;
 
 final class OpensearchSchemaManager implements SchemaManagerInterface
 {
@@ -21,14 +23,20 @@ final class OpensearchSchemaManager implements SchemaManagerInterface
         ]);
     }
 
-    public function dropIndex(Index $index): void
+    public function dropIndex(Index $index, array $options = []): ?TaskInterface
     {
-         $this->client->indices()->delete([
+        $this->client->indices()->delete([
             'index' => $index->name,
         ]);
+
+        if (true !== ($options['return_slow_promise_result'] ?? false)) {
+            return null;
+        }
+
+        return new SyncTask(null); // TODO wait for index drop
     }
 
-    public function createIndex(Index $index): void
+    public function createIndex(Index $index, array $options = []): ?TaskInterface
     {
         $properties = $this->createPropertiesMapping($index->fields);
 
@@ -40,6 +48,12 @@ final class OpensearchSchemaManager implements SchemaManagerInterface
                 ],
             ],
         ]);
+
+        if (true !== ($options['return_slow_promise_result'] ?? false)) {
+            return null;
+        }
+
+        return new SyncTask(null); // TODO wait for index create
     }
 
     /**

--- a/packages/seal/Adapter/ConnectionInterface.php
+++ b/packages/seal/Adapter/ConnectionInterface.php
@@ -5,15 +5,27 @@ namespace Schranz\Search\SEAL\Adapter;
 use Schranz\Search\SEAL\Schema\Index;
 use Schranz\Search\SEAL\Search\Result;
 use Schranz\Search\SEAL\Search\Search;
+use Schranz\Search\SEAL\Task\TaskInterface;
 
 interface ConnectionInterface
 {
     /**
-     * @param array<string, mixed> $document
+     * @template T of bool
+     *
+     * @param array{return_slow_promise_result: T} $options
+     *
+     * @return (T is true ? TaskInterface : null)
      */
-    public function save(Index $index, array $document): void;
+    public function save(Index $index, array $document, array $options = []): ?TaskInterface;
 
-    public function delete(Index $index, string $identifier): void;
+    /**
+     * @template T of bool
+     *
+     * @param array{return_slow_promise_result: T} $options
+     *
+     * @return (T is true ? TaskInterface : null)
+     */
+    public function delete(Index $index, string $identifier, array $options = []): ?TaskInterface;
 
     public function search(Search $search): Result;
 }

--- a/packages/seal/Adapter/SchemaManagerInterface.php
+++ b/packages/seal/Adapter/SchemaManagerInterface.php
@@ -3,12 +3,27 @@
 namespace Schranz\Search\SEAL\Adapter;
 
 use Schranz\Search\SEAL\Schema\Index;
+use Schranz\Search\SEAL\Task\TaskInterface;
 
 interface SchemaManagerInterface
 {
     public function existIndex(Index $index): bool;
 
-    public function dropIndex(Index $index): void;
+    /**
+     * @template T of bool
+     *
+     * @param array{return_slow_promise_result: T} $options
+     *
+     * @return (T is true ? TaskInterface : null)
+     */
+    public function dropIndex(Index $index, array $options = []): ?TaskInterface;
 
-    public function createIndex(Index $index): void;
+    /**
+     * @template T of bool
+     *
+     * @param array{return_slow_promise_result: T} $options
+     *
+     * @return (T is true ? TaskInterface : null)
+     */
+    public function createIndex(Index $index, array $options = []): ?TaskInterface;
 }

--- a/packages/seal/Task/AsyncTask.php
+++ b/packages/seal/Task/AsyncTask.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Schranz\Search\SEAL\Task;
+
+/**
+ * A Task object for asynchronous tasks.
+ *
+ * As example Algolia returns us just a task id, which we can use to wait for the task to finish.
+ *
+ * @template-covariant T of mixed
+ *
+ * @template-implements TaskInterface<T>
+ */
+final class AsyncTask implements TaskInterface
+{
+    /**
+     * @param \Closure(): T $callback
+     */
+    public function __construct(
+        \Closure $callback,
+    ) {
+
+    }
+
+    public function wait(): mixed
+    {
+        throw new \RuntimeException('TODO need to be implemented');
+    }
+}

--- a/packages/seal/Task/SyncTask.php
+++ b/packages/seal/Task/SyncTask.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Schranz\Search\SEAL\Task;
+
+/**
+ * An easier to use Task object for synchronous tasks.
+ *
+ * @template-covariant T of mixed
+ *
+ * @template-implements TaskInterface<T>
+ */
+final class SyncTask implements TaskInterface
+{
+    /**
+     * @param T $result
+     */
+    public function __construct(
+        private readonly mixed $result,
+    ) {}
+
+    public function wait(): mixed
+    {
+        return $this->result;
+    }
+}

--- a/packages/seal/Task/TaskInterface.php
+++ b/packages/seal/Task/TaskInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Schranz\Search\SEAL\Task;
+
+/**
+ * @template-covariant T of mixed
+ */
+interface TaskInterface
+{
+    /**
+     * In most cases for performance reasons it should be avoided to wait for a task to finish.
+     * The search index normally correctly schedules syncs that we even don't need to wait example
+     * that the index is created to index documents.
+     * So the main usecase for return a task and wait for it are inside tests where index create and drops are tested.
+     *
+     * @return T
+     */
+    public function wait(): mixed;
+}


### PR DESCRIPTION
Introduce an optional task return to provide easier support for async search engines.

This means all write index operations can based on a flag return a `TaskInterface`:

 - `save(Index $index, array $document, array $options = []): ?TaskInterface;`
 - `delete(delete $index, string $identifier, array $options = []): ?TaskInterface;`
 - `dropIndex(Index $index, array $options = []): ?TaskInterface;`
 - `createIndex(Index $index, array $options = []): ?TaskInterface;`

As returning a Task should be an edgecase it is hidden behind a `options` array. We still have full static code analyzer support via generic and conditional phpstan return types:

```php
    /**
     * @template T of bool
     *
     * @param array{return_slow_promise_result: T} $options
     *
     * @return (T is true ? TaskInterface : null)
     */
    public function dropIndex(Index $index, array $options = []): ?TaskInterface;
```

The name `Task` is inspired by Meilisearch which works full Async and uses task for all operations: https://docs.meilisearch.com/reference/api/tasks.html.

**Usage:**

```php
$task = $engine->createIndex('test', ['return_slow_promise_result' => true)]);
$task->wait(); // wait until the index was really created
```

Alternative to `Task` could be `Operation`.