### PR TITLE
Remove sleep and use AsyncTask->wait() instade for Meilisearch Adapter

### DIFF
--- a/packages/seal-meilisearch-adapter/Tests/MeilisearchAdapterTest.php
+++ b/packages/seal-meilisearch-adapter/Tests/MeilisearchAdapterTest.php
@@ -15,24 +15,4 @@ class MeilisearchAdapterTest extends AbstractAdapterTestCase
 
         self::$adapter = new MeilisearchAdapter(self::$client);
     }
-
-    protected static function waitForCreateIndex(): void
-    {
-        usleep((int) ($_ENV['MEILISEARCH_WAIT_TIME'] ?? 200_000));
-    }
-
-    protected static function waitForDropIndex(): void
-    {
-        usleep((int) ($_ENV['MEILISEARCH_WAIT_TIME'] ?? 200_000));
-    }
-
-    public static function waitForAddDocuments(): void
-    {
-        usleep((int) ($_ENV['MEILISEARCH_WAIT_TIME'] ?? 200_000));
-    }
-
-    public static function waitForDeleteDocuments(): void
-    {
-        usleep((int) ($_ENV['MEILISEARCH_WAIT_TIME'] ?? 200_000));
-    }
 }

--- a/packages/seal-meilisearch-adapter/Tests/MeilisearchConnectionTest.php
+++ b/packages/seal-meilisearch-adapter/Tests/MeilisearchConnectionTest.php
@@ -19,24 +19,4 @@ class MeilisearchConnectionTest extends AbstractConnectionTestCase
 
         parent::setUpBeforeClass();
     }
-
-    protected static function waitForCreateIndex(): void
-    {
-        usleep((int) ($_ENV['MEILISEARCH_WAIT_TIME'] ?? 200_000));
-    }
-
-    protected static function waitForDropIndex(): void
-    {
-        usleep((int) ($_ENV['MEILISEARCH_WAIT_TIME'] ?? 200_000));
-    }
-
-    public static function waitForAddDocuments(): void
-    {
-        usleep((int) ($_ENV['MEILISEARCH_WAIT_TIME'] ?? 200_000));
-    }
-
-    public static function waitForDeleteDocuments(): void
-    {
-        usleep((int) ($_ENV['MEILISEARCH_WAIT_TIME'] ?? 200_000));
-    }
 }

--- a/packages/seal-meilisearch-adapter/Tests/MeilisearchSchemaManagerTest.php
+++ b/packages/seal-meilisearch-adapter/Tests/MeilisearchSchemaManagerTest.php
@@ -17,14 +17,4 @@ class MeilisearchSchemaManagerTest extends AbstractSchemaManagerTestCase
 
         self::$schemaManager = new MeilisearchSchemaManager(self::$client);
     }
-
-    protected static function waitForCreateIndex(): void
-    {
-        usleep((int) ($_ENV['MEILISEARCH_WAIT_TIME'] ?? 200_000));
-    }
-
-    protected static function waitForDropIndex(): void
-    {
-        usleep((int) ($_ENV['MEILISEARCH_WAIT_TIME'] ?? 200_000));
-    }
 }


### PR DESCRIPTION
Same as for Algolia Adapter in #44. We are now using the newly implemented Task objects as optional response for write index processes from https://github.com/schranz-search/schranz-search/pull/35.

This way we can wait inside tests for things like index created, index removed, document added, document removed. So we can remove requires usleep from the algolia tests.