### PR TITLE
Remove not longer required waitFor test methods

### DIFF
--- a/packages/seal-elasticsearch-adapter/Tests/ElasticsearchSchemaManagerTest.php
+++ b/packages/seal-elasticsearch-adapter/Tests/ElasticsearchSchemaManagerTest.php
@@ -20,9 +20,8 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
     public function testSimpleElasticsearchMapping(): void
     {
         $index = $this->schema->indexes[TestingHelper::INDEX_SIMPLE];
-        static::$schemaManager->createIndex($index);
-
-        $this->waitForCreateIndex();
+        $task = static::$schemaManager->createIndex($index, ['return_slow_promise_result' => true]);
+        $task->wait();
 
         $mapping = self::$client->indices()->getMapping([
             'index' => $index->name,
@@ -39,16 +38,15 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             ],
         ], $mapping[$index->name]['mappings']['properties']);
 
-        static::$schemaManager->dropIndex($index);
-        static::waitForDropIndex();
+        $task = static::$schemaManager->dropIndex($index, ['return_slow_promise_result' => true]);
+        $task->wait();
     }
 
     public function testComplexElasticsearchMapping(): void
     {
         $index = $this->schema->indexes[TestingHelper::INDEX_COMPLEX];
-        static::$schemaManager->createIndex($index);
-
-        $this->waitForCreateIndex();
+        $task = static::$schemaManager->createIndex($index, ['return_slow_promise_result' => true]);
+        $task->wait();
 
         $mapping = self::$client->indices()->getMapping([
             'index' => $index->name,
@@ -149,7 +147,7 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             ],
         ], $mapping[$index->name]['mappings']['properties']);
 
-        static::$schemaManager->dropIndex($index);
-        static::waitForDropIndex();
+        $task = static::$schemaManager->dropIndex($index, ['return_slow_promise_result' => true]);
+        $task->wait();
     }
 }

--- a/packages/seal-opensearch-adapter/Tests/OpensearchSchemaManagerTest.php
+++ b/packages/seal-opensearch-adapter/Tests/OpensearchSchemaManagerTest.php
@@ -20,8 +20,8 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
     public function testSimpleOpensearchMapping(): void
     {
         $index = $this->schema->indexes[TestingHelper::INDEX_SIMPLE];
-        static::$schemaManager->createIndex($index);
-        static::waitForCreateIndex();
+        $task = static::$schemaManager->createIndex($index, ['return_slow_promise_result' => true]);
+        $task->wait();
 
         $mapping = self::$client->indices()->getMapping([
             'index' => $index->name,
@@ -38,15 +38,15 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             ],
         ], $mapping[$index->name]['mappings']['properties']);
 
-        static::$schemaManager->dropIndex($index);
-        static::waitForDropIndex();
+        $task = static::$schemaManager->dropIndex($index, ['return_slow_promise_result' => true]);
+        $task->wait();
     }
 
     public function testComplexOpensearchMapping(): void
     {
         $index = $this->schema->indexes[TestingHelper::INDEX_COMPLEX];
-        static::$schemaManager->createIndex($index);
-        static::waitForCreateIndex();
+        $task = static::$schemaManager->createIndex($index, ['return_slow_promise_result' => true]);
+        $task->wait();
 
         $mapping = self::$client->indices()->getMapping([
             'index' => $index->name,
@@ -147,7 +147,7 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             ],
         ], $mapping[$index->name]['mappings']['properties']);
 
-        static::$schemaManager->dropIndex($index);
-        static::waitForDropIndex();
+        $task = static::$schemaManager->dropIndex($index, ['return_slow_promise_result' => true]);
+        $task->wait();
     }
 }

--- a/packages/seal/Testing/AbstractAdapterTestCase.php
+++ b/packages/seal/Testing/AbstractAdapterTestCase.php
@@ -46,13 +46,11 @@ abstract class AbstractAdapterTestCase extends TestCase
 
         $task = $engine->createIndex($indexName, ['return_slow_promise_result' => true]);
         $task->wait();
-        static::waitForCreateIndex(); // TODO remove when all adapter migrated to $task->wait();
 
         $this->assertTrue($engine->existIndex($indexName));
 
         $task = $engine->dropIndex($indexName, ['return_slow_promise_result' => true]);
         $task->wait();
-        static::waitForDropIndex(); // TODO remove when all adapter migrated to $task->wait();
 
         $this->assertFalse($engine->existIndex($indexName));
     }
@@ -64,7 +62,6 @@ abstract class AbstractAdapterTestCase extends TestCase
 
         $task = $engine->createSchema(['return_slow_promise_result' => true]);
         $task->wait();
-        static::waitForCreateIndex(); // TODO remove when all adapter migrated to $task->wait();
 
         foreach (array_keys($indexes) as $index) {
             $this->assertTrue($engine->existIndex($index));
@@ -72,7 +69,6 @@ abstract class AbstractAdapterTestCase extends TestCase
 
         $task = $engine->dropSchema(['return_slow_promise_result' => true]);
         $task->wait();
-        static::waitForDropIndex(); // TODO remove when all adapter migrated to $task->wait();
 
         foreach (array_keys($indexes) as $index) {
             $this->assertFalse($engine->existIndex($index));
@@ -84,7 +80,6 @@ abstract class AbstractAdapterTestCase extends TestCase
         $engine = self::getEngine();
         $task = $engine->createSchema(['return_slow_promise_result' => true]);
         $task->wait();
-        static::waitForCreateIndex(); // TODO remove when all adapter migrated to $task->wait();
 
         $documents = TestingHelper::createComplexFixtures();
 
@@ -93,7 +88,6 @@ abstract class AbstractAdapterTestCase extends TestCase
         }
 
         self::$taskHelper->waitForAll();
-        static::waitForAddDocuments(); // TODO remove when all adapter migrated to $task->wait();
 
         $loadedDocuments = [];
         foreach ($documents as $document) {
@@ -116,7 +110,6 @@ abstract class AbstractAdapterTestCase extends TestCase
         }
 
         self::$taskHelper->waitForAll();
-        static::waitForDeleteDocuments(); // TODO remove when all adapter migrated to $task->wait();
 
         foreach ($documents as $document) {
             $exceptionThrown = false;
@@ -142,45 +135,5 @@ abstract class AbstractAdapterTestCase extends TestCase
     public static function tearDownAfterClass(): void
     {
         self::getEngine()->dropSchema();
-    }
-
-    /**
-     * @deprecated Use return AsyncTask instead.
-     *
-     * For async adapters, we need to wait for the index to add documents.
-     */
-    protected static function waitForAddDocuments(): void
-    {
-        // TODO remove when all adapter migrated to $task->wait();
-    }
-
-    /**
-     * @deprecated Use return AsyncTask instead.
-     *
-     * For async adapters, we need to wait for the index to delete documents.
-     */
-    protected static function waitForDeleteDocuments(): void
-    {
-        // TODO remove when all adapter migrated to $task->wait();
-    }
-
-    /**
-     * @deprecated Use return AsyncTask instead.
-     *
-     * For async adapters, we need to wait for the index to be created.
-     */
-    protected static function waitForCreateIndex(): void
-    {
-        // TODO remove when all adapter migrated to $task->wait();
-    }
-
-    /**
-     * @deprecated Use return AsyncTask instead.
-     *
-     * For async adapters, we need to wait for the index to be deleted.
-     */
-    protected static function waitForDropIndex(): void
-    {
-        // TODO remove when all adapter migrated to $task->wait();
     }
 }

--- a/packages/seal/Testing/AbstractConnectionTestCase.php
+++ b/packages/seal/Testing/AbstractConnectionTestCase.php
@@ -32,7 +32,6 @@ abstract class AbstractConnectionTestCase extends TestCase
         }
 
         self::$taskHelper->waitForAll();
-        static::waitForCreateIndex(); // TODO remove when all adapter migrated to $task->wait();
     }
 
     public static function tearDownAfterClass(): void
@@ -43,7 +42,6 @@ abstract class AbstractConnectionTestCase extends TestCase
         }
 
         self::$taskHelper->waitForAll();
-        static::waitForDropIndex(); // TODO remove when all adapter migrated to $task->wait();
     }
 
     protected static function getSchema(): Schema
@@ -68,8 +66,7 @@ abstract class AbstractConnectionTestCase extends TestCase
                 ['return_slow_promise_result' => true]
             );
         }
-        self::$taskHelper->waitForAll();;
-        static::waitForAddDocuments(); // TODO remove when all adapter migrated to $task->wait();
+        self::$taskHelper->waitForAll();
 
         $loadedDocuments = [];
         foreach ($documents as $document) {
@@ -104,7 +101,6 @@ abstract class AbstractConnectionTestCase extends TestCase
         }
 
         self::$taskHelper->waitForAll();
-        static::waitForDeleteDocuments(); // TODO remove when all adapter migrated to $task->wait();
 
         foreach ($documents as $document) {
             $search = new SearchBuilder($schema, self::$connection);
@@ -115,45 +111,5 @@ abstract class AbstractConnectionTestCase extends TestCase
 
             $this->assertNull($resultDocument, 'Expected document with id "' . $document['id'] . '" to be deleted.');
         }
-    }
-
-    /**
-     * @deprecated Use return AsyncTask instead.
-     *
-     * For async adapters, we need to wait for the index to be created.
-     */
-    protected static function waitForCreateIndex(): void
-    {
-        // TODO remove when all adapter migrated to $task->wait();
-    }
-
-    /**
-     * @deprecated Use return AsyncTask instead.
-     *
-     * For async adapters, we need to wait for the index to be deleted.
-     */
-    protected static function waitForDropIndex(): void
-    {
-        // TODO remove when all adapter migrated to $task->wait();
-    }
-
-    /**
-     * @deprecated Use return AsyncTask instead.
-     *
-     * For async adapters, we need to wait for the index to add documents.
-     */
-    protected static function waitForAddDocuments(): void
-    {
-        // TODO remove when all adapter migrated to $task->wait();
-    }
-
-    /**
-     * @deprecated Use return AsyncTask instead.
-     *
-     * For async adapters, we need to wait for the index to delete documents.
-     */
-    protected static function waitForDeleteDocuments(): void
-    {
-        // TODO remove when all adapter migrated to $task->wait();
     }
 }

--- a/packages/seal/Testing/AbstractSchemaManagerTestCase.php
+++ b/packages/seal/Testing/AbstractSchemaManagerTestCase.php
@@ -25,13 +25,11 @@ abstract class AbstractSchemaManagerTestCase extends TestCase
 
         $task = static::$schemaManager->createIndex($index, ['return_slow_promise_result' => true]);
         $task->wait();
-        static::waitForCreateIndex(); // TODO remove when all adapter migrated to $task->wait();
 
         $this->assertTrue(static::$schemaManager->existIndex($index));
 
         $task = static::$schemaManager->dropIndex($index, ['return_slow_promise_result' => true]);
         $task->wait();
-        static::waitForDropIndex(); // TODO remove when all adapter migrated to $task->wait();
 
         $this->assertFalse(static::$schemaManager->existIndex($index));
     }
@@ -44,34 +42,12 @@ abstract class AbstractSchemaManagerTestCase extends TestCase
 
         $task = static::$schemaManager->createIndex($index, ['return_slow_promise_result' => true]);
         $task->wait();
-        static::waitForCreateIndex(); // TODO remove when all adapter migrated to $task->wait();
 
         $this->assertTrue(static::$schemaManager->existIndex($index));
 
         $task = static::$schemaManager->dropIndex($index, ['return_slow_promise_result' => true]);
         $task->wait();
-        static::waitForDropIndex(); // TODO remove when all adapter migrated to $task->wait();
 
         $this->assertFalse(static::$schemaManager->existIndex($index));
-    }
-
-    /**
-     * @deprecated Use return AsyncTask instead.
-     *
-     * For async adapters, we need to wait for the index to be created.
-     */
-    protected static function waitForCreateIndex(): void
-    {
-        // TODO remove when all adapter migrated to $task->wait();
-    }
-
-    /**
-     * @deprecated Use return AsyncTask instead.
-     *
-     * For async adapters, we need to wait for the index to be deleted.
-     */
-    protected static function waitForDropIndex(): void
-    {
-        // TODO remove when all adapter migrated to $task->wait();
     }
 }


### PR DESCRIPTION
As #45, #44, #43 all adapters are changed to return AsyncTask / SyncTask object. The waitFor methods which where used to set usleep / sleep to wait for processing is not longer required for tests.