### PR TITLE
Remove sleep and use AsyncTask->wait() instead for Algolia Adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ At current state collect here different search engines which are around and coul
  - [PostgreSQL Full Text Search](#postgresql-full-text-search)
  - [MySQL Full Text Search](#mysql-full-text-search)
  - [Sphinx Search](#sphinx-search)
+ - [Manticoresearch](#manticoresearch)
  - [Azure Cognitive Search](#azure-cognitive-search)
  - [Google Cloud Search](#google-cloud-search)
  - [Amazon CloudSearch](#amazon-cloudsearch)
@@ -177,20 +178,28 @@ None open source search engine from MongoDB. It is a cloud based search engine.
 
 ### PostgreSQL Full Text Search
 
- - Server: [PostgreSQL](https://www.postgresql.org/)
+ - Server: [PostgreSQL Server](https://www.postgresql.org/)
  - PHP Client: No client use the [Full Text Feature](https://www.postgresql.org/docs/current/textsearch.html) the Database connection.
 
 ### MySQL Full Text Search
 
- - Server: [MySQL](https://dev.mysql.com/)
+ - Server: [MySQL Server](https://dev.mysql.com/)
  - PHP Client: No client use the [Full Text Feature](https://dev.mysql.com/doc/refman/8.0/en/fulltext-search.html) the Database connection.
 
 ### Sphinx Search
 
 An older search engine written in Python.
 
- - Server: [Sphinx Search](http://sphinxsearch.com/downloads/current/)
+ - Server: [Sphinx Search Server](http://sphinxsearch.com/downloads/current/)
  - PHP Client: No official client available
+
+### Manticore Search
+
+Fork of Sphinx 2.3.2 in 2017, describes itself as an easy to use open source fast database for search.
+Good alternative for Elasticsearch.
+
+ - Server: [Manticore Search Server](https://github.com/manticoresoftware/manticoresearch)
+ - PHP Client: [Manticore Search PHP Client](https://github.com/manticoresoftware/manticoresearch-php)
 
 ### Azure Cognitive Search
 

--- a/packages/seal-algolia-adapter/Tests/AlgoliaAdapterTest.php
+++ b/packages/seal-algolia-adapter/Tests/AlgoliaAdapterTest.php
@@ -15,24 +15,4 @@ class AlgoliaAdapterTest extends AbstractAdapterTestCase
 
         self::$adapter = new AlgoliaAdapter(self::$client);
     }
-
-    protected static function waitForCreateIndex(): void
-    {
-        usleep((int) ($_ENV['ALGOLIA_WAIT_TIME'] ?? 5_000_000));
-    }
-
-    protected static function waitForDropIndex(): void
-    {
-        usleep((int) ($_ENV['ALGOLIA_WAIT_TIME'] ?? 5_000_000));
-    }
-
-    public static function waitForAddDocuments(): void
-    {
-        usleep((int) ($_ENV['ALGOLIA_WAIT_TIME'] ?? 5_000_000));
-    }
-
-    public static function waitForDeleteDocuments(): void
-    {
-        usleep((int) ($_ENV['ALGOLIA_WAIT_TIME'] ?? 5_000_000));
-    }
 }

--- a/packages/seal-algolia-adapter/Tests/AlgoliaConnectionTest.php
+++ b/packages/seal-algolia-adapter/Tests/AlgoliaConnectionTest.php
@@ -19,24 +19,4 @@ class AlgoliaConnectionTest extends AbstractConnectionTestCase
 
         parent::setUpBeforeClass();
     }
-
-    protected static function waitForCreateIndex(): void
-    {
-        usleep((int) ($_ENV['ALGOLIA_WAIT_TIME'] ?? 200_000));
-    }
-
-    protected static function waitForDropIndex(): void
-    {
-        usleep((int) ($_ENV['ALGOLIA_WAIT_TIME'] ?? 5_000_000));
-    }
-
-    public static function waitForAddDocuments(): void
-    {
-        usleep((int) ($_ENV['ALGOLIA_WAIT_TIME'] ?? 5_000_000));
-    }
-
-    public static function waitForDeleteDocuments(): void
-    {
-        usleep((int) ($_ENV['ALGOLIA_WAIT_TIME'] ?? 5_000_000));
-    }
 }

--- a/packages/seal-algolia-adapter/Tests/AlgoliaSchemaManagerTest.php
+++ b/packages/seal-algolia-adapter/Tests/AlgoliaSchemaManagerTest.php
@@ -15,14 +15,4 @@ class AlgoliaSchemaManagerTest extends AbstractSchemaManagerTestCase
 
         self::$schemaManager = new AlgoliaSchemaManager(self::$client);
     }
-
-    protected static function waitForCreateIndex(): void
-    {
-        usleep((int) ($_ENV['ALGOLIA_WAIT_TIME'] ?? 5_000_000));
-    }
-
-    protected static function waitForDropIndex(): void
-    {
-        usleep((int) ($_ENV['ALGOLIA_WAIT_TIME'] ?? 5_000_000));
-    }
 }

--- a/packages/seal-memory-adapter/MemorySchemaManager.php
+++ b/packages/seal-memory-adapter/MemorySchemaManager.php
@@ -4,6 +4,7 @@ namespace Schranz\Search\SEAL\Adapter\Memory;
 
 use Schranz\Search\SEAL\Adapter\SchemaManagerInterface;
 use Schranz\Search\SEAL\Schema\Index;
+use Schranz\Search\SEAL\Task\SyncTask;
 use Schranz\Search\SEAL\Task\TaskInterface;
 
 final class MemorySchemaManager implements SchemaManagerInterface

--- a/packages/seal/Adapter/SchemaManagerInterface.php
+++ b/packages/seal/Adapter/SchemaManagerInterface.php
@@ -14,7 +14,7 @@ interface SchemaManagerInterface
      *
      * @param array{return_slow_promise_result: T} $options
      *
-     * @return (T is true ? TaskInterface : null)
+     * @return (T is true ? TaskInterface<null> : null)
      */
     public function dropIndex(Index $index, array $options = []): ?TaskInterface;
 
@@ -23,7 +23,7 @@ interface SchemaManagerInterface
      *
      * @param array{return_slow_promise_result: T} $options
      *
-     * @return (T is true ? TaskInterface : null)
+     * @return (T is true ? TaskInterface<null> : null)
      */
     public function createIndex(Index $index, array $options = []): ?TaskInterface;
 }

--- a/packages/seal/Engine.php
+++ b/packages/seal/Engine.php
@@ -7,6 +7,8 @@ use Schranz\Search\SEAL\Exception\DocumentNotFoundException;
 use Schranz\Search\SEAL\Schema\Schema;
 use Schranz\Search\SEAL\Search\Condition\IdentifierCondition;
 use Schranz\Search\SEAL\Search\SearchBuilder;
+use Schranz\Search\SEAL\Task\AsyncTask;
+use Schranz\Search\SEAL\Task\MultiTask;
 use Schranz\Search\SEAL\Task\TaskInterface;
 
 final class Engine
@@ -125,9 +127,11 @@ final class Engine
             $tasks[] = $this->adapter->getSchemaManager()->createIndex($index, $options);
         }
 
-        return null;
+        if (true !== ($options['return_slow_promise_result'] ?? false)) {
+            return null;
+        }
 
-        // TODO return TaskInterface for $returnWaitPromise = true
+        return new MultiTask($tasks);
     }
 
     /**
@@ -144,8 +148,10 @@ final class Engine
             $tasks[] = $this->adapter->getSchemaManager()->dropIndex($index, $options);
         }
 
-        return null;
+        if (true !== ($options['return_slow_promise_result'] ?? false)) {
+            return null;
+        }
 
-        // TODO return TaskInterface for $returnWaitPromise = true
+        return new MultiTask($tasks);
     }
 }

--- a/packages/seal/Task/AsyncTask.php
+++ b/packages/seal/Task/AsyncTask.php
@@ -17,13 +17,16 @@ final class AsyncTask implements TaskInterface
      * @param \Closure(): T $callback
      */
     public function __construct(
-        \Closure $callback,
+        private \Closure $callback,
     ) {
-
+        // TODO check if async library (e.g. react-php) should call callback method already here
+        //      for Agolia this is currently not required or possible as they use a blocking usleep
+        //      see https://github.com/algolia/algoliasearch-client-php/issues/712
+        //      but maybe for other adapters make sense to async resolve it here
     }
 
     public function wait(): mixed
     {
-        throw new \RuntimeException('TODO need to be implemented');
+        return ($this->callback)();
     }
 }

--- a/packages/seal/Task/MultiTask.php
+++ b/packages/seal/Task/MultiTask.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Schranz\Search\SEAL\Task;
+
+/**
+ * A Task object which waits for multiple tasks.
+ *
+ * @template-implements TaskInterface<null>
+ */
+final class MultiTask implements TaskInterface
+{
+    public function __construct(
+        private array $tasks,
+    ) {
+    }
+
+    /**
+     * @return null
+     */
+    public function wait(): mixed
+    {
+        foreach ($this->tasks as $task) {
+            $task->wait();
+        }
+
+        return null;
+    }
+}

--- a/packages/seal/Testing/AbstractSchemaManagerTestCase.php
+++ b/packages/seal/Testing/AbstractSchemaManagerTestCase.php
@@ -23,13 +23,15 @@ abstract class AbstractSchemaManagerTestCase extends TestCase
 
         $this->assertFalse(static::$schemaManager->existIndex($index));
 
-        static::$schemaManager->createIndex($index);
-        static::waitForCreateIndex();
+        $task = static::$schemaManager->createIndex($index, ['return_slow_promise_result' => true]);
+        $task->wait();
+        static::waitForCreateIndex(); // TODO remove when all adapter migrated to $task->wait();
 
         $this->assertTrue(static::$schemaManager->existIndex($index));
 
-        static::$schemaManager->dropIndex($index);
-        static::waitForDropIndex();
+        $task = static::$schemaManager->dropIndex($index, ['return_slow_promise_result' => true]);
+        $task->wait();
+        static::waitForDropIndex(); // TODO remove when all adapter migrated to $task->wait();
 
         $this->assertFalse(static::$schemaManager->existIndex($index));
     }
@@ -40,28 +42,36 @@ abstract class AbstractSchemaManagerTestCase extends TestCase
 
         $this->assertFalse(static::$schemaManager->existIndex($index));
 
-        static::$schemaManager->createIndex($index);
-        static::waitForCreateIndex();
+        $task = static::$schemaManager->createIndex($index, ['return_slow_promise_result' => true]);
+        $task->wait();
+        static::waitForCreateIndex(); // TODO remove when all adapter migrated to $task->wait();
 
         $this->assertTrue(static::$schemaManager->existIndex($index));
 
-        static::$schemaManager->dropIndex($index);
-        static::waitForDropIndex();
+        $task = static::$schemaManager->dropIndex($index, ['return_slow_promise_result' => true]);
+        $task->wait();
+        static::waitForDropIndex(); // TODO remove when all adapter migrated to $task->wait();
 
         $this->assertFalse(static::$schemaManager->existIndex($index));
     }
 
     /**
+     * @deprecated Use return AsyncTask instead.
+     *
      * For async adapters, we need to wait for the index to be created.
      */
     protected static function waitForCreateIndex(): void
     {
+        // TODO remove when all adapter migrated to $task->wait();
     }
 
     /**
+     * @deprecated Use return AsyncTask instead.
+     *
      * For async adapters, we need to wait for the index to be deleted.
      */
     protected static function waitForDropIndex(): void
     {
+        // TODO remove when all adapter migrated to $task->wait();
     }
 }

--- a/packages/seal/Testing/TaskHelper.php
+++ b/packages/seal/Testing/TaskHelper.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Schranz\Search\SEAL\Testing;
+
+use Schranz\Search\SEAL\Task\MultiTask;
+use Schranz\Search\SEAL\Task\TaskInterface;
+
+/**
+ * @interal
+ */
+final class TaskHelper
+{
+    /**
+     * @var TaskInterface<mixed>[]
+     */
+    public array $tasks = [];
+
+    public function waitForAll(): void
+    {
+        (new MultiTask($this->tasks))->wait();
+
+        $this->tasks = [];
+    }
+}

--- a/packages/seal/Testing/TestingHelper.php
+++ b/packages/seal/Testing/TestingHelper.php
@@ -5,6 +5,7 @@ namespace Schranz\Search\SEAL\Testing;
 use Schranz\Search\SEAL\Schema\Index;
 use Schranz\Search\SEAL\Schema\Schema;
 use Schranz\Search\SEAL\Schema\Field;
+use Schranz\Search\SEAL\Task\TaskInterface;
 
 class TestingHelper
 {
@@ -161,6 +162,21 @@ class TestingHelper
                 'id' => '3',
             ],
         ];
+    }
+
+    /**
+     * @param \Closure(TaskInterface[]: $tasks) $callback
+     */
+    public static function waitForTasks(\Closure $callback): void
+    {
+        /** @var TaskInterface[] $tasks */
+        $tasks = [];
+
+        ($callback)($tasks);
+
+        foreach ($tasks as $task) {
+            $task->wait();
+        }
     }
 
     /**

--- a/packages/seal/composer.lock
+++ b/packages/seal/composer.lock
@@ -9,31 +9,32 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.5.x-dev",
+            "version": "2.0.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "6f1e0c4fe793e48a58efb931510239f53a15be10"
+                "reference": "d6eef505a6c46e963e54bf73bb9de43cdea70821"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/6f1e0c4fe793e48a58efb931510239f53a15be10",
-                "reference": "6f1e0c4fe793e48a58efb931510239f53a15be10",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d6eef505a6c46e963e54bf73bb9de43cdea70821",
+                "reference": "d6eef505a6c46e963e54bf73bb9de43cdea70821",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^11",
+                "doctrine/coding-standard": "^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.16 || ^1",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.30 || ^5.4"
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -59,7 +60,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.4.x"
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.x"
             },
             "funding": [
                 {
@@ -75,7 +76,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-29T10:47:47+00:00"
+            "time": "2023-01-04T15:42:40+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -319,12 +320,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "9f1f0f9a2fbb680b26d1cf9b61b6eac43a6e4e9c"
+                "reference": "3bd773131666fd5457a2a89ff790dfd2b2260ae9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/9f1f0f9a2fbb680b26d1cf9b61b6eac43a6e4e9c",
-                "reference": "9f1f0f9a2fbb680b26d1cf9b61b6eac43a6e4e9c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/3bd773131666fd5457a2a89ff790dfd2b2260ae9",
+                "reference": "3bd773131666fd5457a2a89ff790dfd2b2260ae9",
                 "shasum": ""
             },
             "require": {
@@ -380,7 +381,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.23"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2"
             },
             "funding": [
                 {
@@ -388,7 +389,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-28T12:41:10+00:00"
+            "time": "2023-01-02T08:36:34+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -637,16 +638,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "22ca7c4249add75f21356e886401376c11e2be1e"
+                "reference": "0b91f6c65ddd492a57c738947110458ce20b0734"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/22ca7c4249add75f21356e886401376c11e2be1e",
-                "reference": "22ca7c4249add75f21356e886401376c11e2be1e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0b91f6c65ddd492a57c738947110458ce20b0734",
+                "reference": "0b91f6c65ddd492a57c738947110458ce20b0734",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1",
+                "doctrine/instantiator": "^1.3.1 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -731,7 +732,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-24T05:47:24+00:00"
+            "time": "2023-01-04T07:20:58+00:00"
         },
         {
             "name": "sebastian/cli-parser",


### PR DESCRIPTION
This fixes parts of #26 as it refractors the abstract tests to be compatible with async api.

We are now using the newly implemented `Task` objects as optional response for write index processes from https://github.com/schranz-search/schranz-search/pull/35.

This way we can wait inside tests for things like index created, index removed, document added, document removed. So we can remove requires usleep from the algolia tests.