### PR TITLE
Add Test for MultiIndex Search

### DIFF
--- a/packages/seal-algolia-adapter/AlgoliaConnection.php
+++ b/packages/seal-algolia-adapter/AlgoliaConnection.php
@@ -10,7 +10,6 @@ use Schranz\Search\SEAL\Search\Condition\IdentifierCondition;
 use Schranz\Search\SEAL\Search\Result;
 use Schranz\Search\SEAL\Search\Search;
 use Schranz\Search\SEAL\Task\AsyncTask;
-use Schranz\Search\SEAL\Task\SyncTask;
 use Schranz\Search\SEAL\Task\TaskInterface;
 
 final class AlgoliaConnection implements ConnectionInterface
@@ -85,7 +84,7 @@ final class AlgoliaConnection implements ConnectionInterface
         }
 
         if (count($search->indexes) !== 1) {
-            throw new \RuntimeException('Algolia does not support multiple indexes in one query.');
+            throw new \RuntimeException('Algolia Adapter does not yet support search multiple indexes: https://github.com/schranz-search/schranz-search/issues/41');
         }
 
         $index = $this->client->initIndex($search->indexes[\array_key_first($search->indexes)]->name);

--- a/packages/seal-algolia-adapter/Tests/AlgoliaConnectionTest.php
+++ b/packages/seal-algolia-adapter/Tests/AlgoliaConnectionTest.php
@@ -19,4 +19,9 @@ class AlgoliaConnectionTest extends AbstractConnectionTestCase
 
         parent::setUpBeforeClass();
     }
+
+    public function testFindMultipleIndexes(): void
+    {
+        $this->markTestSkipped('Not supported by Meilisearch: https://github.com/schranz-search/schranz-search/issues/41');
+    }
 }

--- a/packages/seal-elasticsearch-adapter/ElasticsearchConnection.php
+++ b/packages/seal-elasticsearch-adapter/ElasticsearchConnection.php
@@ -129,7 +129,7 @@ final class ElasticsearchConnection implements ConnectionInterface
         }
 
         $searchResult = $this->client->search([
-            'index' => count($indexesNames) === 1 ? $indexesNames[0] : $indexesNames,
+            'index' => implode(',', $indexesNames),
             'body' => [
                 'query' => $query,
             ],

--- a/packages/seal-elasticsearch-adapter/Tests/ElasticsearchSchemaManagerTest.php
+++ b/packages/seal-elasticsearch-adapter/Tests/ElasticsearchSchemaManagerTest.php
@@ -133,9 +133,6 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
                     ],
                 ],
             ],
-            'id' => [
-                'type' => 'keyword',
-            ],
             'rating' => [
                 'type' => 'float',
             ],
@@ -144,6 +141,9 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             ],
             'title' => [
                 'type' => 'text',
+            ],
+            'uuid' => [
+                'type' => 'keyword',
             ],
         ], $mapping[$index->name]['mappings']['properties']);
 

--- a/packages/seal-meilisearch-adapter/MeilisearchConnection.php
+++ b/packages/seal-meilisearch-adapter/MeilisearchConnection.php
@@ -89,7 +89,7 @@ final class MeilisearchConnection implements ConnectionInterface
         }
 
         if (count($search->indexes) !== 1) {
-            throw new \RuntimeException('Meilisearch does not support multiple indexes in one query.');
+            throw new \RuntimeException('Meilisearch does not yet support search multiple indexes: https://github.com/schranz-search/schranz-search/issues/28');
         }
 
         $index = $this->client->index($search->indexes[\array_key_first($search->indexes)]->name);

--- a/packages/seal-meilisearch-adapter/Tests/MeilisearchConnectionTest.php
+++ b/packages/seal-meilisearch-adapter/Tests/MeilisearchConnectionTest.php
@@ -19,4 +19,9 @@ class MeilisearchConnectionTest extends AbstractConnectionTestCase
 
         parent::setUpBeforeClass();
     }
+
+    public function testFindMultipleIndexes(): void
+    {
+        $this->markTestSkipped('Not supported by Meilisearch: https://github.com/schranz-search/schranz-search/issues/28');
+    }
 }

--- a/packages/seal-opensearch-adapter/OpensearchConnection.php
+++ b/packages/seal-opensearch-adapter/OpensearchConnection.php
@@ -118,7 +118,7 @@ final class OpensearchConnection implements ConnectionInterface
         }
 
         $searchResult = $this->client->search([
-            'index' => count($indexesNames) === 1 ? $indexesNames[0] : $indexesNames,
+            'index' => implode(',', $indexesNames),
             'body' => [
                 'query' => $query,
             ],

--- a/packages/seal-opensearch-adapter/Tests/OpensearchSchemaManagerTest.php
+++ b/packages/seal-opensearch-adapter/Tests/OpensearchSchemaManagerTest.php
@@ -133,9 +133,6 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
                     ],
                 ],
             ],
-            'id' => [
-                'type' => 'keyword',
-            ],
             'rating' => [
                 'type' => 'float',
             ],
@@ -144,6 +141,9 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             ],
             'title' => [
                 'type' => 'text',
+            ],
+            'uuid' => [
+                'type' => 'keyword',
             ],
         ], $mapping[$index->name]['mappings']['properties']);
 

--- a/packages/seal/Testing/AbstractAdapterTestCase.php
+++ b/packages/seal/Testing/AbstractAdapterTestCase.php
@@ -91,7 +91,7 @@ abstract class AbstractAdapterTestCase extends TestCase
 
         $loadedDocuments = [];
         foreach ($documents as $document) {
-            $loadedDocuments[] = $engine->getDocument(TestingHelper::INDEX_COMPLEX, $document['id']);
+            $loadedDocuments[] = $engine->getDocument(TestingHelper::INDEX_COMPLEX, $document['uuid']);
         }
 
         $this->assertSame(
@@ -106,7 +106,7 @@ abstract class AbstractAdapterTestCase extends TestCase
         }
 
         foreach ($documents as $document) {
-            self::$taskHelper->tasks[] = $engine->deleteDocument(TestingHelper::INDEX_COMPLEX, $document['id'], ['return_slow_promise_result' => true]);
+            self::$taskHelper->tasks[] = $engine->deleteDocument(TestingHelper::INDEX_COMPLEX, $document['uuid'], ['return_slow_promise_result' => true]);
         }
 
         self::$taskHelper->waitForAll();
@@ -115,7 +115,7 @@ abstract class AbstractAdapterTestCase extends TestCase
             $exceptionThrown = false;
 
             try {
-                $engine->getDocument(TestingHelper::INDEX_COMPLEX, $document['id']);
+                $engine->getDocument(TestingHelper::INDEX_COMPLEX, $document['uuid']);
             } catch (DocumentNotFoundException $e) {
                 $exceptionThrown = true;
             }

--- a/packages/seal/Testing/TestingHelper.php
+++ b/packages/seal/Testing/TestingHelper.php
@@ -20,7 +20,7 @@ class TestingHelper
         $prefix = getenv('TEST_INDEX_PREFIX') ?: $_ENV['TEST_INDEX_PREFIX'] ?? 'test_';
 
         $complexFields = [
-            'id' => new Field\IdentifierField('id'),
+            'uuid' => new Field\IdentifierField('uuid'),
             'title' => new Field\TextField('title'),
             'header' => new Field\TypedField('header', 'type', [
                 'image' => [
@@ -96,7 +96,7 @@ class TestingHelper
     {
         return [
             [
-                'id' => '1',
+                'uuid' => '23b30f01-d8fd-4dca-b36a-4710e360a965',
                 'title' => 'New Blog',
                 'header' => [
                     'type' => 'image',
@@ -141,7 +141,7 @@ class TestingHelper
                 'categoryIds' => [1, 2],
             ],
             [
-                'id' => '2',
+                'uuid' => '79848403-c1a1-4420-bcc2-06ed537e0d4d',
                 'title' => 'Other Blog',
                 'header' => [
                     'type' => 'video',
@@ -159,7 +159,7 @@ class TestingHelper
                 'categoryIds' => [2, 3],
             ],
             [
-                'id' => '3',
+                'uuid' => '97cd3e94-c17f-4c11-a22b-d9da2e5318cd',
             ],
         ];
     }


### PR DESCRIPTION
This will add a test case for a basic MultiIndex. This is currently not supported by AlgoliaAdapter #41 and the Meilisearch #28 .