### PR TITLE
Implement searchable false into adapters

### DIFF
--- a/packages/seal-algolia-adapter/AlgoliaSchemaManager.php
+++ b/packages/seal-algolia-adapter/AlgoliaSchemaManager.php
@@ -4,6 +4,7 @@ namespace Schranz\Search\SEAL\Adapter\Algolia;
 
 use Algolia\AlgoliaSearch\SearchClient;
 use Schranz\Search\SEAL\Adapter\SchemaManagerInterface;
+use Schranz\Search\SEAL\Schema\Field;
 use Schranz\Search\SEAL\Schema\Index;
 use Schranz\Search\SEAL\Task\AsyncTask;
 use Schranz\Search\SEAL\Task\TaskInterface;
@@ -41,12 +42,12 @@ final class AlgoliaSchemaManager implements SchemaManagerInterface
     {
         $searchIndex = $this->client->initIndex($index->name);
 
-        $indexResponse = $searchIndex->setSettings([
-            'searchableAttributes' => [],
-            'attributesForFaceting' => [
-                $index->getIdentifierField()->name,
-            ],
-        ]);
+        $attributes = $this->getAttributes($index->fields);
+        $attributes['attributesForFaceting'] = [
+            $index->getIdentifierField()->name
+        ];
+
+        $indexResponse = $searchIndex->setSettings($attributes);
 
         if (true !== ($options['return_slow_promise_result'] ?? false)) {
             return null;
@@ -55,5 +56,47 @@ final class AlgoliaSchemaManager implements SchemaManagerInterface
         return new AsyncTask(function() use ($indexResponse) {
             $indexResponse->wait();
         });
+    }
+
+    /**
+     * @param Field\AbstractField[] $fields
+     *
+     * @return array{
+     *     searchableAttributes: array<string>,
+     * }
+     */
+    private function getAttributes(array $fields): array
+    {
+        $attributes = [
+            'searchableAttributes' => [],
+        ];
+
+        foreach ($fields as $name => $field) {
+            if ($field instanceof Field\ObjectField) {
+                foreach ($this->getAttributes($field->fields) as $attributeType => $fieldNames) {
+                    foreach ($fieldNames as $fieldName) {
+                        $attributes[$attributeType][] = $name . '.' . $fieldName;
+                    }
+                }
+
+                continue;
+            } elseif ($field instanceof Field\TypedField) {
+                foreach ($field->types as $type => $fields) {
+                    foreach ($this->getAttributes($fields) as $attributeType => $fieldNames) {
+                        foreach ($fieldNames as $fieldName) {
+                            $attributes[$attributeType][] = $name . '.' . $type . '.' . $fieldName;
+                        }
+                    }
+                }
+
+                continue;
+            }
+
+            if ($field->searchable) {
+                $attributes['searchableAttributes'][] = $name;
+            }
+        }
+
+        return $attributes;
     }
 }

--- a/packages/seal-elasticsearch-adapter/ElasticsearchConnection.php
+++ b/packages/seal-elasticsearch-adapter/ElasticsearchConnection.php
@@ -40,10 +40,6 @@ final class ElasticsearchConnection implements ConnectionInterface
             'refresh' => $options['return_slow_promise_result'] ?? false, // update document immediately, so it is available in the `/_search` api directly
         ]);
 
-        if ($response->getStatusCode() !== 201) {
-            throw new \RuntimeException('Unexpected error while save document with identifier "' . $identifier . '".');
-        }
-
         if (true !== ($options['return_slow_promise_result'] ?? false)) {
             return null;
         }

--- a/packages/seal-elasticsearch-adapter/ElasticsearchSchemaManager.php
+++ b/packages/seal-elasticsearch-adapter/ElasticsearchSchemaManager.php
@@ -71,21 +71,27 @@ final class ElasticsearchSchemaManager implements SchemaManagerInterface
             match (true) {
                 $field instanceof Field\IdentifierField => $properties[$name] = [
                     'type' => 'keyword',
+                    'index' => $field->searchable,
                 ],
                 $field instanceof Field\TextField => $properties[$name] = [
                     'type' => 'text',
+                    'index' => $field->searchable,
                 ],
                 $field instanceof Field\BooleanField => $properties[$name] = [
                     'type' => 'boolean',
+                    'index' => $field->searchable,
                 ],
                 $field instanceof Field\DateTimeField => $properties[$name] = [
                     'type' => 'date',
+                    'index' => $field->searchable,
                 ],
                 $field instanceof Field\IntegerField => $properties[$name] = [
                     'type' => 'integer',
+                    'index' => $field->searchable,
                 ],
                 $field instanceof Field\FloatField => $properties[$name] = [
                     'type' => 'float',
+                    'index' => $field->searchable,
                 ],
                 $field instanceof Field\ObjectField => $properties[$name] = [
                     'type' => 'object',

--- a/packages/seal-elasticsearch-adapter/Tests/ElasticsearchSchemaManagerTest.php
+++ b/packages/seal-elasticsearch-adapter/Tests/ElasticsearchSchemaManagerTest.php
@@ -27,19 +27,20 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             'index' => $index->name,
         ])->asArray();
 
+        $task = static::$schemaManager->dropIndex($index, ['return_slow_promise_result' => true]);
+        $task->wait();
+
         $this->assertTrue(isset($mapping[$index->name]['mappings']['properties']));
 
         $this->assertSame([
             'id' => [
                 'type' => 'keyword',
+                'index' => false,
             ],
             'title' => [
                 'type' => 'text',
             ],
         ], $mapping[$index->name]['mappings']['properties']);
-
-        $task = static::$schemaManager->dropIndex($index, ['return_slow_promise_result' => true]);
-        $task->wait();
     }
 
     public function testComplexElasticsearchMapping(): void
@@ -51,6 +52,9 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
         $mapping = self::$client->indices()->getMapping([
             'index' => $index->name,
         ])->asArray();
+
+        $task = static::$schemaManager->dropIndex($index, ['return_slow_promise_result' => true]);
+        $task->wait();
 
         $this->assertTrue(isset($mapping[$index->name]['mappings']['properties']));
 
@@ -64,6 +68,7 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
                         'properties' => [
                             'media' => [
                                 'type' => 'text',
+                                'index' => false,
                             ],
                             'title' => [
                                 'type' => 'text',
@@ -77,6 +82,7 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
                             ],
                             'media' => [
                                 'type' => 'integer',
+                                'index' => false,
                             ],
                             'title' => [
                                 'type' => 'text',
@@ -87,11 +93,13 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             ],
             'categoryIds' => [
                 'type' => 'integer',
+                'index' => false,
             ],
             'comments' => [
                 'properties' => [
                     'email' => [
                         'type' => 'text',
+                        'index' => false,
                     ],
                     'text' => [
                         'type' => 'text',
@@ -100,6 +108,7 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             ],
             'commentsCount' => [
                 'type' => 'integer',
+                'index' => false,
             ],
             'created' => [
                 'type' => 'date',
@@ -117,6 +126,7 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
                         'properties' => [
                             'media' => [
                                 'type' => 'integer',
+                                'index' => false,
                             ],
                         ],
                     ],
@@ -124,6 +134,7 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
                         'properties' => [
                             'media' => [
                                 'type' => 'text',
+                                'index' => false,
                             ],
                         ],
                     ],
@@ -131,6 +142,7 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             ],
             'rating' => [
                 'type' => 'float',
+                'index' => false,
             ],
             'tags' => [
                 'type' => 'text',
@@ -140,10 +152,8 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             ],
             'uuid' => [
                 'type' => 'keyword',
+                'index' => false,
             ],
         ], $mapping[$index->name]['mappings']['properties']);
-
-        $task = static::$schemaManager->dropIndex($index, ['return_slow_promise_result' => true]);
-        $task->wait();
     }
 }

--- a/packages/seal-opensearch-adapter/OpensearchConnection.php
+++ b/packages/seal-opensearch-adapter/OpensearchConnection.php
@@ -40,10 +40,6 @@ final class OpensearchConnection implements ConnectionInterface
             'refresh' => $options['return_slow_promise_result'] ?? false, // update document immediately, so it is available in the `/_search` api directly
         ]);
 
-        if ($data['result'] !== 'created') {
-            throw new \RuntimeException('Unexpected error while save document with identifier "' . $identifier . '" into Index "' . $index->name . '".');
-        }
-
         if (true !== ($options['return_slow_promise_result'] ?? false)) {
             return null;
         }

--- a/packages/seal-opensearch-adapter/OpensearchSchemaManager.php
+++ b/packages/seal-opensearch-adapter/OpensearchSchemaManager.php
@@ -69,21 +69,27 @@ final class OpensearchSchemaManager implements SchemaManagerInterface
             match (true) {
                 $field instanceof Field\IdentifierField => $properties[$name] = [
                     'type' => 'keyword',
+                    'index' => $field->searchable,
                 ],
                 $field instanceof Field\TextField => $properties[$name] = [
                     'type' => 'text',
+                    'index' => $field->searchable,
                 ],
                 $field instanceof Field\BooleanField => $properties[$name] = [
                     'type' => 'boolean',
+                    'index' => $field->searchable,
                 ],
                 $field instanceof Field\DateTimeField => $properties[$name] = [
                     'type' => 'date',
+                    'index' => $field->searchable,
                 ],
                 $field instanceof Field\IntegerField => $properties[$name] = [
                     'type' => 'integer',
+                    'index' => $field->searchable,
                 ],
                 $field instanceof Field\FloatField => $properties[$name] = [
                     'type' => 'float',
+                    'index' => $field->searchable,
                 ],
                 $field instanceof Field\ObjectField => $properties[$name] = [
                     'type' => 'object',

--- a/packages/seal-opensearch-adapter/Tests/OpensearchSchemaManagerTest.php
+++ b/packages/seal-opensearch-adapter/Tests/OpensearchSchemaManagerTest.php
@@ -27,19 +27,20 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             'index' => $index->name,
         ]);
 
+        $task = static::$schemaManager->dropIndex($index, ['return_slow_promise_result' => true]);
+        $task->wait();
+
         $this->assertTrue(isset($mapping[$index->name]['mappings']['properties']));
 
         $this->assertSame([
             'id' => [
                 'type' => 'keyword',
+                'index' => false,
             ],
             'title' => [
                 'type' => 'text',
             ],
         ], $mapping[$index->name]['mappings']['properties']);
-
-        $task = static::$schemaManager->dropIndex($index, ['return_slow_promise_result' => true]);
-        $task->wait();
     }
 
     public function testComplexOpensearchMapping(): void
@@ -51,6 +52,9 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
         $mapping = self::$client->indices()->getMapping([
             'index' => $index->name,
         ]);
+
+        $task = static::$schemaManager->dropIndex($index, ['return_slow_promise_result' => true]);
+        $task->wait();
 
         $this->assertTrue(isset($mapping[$index->name]['mappings']['properties']));
 
@@ -64,6 +68,7 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
                         'properties' => [
                             'media' => [
                                 'type' => 'text',
+                                'index' => false,
                             ],
                             'title' => [
                                 'type' => 'text',
@@ -77,6 +82,7 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
                             ],
                             'media' => [
                                 'type' => 'integer',
+                                'index' => false,
                             ],
                             'title' => [
                                 'type' => 'text',
@@ -87,11 +93,13 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             ],
             'categoryIds' => [
                 'type' => 'integer',
+                'index' => false,
             ],
             'comments' => [
                 'properties' => [
                     'email' => [
                         'type' => 'text',
+                        'index' => false,
                     ],
                     'text' => [
                         'type' => 'text',
@@ -100,6 +108,7 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             ],
             'commentsCount' => [
                 'type' => 'integer',
+                'index' => false,
             ],
             'created' => [
                 'type' => 'date',
@@ -117,6 +126,7 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
                         'properties' => [
                             'media' => [
                                 'type' => 'integer',
+                                'index' => false,
                             ],
                         ],
                     ],
@@ -124,6 +134,7 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
                         'properties' => [
                             'media' => [
                                 'type' => 'text',
+                                'index' => false,
                             ],
                         ],
                     ],
@@ -131,6 +142,7 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             ],
             'rating' => [
                 'type' => 'float',
+                'index' => false,
             ],
             'tags' => [
                 'type' => 'text',
@@ -140,10 +152,8 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             ],
             'uuid' => [
                 'type' => 'keyword',
+                'index' => false,
             ],
         ], $mapping[$index->name]['mappings']['properties']);
-
-        $task = static::$schemaManager->dropIndex($index, ['return_slow_promise_result' => true]);
-        $task->wait();
     }
 }

--- a/packages/seal/README.md
+++ b/packages/seal/README.md
@@ -226,7 +226,7 @@ $fields = [
         'text' => new Field\TextField('text'),
     ], multiple: true),
     'tags' => new Field\TextField('tags', multiple: true, filterable: true),
-    'categoryIds' => new Field\IntegerField('categoryIds', multiple: true, filterable: true),
+    'categoryIds' => new Field\IntegerField('categoryIds', multiple: true, searchable: false, filterable: true),
 ];
 ```
 

--- a/packages/seal/Testing/AbstractConnectionTestCase.php
+++ b/packages/seal/Testing/AbstractConnectionTestCase.php
@@ -199,6 +199,28 @@ abstract class AbstractConnectionTestCase extends TestCase
         }
     }
 
+    public function testNoneSearchableFields(): void
+    {
+        $documents = TestingHelper::createComplexFixtures();
+
+        $schema = self::getSchema();
+
+        foreach ($documents as $document) {
+            self::$taskHelper->tasks[] = self::$connection->save(
+                $schema->indexes[TestingHelper::INDEX_COMPLEX],
+                $document,
+                ['return_slow_promise_result' => true],
+            );
+        }
+        self::$taskHelper->waitForAll();
+
+        $search = new SearchBuilder($schema, self::$connection);
+        $search->addIndex(TestingHelper::INDEX_COMPLEX);
+        $search->addFilter(new SearchCondition('admin.nonesearchablefield@localhost'));
+
+        $this->assertCount(0, [...$search->getResult()]);
+    }
+
     public function testLimitAndOffset(): void
     {
         $documents = TestingHelper::createComplexFixtures();

--- a/packages/seal/Testing/TestingHelper.php
+++ b/packages/seal/Testing/TestingHelper.php
@@ -53,7 +53,7 @@ class TestingHelper
                 'text' => new Field\TextField('text'),
             ], multiple: true),
             'tags' => new Field\TextField('tags', multiple: true, filterable: true),
-            'categoryIds' => new Field\IntegerField('categoryIds', multiple: true, filterable: true),
+            'categoryIds' => new Field\IntegerField('categoryIds', multiple: true, searchable: false, filterable: true),
         ];
 
         $simpleFields = [
@@ -129,11 +129,11 @@ class TestingHelper
                 'rating' => 3.5,
                 'comments' => [
                     [
-                        'email' => 'admin@localhost',
+                        'email' => 'admin.nonesearchablefield@localhost',
                         'text' => 'Awesome blog!',
                     ],
                     [
-                        'email' => 'example@localhost',
+                        'email' => 'example.nonesearchablefield@localhost',
                         'text' => 'Like this blog!',
                     ],
                 ],

--- a/packages/seal/Tests/Marshaller/MarshallerTest.php
+++ b/packages/seal/Tests/Marshaller/MarshallerTest.php
@@ -79,11 +79,11 @@ class MarshallerTest extends TestCase
             'rating' => 3.5,
             'comments' => [
                 [
-                    'email' => 'admin@localhost',
+                    'email' => 'admin.nonesearchablefield@localhost',
                     'text' => 'Awesome blog!',
                 ],
                 [
-                    'email' => 'example@localhost',
+                    'email' => 'example.nonesearchablefield@localhost',
                     'text' => 'Like this blog!',
                 ],
             ],


### PR DESCRIPTION
This will implement `searchable: false` into the adapters. This fields should not be searchable and be ignored by the specific search engines when searching fo a document.