### PR TITLE
Change nesting of typed fields marshalling

### DIFF
--- a/packages/seal-elasticsearch-adapter/ElasticsearchSchemaManager.php
+++ b/packages/seal-elasticsearch-adapter/ElasticsearchSchemaManager.php
@@ -104,15 +104,18 @@ final class ElasticsearchSchemaManager implements SchemaManagerInterface
      */
     private function createTypedFieldMapping(string $name, Field\TypedField $field): array
     {
-        $properties = [];
+        $typedProperties = [];
 
         foreach ($field->types as $type => $fields) {
-            $properties[$name . '.' . $type] = [
-                'type' => 'nested',
-                'properties' => $this->createPropertiesMapping($fields),
+            $typedProperties[$type] = [
+                'type' => 'object',
+                'properties' => $this->createPropertiesMapping($fields)
             ];
         }
 
-        return $properties;
+        return [$name => [
+            'type' => 'object',
+            'properties' => $typedProperties,
+        ]];
     }
 }

--- a/packages/seal-elasticsearch-adapter/Tests/ElasticsearchSchemaManagerTest.php
+++ b/packages/seal-elasticsearch-adapter/Tests/ElasticsearchSchemaManagerTest.php
@@ -61,7 +61,6 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             'blocks' => [
                 'properties' => [
                     'embed' => [
-                        'type' => 'nested',
                         'properties' => [
                             'media' => [
                                 'type' => 'text',
@@ -72,7 +71,6 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
                         ],
                     ],
                     'text' => [
-                        'type' => 'nested',
                         'properties' => [
                             'description' => [
                                 'type' => 'text',
@@ -116,7 +114,6 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             'header' => [
                 'properties' => [
                     'image' => [
-                        'type' => 'nested',
                         'properties' => [
                             'media' => [
                                 'type' => 'integer',
@@ -124,7 +121,6 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
                         ],
                     ],
                     'video' => [
-                        'type' => 'nested',
                         'properties' => [
                             'media' => [
                                 'type' => 'text',

--- a/packages/seal-opensearch-adapter/OpensearchSchemaManager.php
+++ b/packages/seal-opensearch-adapter/OpensearchSchemaManager.php
@@ -102,15 +102,18 @@ final class OpensearchSchemaManager implements SchemaManagerInterface
      */
     private function createTypedFieldMapping(string $name, Field\TypedField $field): array
     {
-        $properties = [];
+        $typedProperties = [];
 
         foreach ($field->types as $type => $fields) {
-            $properties[$name . '.' . $type] = [
-                'type' => 'nested',
-                'properties' => $this->createPropertiesMapping($fields),
+            $typedProperties[$type] = [
+                'type' => 'object',
+                'properties' => $this->createPropertiesMapping($fields)
             ];
         }
 
-        return $properties;
+        return [$name => [
+            'type' => 'object',
+            'properties' => $typedProperties,
+        ]];
     }
 }

--- a/packages/seal-opensearch-adapter/Tests/OpensearchSchemaManagerTest.php
+++ b/packages/seal-opensearch-adapter/Tests/OpensearchSchemaManagerTest.php
@@ -61,7 +61,6 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             'blocks' => [
                 'properties' => [
                     'embed' => [
-                        'type' => 'nested',
                         'properties' => [
                             'media' => [
                                 'type' => 'text',
@@ -72,7 +71,6 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
                         ],
                     ],
                     'text' => [
-                        'type' => 'nested',
                         'properties' => [
                             'description' => [
                                 'type' => 'text',
@@ -116,7 +114,6 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             'header' => [
                 'properties' => [
                     'image' => [
-                        'type' => 'nested',
                         'properties' => [
                             'media' => [
                                 'type' => 'integer',
@@ -124,7 +121,6 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
                         ],
                     ],
                     'video' => [
-                        'type' => 'nested',
                         'properties' => [
                             'media' => [
                                 'type' => 'text',

--- a/packages/seal/Marshaller/Marshaller.php
+++ b/packages/seal/Marshaller/Marshaller.php
@@ -85,12 +85,12 @@ final class Marshaller
             ], $this->marshall($typedFields, $data));
 
             if ($field->multiple) {
-                $rawFields[$name . '.' . $type][] = $rawData;
+                $rawFields[$name][$type][] = $rawData;
 
                 continue;
             }
 
-            $rawFields[$name . '.' . $type] = $rawData;
+            $rawFields[$name][$type] = $rawData;
         }
 
         return $rawFields;
@@ -131,11 +131,11 @@ final class Marshaller
         $documentFields = [];
 
         foreach ($field->types as $type => $typedFields) {
-            if (!isset($raw[$name . '.' . $type])) {
+            if (!isset($raw[$name][$type])) {
                 continue;
             }
 
-            $dataList = $field->multiple ? $raw[$name . '.' . $type] : [$raw[$name . '.' . $type]];
+            $dataList = $field->multiple ? $raw[$name][$type] : [$raw[$name][$type]];
 
             foreach ($dataList as $data) {
                 $documentData = \array_replace([$field->typeField => $type], $this->unmarshall($typedFields, $data));


### PR DESCRIPTION
Nesting of typed fields will be changed from:

**Before Schema:**

```json
[
    "blocks.<type>": [
         "type": "nested",
         "properties": [
              ...
         ],
    ],
]
```

**After Schema:**

```json
[
    "blocks": {
        "type": "object",
        "properties": {
            "<type>": {
                "type": "object",
                "properties": [
                    ...
                ],
            },
        },
    },
]
```

**Before Marshalled Data:**

```php
[
    'blocks.<type>' => []
]
```

**After Marshalled Data:**

```php
[
    'blocks' => [
        '<type>' => []
    ]
]
```

Basically Elasticsearch did interpret already the structure with `block.<type>` the same way but the marshaller is changed to give give the rawDocument now back instead of `'blocks.type1' => []` returns now `'blocks' => ['type1' => []]`.

The change from `nested` to `object` is here to avoid hitting the nested limit of 50 fields. Yet we have not a usecase for `nested` maybe additional `options` in future will allow to make it nested.