### PR TITLE
Use Sync Task instead of sleep for Elasticsearch and Opensearch Adapters

### DIFF
--- a/packages/seal-elasticsearch-adapter/ElasticsearchConnection.php
+++ b/packages/seal-elasticsearch-adapter/ElasticsearchConnection.php
@@ -34,6 +34,7 @@ final class ElasticsearchConnection implements ConnectionInterface
             'index' => $index->name,
             'id' => $identifier,
             'body' => $document,
+            // TODO refresh should be refactored with async tasks
             'refresh' => $options['return_slow_promise_result'] ?? false, // update document immediately, so it is available in the `/_search` api directly
         ]);
 
@@ -56,6 +57,7 @@ final class ElasticsearchConnection implements ConnectionInterface
             $response = $this->client->delete([
                 'index' => $index->name,
                 'id' => $identifier,
+                // TODO refresh should be refactored with async tasks
                 'refresh' => $options['return_slow_promise_result'] ?? false, // update document immediately, so it is no longer available in the `/_search` api directly
             ]);
 

--- a/packages/seal-elasticsearch-adapter/Tests/ElasticsearchAdapterTest.php
+++ b/packages/seal-elasticsearch-adapter/Tests/ElasticsearchAdapterTest.php
@@ -15,14 +15,4 @@ class ElasticsearchAdapterTest extends AbstractAdapterTestCase
 
         self::$adapter = new ElasticsearchAdapter(self::$client);
     }
-
-    public static function waitForAddDocuments(): void
-    {
-        usleep((int) ($_ENV['ELASTICSEARCH_WAIT_TIME'] ?? 100_000));
-    }
-
-    public static function waitForDeleteDocuments(): void
-    {
-        usleep((int) ($_ENV['ELASTICSEARCH_WAIT_TIME'] ?? 100_000));
-    }
 }

--- a/packages/seal-elasticsearch-adapter/Tests/ElasticsearchConnectionTest.php
+++ b/packages/seal-elasticsearch-adapter/Tests/ElasticsearchConnectionTest.php
@@ -19,14 +19,4 @@ class ElasticsearchConnectionTest extends AbstractConnectionTestCase
 
         parent::setUpBeforeClass();
     }
-
-    public static function waitForAddDocuments(): void
-    {
-        usleep((int) ($_ENV['ELASTICSEARCH_WAIT_TIME'] ?? 100_000));
-    }
-
-    public static function waitForDeleteDocuments(): void
-    {
-        usleep((int) ($_ENV['ELASTICSEARCH_WAIT_TIME'] ?? 100_000));
-    }
 }

--- a/packages/seal-opensearch-adapter/OpensearchConnection.php
+++ b/packages/seal-opensearch-adapter/OpensearchConnection.php
@@ -34,6 +34,7 @@ final class OpensearchConnection implements ConnectionInterface
             'index' => $index->name,
             'id' => $identifier,
             'body' => $document,
+            // TODO refresh should be refactored with async tasks
             'refresh' => $options['return_slow_promise_result'] ?? false, // update document immediately, so it is available in the `/_search` api directly
         ]);
 
@@ -55,6 +56,7 @@ final class OpensearchConnection implements ConnectionInterface
         $data = $this->client->delete([
             'index' => $index->name,
             'id' => $identifier,
+            // TODO refresh should be refactored with async tasks
             'refresh' => $options['return_slow_promise_result'] ?? false, // update document immediately, so it is no longer available in the `/_search` api directly
         ]);
 

--- a/packages/seal-opensearch-adapter/Tests/OpensearchAdapterTest.php
+++ b/packages/seal-opensearch-adapter/Tests/OpensearchAdapterTest.php
@@ -15,14 +15,4 @@ class OpensearchAdapterTest extends AbstractAdapterTestCase
 
         self::$adapter = new OpensearchAdapter(self::$client);
     }
-
-    public static function waitForAddDocuments(): void
-    {
-        usleep((int) ($_ENV['OPENSEARCH_WAIT_TIME'] ?? 1_000_000));
-    }
-
-    public static function waitForDeleteDocuments(): void
-    {
-        usleep((int) ($_ENV['OPENSEARCH_WAIT_TIME'] ?? 1_000_000));
-    }
 }

--- a/packages/seal-opensearch-adapter/Tests/OpensearchConnectionTest.php
+++ b/packages/seal-opensearch-adapter/Tests/OpensearchConnectionTest.php
@@ -19,14 +19,4 @@ class OpensearchConnectionTest extends AbstractConnectionTestCase
 
         parent::setUpBeforeClass();
     }
-
-    public static function waitForAddDocuments(): void
-    {
-        usleep((int) ($_ENV['OPENSEARCH_WAIT_TIME'] ?? 100_000));
-    }
-
-    public static function waitForDeleteDocuments(): void
-    {
-        usleep((int) ($_ENV['OPENSEARCH_WAIT_TIME'] ?? 100_000));
-    }
 }


### PR DESCRIPTION
This solve parts of #26. Still a async way should be implemented maybe via polling how Algolia is doing it internal.