### PR TITLE
Add searchable, filterable and sortable to Schema Fields

### DIFF
--- a/packages/seal/README.md
+++ b/packages/seal/README.md
@@ -184,6 +184,54 @@ $schema = new Schema([
 
 The schema is serializable, so it can be stored in any cache and loaded fast.
 
+A more detailed schema definition can be made by defining which fields are 
+searchable, filterable and sortable. By default, all fields are `searchable`
+but no fields are `filterable` or `sortable`.
+
+<details>
+   <summary>Schema with searchable, filterable, sortable definitions:</summary>
+
+```php
+$fields = [
+    'id' => new Field\IdentifierField('uuid'),
+    'title' => new Field\TextField('title'),
+    'header' => new Field\TypedField('header', 'type', [
+        'image' => [
+            'media' => new Field\IntegerField('media', searchable: false),
+        ],
+        'video' => [
+            'media' => new Field\TextField('media', searchable: false),
+        ],
+    ]),
+    'article' => new Field\TextField('article'),
+    'blocks' => new Field\TypedField('blocks', 'type', [
+        'text' => [
+            'title' => new Field\TextField('title'),
+            'description' => new Field\TextField('description'),
+            'media' => new Field\IntegerField('media', multiple: true, searchable: false),
+        ],
+        'embed' => [
+            'title' => new Field\TextField('title'),
+            'media' => new Field\TextField('media', searchable: false),
+        ],
+    ], multiple: true),
+    'footer' => new Field\ObjectField('footer', [
+        'title' => new Field\TextField('title'),
+    ]),
+    'created' => new Field\DateTimeField('created', filterable: true, sortable: true),
+    'commentsCount' => new Field\IntegerField('commentsCount', searchable: false, filterable: true, sortable: true),
+    'rating' => new Field\FloatField('rating', searchable: false, filterable: true, sortable: true),
+    'comments' => new Field\ObjectField('comments', [
+        'email' => new Field\TextField('email', searchable: false),
+        'text' => new Field\TextField('text'),
+    ], multiple: true),
+    'tags' => new Field\TextField('tags', multiple: true, filterable: true),
+    'categoryIds' => new Field\IntegerField('categoryIds', multiple: true, filterable: true),
+];
+```
+
+</details>
+
 ### Create the engine
 
 The engine requires [an adapter](#list-of-adapters) and a previously created schema.

--- a/packages/seal/Schema/Field/AbstractField.php
+++ b/packages/seal/Schema/Field/AbstractField.php
@@ -10,6 +10,9 @@ abstract class AbstractField
     public function __construct(
         public readonly string $name,
         public readonly bool $multiple,
+        public readonly bool $searchable,
+        public readonly bool $filterable,
+        public readonly bool $sortable,
         public readonly array $options,
     ) {}
 }

--- a/packages/seal/Schema/Field/BooleanField.php
+++ b/packages/seal/Schema/Field/BooleanField.php
@@ -10,8 +10,21 @@ final class BooleanField extends AbstractField
     /**
      * @param array<string, mixed> $options
      */
-    public function __construct(string $name, bool $multiple = false, array $options = [])
-    {
-        parent::__construct($name, $multiple, $options);
+    public function __construct(
+        string $name,
+        bool $multiple = false,
+        bool $searchable = false,
+        bool $filterable = false,
+        bool $sortable = false,
+        array $options = []
+    ) {
+        parent::__construct(
+            $name,
+            $multiple,
+            $searchable,
+            $filterable,
+            $sortable,
+            $options
+        );
     }
 }

--- a/packages/seal/Schema/Field/DateTimeField.php
+++ b/packages/seal/Schema/Field/DateTimeField.php
@@ -10,8 +10,21 @@ final class DateTimeField extends AbstractField
     /**
      * @param array<string, mixed> $options
      */
-    public function __construct(string $name, bool $multiple = false, array $options = [])
-    {
-        parent::__construct($name, $multiple, $options);
+    public function __construct(
+        string $name,
+        bool $multiple = false,
+        bool $searchable = true,
+        bool $filterable = false,
+        bool $sortable = false,
+        array $options = []
+    ) {
+        parent::__construct(
+            $name,
+            $multiple,
+            $searchable,
+            $filterable,
+            $sortable,
+            $options
+        );
     }
 }

--- a/packages/seal/Schema/Field/FloatField.php
+++ b/packages/seal/Schema/Field/FloatField.php
@@ -10,8 +10,21 @@ final class FloatField extends AbstractField
     /**
      * @param array<string, mixed> $options
      */
-    public function __construct(string $name, bool $multiple = false, array $options = [])
-    {
-        parent::__construct($name, $multiple, $options);
+    public function __construct(
+        string $name,
+        bool $multiple = false,
+        bool $searchable = true,
+        bool $filterable = false,
+        bool $sortable = false,
+        array $options = []
+    ) {
+        parent::__construct(
+            $name,
+            $multiple,
+            $searchable,
+            $filterable,
+            $sortable,
+            $options
+        );
     }
 }

--- a/packages/seal/Schema/Field/IdentifierField.php
+++ b/packages/seal/Schema/Field/IdentifierField.php
@@ -9,6 +9,13 @@ final class IdentifierField extends AbstractField
 {
     public function __construct(string $name)
     {
-        parent::__construct($name, false, []);
+        parent::__construct(
+            $name,
+            multiple: false,
+            searchable: false,
+            filterable: true,
+            sortable: true,
+            options: [],
+        );
     }
 }

--- a/packages/seal/Schema/Field/IntegerField.php
+++ b/packages/seal/Schema/Field/IntegerField.php
@@ -10,8 +10,21 @@ final class IntegerField extends AbstractField
     /**
      * @param array<string, mixed> $options
      */
-    public function __construct(string $name, bool $multiple = false, array $options = [])
-    {
-        parent::__construct($name, $multiple, $options);
+    public function __construct(
+        string $name,
+        bool $multiple = false,
+        bool $searchable = true,
+        bool $filterable = false,
+        bool $sortable = false,
+        array $options = []
+    ) {
+        parent::__construct(
+            $name,
+            $multiple,
+            $searchable,
+            $filterable,
+            $sortable,
+            $options
+        );
     }
 }

--- a/packages/seal/Schema/Field/ObjectField.php
+++ b/packages/seal/Schema/Field/ObjectField.php
@@ -11,8 +11,37 @@ final class ObjectField extends AbstractField
      * @param array<string, AbstractField> $fields
      * @param array<string, mixed> $options
      */
-    public function __construct(string $name, readonly public array $fields, bool $multiple = false, array $options = [])
-    {
-        parent::__construct($name, $multiple, $options);
+    public function __construct(
+        string $name,
+        readonly public array $fields,
+        bool $multiple = false,
+        array $options = []
+    ) {
+        $searchable = false;
+        $filterable = false;
+        $sortable = false;
+
+        foreach ($fields as $field) {
+            if ($field->searchable) {
+                $searchable = true;
+            }
+
+            if ($field->filterable) {
+                $filterable = true;
+            }
+
+            if ($field->sortable) {
+                $sortable = true;
+            }
+        }
+
+        parent::__construct(
+            $name,
+            $multiple,
+            $searchable,
+            $filterable,
+            $sortable,
+            $options
+        );
     }
 }

--- a/packages/seal/Schema/Field/TextField.php
+++ b/packages/seal/Schema/Field/TextField.php
@@ -7,8 +7,24 @@ namespace Schranz\Search\SEAL\Schema\Field;
  */
 final class TextField extends AbstractField
 {
-    public function __construct(string $name, bool $multiple = false, array $options = [])
-    {
-        parent::__construct($name, $multiple, $options);
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function __construct(
+        string $name,
+        bool $multiple = false,
+        bool $searchable = true,
+        bool $filterable = false,
+        bool $sortable = false,
+        array $options = []
+    ) {
+        parent::__construct(
+            $name,
+            $multiple,
+            $searchable,
+            $filterable,
+            $sortable,
+            $options
+        );
     }
 }

--- a/packages/seal/Schema/Field/TypedField.php
+++ b/packages/seal/Schema/Field/TypedField.php
@@ -16,8 +16,35 @@ final class TypedField extends AbstractField
         public readonly string $typeField,
         public readonly iterable $types,
         bool $multiple = false,
-        array $options = [],
+        array $options = []
     ) {
-        parent::__construct($name, $multiple, $options);
+        $searchable = false;
+        $filterable = false;
+        $sortable = false;
+
+        foreach ($types as $fields) {
+            foreach ($fields as $field) {
+                if ($field->searchable) {
+                    $searchable = true;
+                }
+
+                if ($field->filterable) {
+                    $filterable = true;
+                }
+
+                if ($field->sortable) {
+                    $sortable = true;
+                }
+            }
+        }
+
+        parent::__construct(
+            $name,
+            $multiple,
+            $searchable,
+            $filterable,
+            $sortable,
+            $options
+        );
     }
 }

--- a/packages/seal/Testing/TestingHelper.php
+++ b/packages/seal/Testing/TestingHelper.php
@@ -24,10 +24,10 @@ class TestingHelper
             'title' => new Field\TextField('title'),
             'header' => new Field\TypedField('header', 'type', [
                 'image' => [
-                    'media' => new Field\IntegerField('media'),
+                    'media' => new Field\IntegerField('media', searchable: false),
                 ],
                 'video' => [
-                    'media' => new Field\TextField('media'),
+                    'media' => new Field\TextField('media', searchable: false),
                 ],
             ]),
             'article' => new Field\TextField('article'),
@@ -35,25 +35,25 @@ class TestingHelper
                 'text' => [
                     'title' => new Field\TextField('title'),
                     'description' => new Field\TextField('description'),
-                    'media' => new Field\IntegerField('media', multiple: true),
+                    'media' => new Field\IntegerField('media', multiple: true, searchable: false),
                 ],
                 'embed' => [
                     'title' => new Field\TextField('title'),
-                    'media' => new Field\TextField('media'),
+                    'media' => new Field\TextField('media', searchable: false),
                 ],
             ], multiple: true),
             'footer' => new Field\ObjectField('footer', [
                 'title' => new Field\TextField('title'),
             ]),
-            'created' => new Field\DateTimeField('created'),
-            'commentsCount' => new Field\IntegerField('commentsCount'),
-            'rating' => new Field\FloatField('rating'),
+            'created' => new Field\DateTimeField('created', filterable: true, sortable: true),
+            'commentsCount' => new Field\IntegerField('commentsCount', searchable: false, filterable: true, sortable: true),
+            'rating' => new Field\FloatField('rating',  searchable: false, filterable: true, sortable: true),
             'comments' => new Field\ObjectField('comments', [
-                'email' => new Field\TextField('email'),
+                'email' => new Field\TextField('email', searchable: false),
                 'text' => new Field\TextField('text'),
             ], multiple: true),
-            'tags' => new Field\TextField('tags', multiple: true),
-            'categoryIds' => new Field\IntegerField('categoryIds', multiple: true),
+            'tags' => new Field\TextField('tags', multiple: true, filterable: true),
+            'categoryIds' => new Field\IntegerField('categoryIds', multiple: true, filterable: true),
         ];
 
         $simpleFields = [


### PR DESCRIPTION
We need `searchable`, `filterable`, `sortable` to define our indexed data more specific. Indexes like meilisearch, algolia support this out of the box. For Elasticsearch for filterable and sortable we need create additional `.raw` field on text fields so we can filter / sort them. 