### PR TITLE
Add EqualCondition and NotEuqualCondition for first filterable fields

### DIFF
--- a/packages/seal-algolia-adapter/AlgoliaConnection.php
+++ b/packages/seal-algolia-adapter/AlgoliaConnection.php
@@ -103,6 +103,8 @@ final class AlgoliaConnection implements ConnectionInterface
             match (true) {
                 $filter instanceof Condition\IdentifierCondition => $filters[] = $index->getIdentifierField()->name . ':' . $filter->identifier,
                 $filter instanceof Condition\SearchCondition => $query = $filter->query,
+                $filter instanceof Condition\EqualCondition => $filters[] = $filter->field . ':' . $filter->value,
+                $filter instanceof Condition\NotEqualCondition => $filters[] = 'NOT ' . $filter->field . ':' . $filter->value,
                 default =>  throw new \LogicException($filter::class . ' filter not implemented.'),
             };
         }

--- a/packages/seal-algolia-adapter/AlgoliaSchemaManager.php
+++ b/packages/seal-algolia-adapter/AlgoliaSchemaManager.php
@@ -43,9 +43,6 @@ final class AlgoliaSchemaManager implements SchemaManagerInterface
         $searchIndex = $this->client->initIndex($index->name);
 
         $attributes = $this->getAttributes($index->fields);
-        $attributes['attributesForFaceting'] = [
-            $index->getIdentifierField()->name
-        ];
 
         $indexResponse = $searchIndex->setSettings($attributes);
 
@@ -63,12 +60,14 @@ final class AlgoliaSchemaManager implements SchemaManagerInterface
      *
      * @return array{
      *     searchableAttributes: array<string>,
+     *     attributesForFaceting: array<string>,
      * }
      */
     private function getAttributes(array $fields): array
     {
         $attributes = [
             'searchableAttributes' => [],
+            'attributesForFaceting' => [],
         ];
 
         foreach ($fields as $name => $field) {
@@ -94,6 +93,10 @@ final class AlgoliaSchemaManager implements SchemaManagerInterface
 
             if ($field->searchable) {
                 $attributes['searchableAttributes'][] = $name;
+            }
+
+            if ($field->filterable) {
+                $attributes['attributesForFaceting'][] = $name;
             }
         }
 

--- a/packages/seal-elasticsearch-adapter/ElasticsearchConnection.php
+++ b/packages/seal-elasticsearch-adapter/ElasticsearchConnection.php
@@ -6,6 +6,8 @@ use Elastic\Elasticsearch\Client;
 use Elastic\Elasticsearch\Exception\ClientResponseException;
 use Schranz\Search\SEAL\Adapter\ConnectionInterface;
 use Schranz\Search\SEAL\Marshaller\Marshaller;
+use Schranz\Search\SEAL\Schema\Exception\FieldByPathNotFoundException;
+use Schranz\Search\SEAL\Schema\Field;
 use Schranz\Search\SEAL\Schema\Index;
 use Schranz\Search\SEAL\Search\Condition;
 use Schranz\Search\SEAL\Search\Result;
@@ -118,6 +120,8 @@ final class ElasticsearchConnection implements ConnectionInterface
             match (true) {
                 $filter instanceof Condition\IdentifierCondition => $query['ids']['values'][] = $filter->identifier,
                 $filter instanceof Condition\SearchCondition => $query['query_string']['query'] = $filter->query,
+                $filter instanceof Condition\EqualCondition => $query['term'][$this->getFilterField($search->indexes, $filter->field)]['value'] = $filter->value,
+                $filter instanceof Condition\NotEqualCondition => $query['bool']['must_not']['term'][$this->getFilterField($search->indexes, $filter->field)]['value'] = $filter->value,
                 default => throw new \LogicException($filter::class . ' filter not implemented.'),
             };
         }
@@ -170,5 +174,24 @@ final class ElasticsearchConnection implements ConnectionInterface
 
             yield $this->marshaller->unmarshall($index->fields, $hit['_source']);
         }
+    }
+
+    private function getFilterField(array $indexes, string $name): string
+    {
+        foreach ($indexes as $index) {
+            try {
+                $field = $index->getFieldByPath($name);
+
+                if ($field instanceof Field\TextField) {
+                    return $name . '.raw';
+                }
+
+                return $name;
+            } catch (FieldByPathNotFoundException $e) {
+                // ignore when field is not found and use go to next index instead
+            }
+        }
+
+        return $name;
     }
 }

--- a/packages/seal-elasticsearch-adapter/ElasticsearchSchemaManager.php
+++ b/packages/seal-elasticsearch-adapter/ElasticsearchSchemaManager.php
@@ -73,10 +73,14 @@ final class ElasticsearchSchemaManager implements SchemaManagerInterface
                     'type' => 'keyword',
                     'index' => $field->searchable,
                 ],
-                $field instanceof Field\TextField => $properties[$name] = [
+                $field instanceof Field\TextField => $properties[$name] = \array_replace([
                     'type' => 'text',
                     'index' => $field->searchable,
-                ],
+                ], ($field->filterable || $field->sortable) ? [
+                    'fields' => [
+                        'raw' => ['type' => 'keyword'],
+                    ],
+                ] : []),
                 $field instanceof Field\BooleanField => $properties[$name] = [
                     'type' => 'boolean',
                     'index' => $field->searchable,

--- a/packages/seal-elasticsearch-adapter/Tests/ElasticsearchSchemaManagerTest.php
+++ b/packages/seal-elasticsearch-adapter/Tests/ElasticsearchSchemaManagerTest.php
@@ -146,6 +146,11 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             ],
             'tags' => [
                 'type' => 'text',
+                'fields' => [
+                    'raw' => [
+                        'type' => 'keyword',
+                    ],
+                ],
             ],
             'title' => [
                 'type' => 'text',

--- a/packages/seal-meilisearch-adapter/MeilisearchConnection.php
+++ b/packages/seal-meilisearch-adapter/MeilisearchConnection.php
@@ -106,6 +106,8 @@ final class MeilisearchConnection implements ConnectionInterface
             match (true) {
                 $filter instanceof Condition\IdentifierCondition => $filters[] = $index->getIdentifierField()->name . ' = "' . $filter->identifier . '"', // TODO escape?
                 $filter instanceof Condition\SearchCondition => $query = $filter->query,
+                $filter instanceof Condition\EqualCondition => $filters[] = $filter->field . ' = "' . $filter->value . '"', // TODO escape?
+                $filter instanceof Condition\NotEqualCondition => $filters[] = $filter->field . ' != "' . $filter->value . '"', // TODO escape?
                 default => throw new \LogicException($filter::class . ' filter not implemented.'),
             };
         }

--- a/packages/seal-meilisearch-adapter/MeilisearchSchemaManager.php
+++ b/packages/seal-meilisearch-adapter/MeilisearchSchemaManager.php
@@ -56,9 +56,6 @@ final class MeilisearchSchemaManager implements SchemaManagerInterface
         );
 
         $attributes = $this->getAttributes($index->fields);
-        $attributes['filterableAttributes'] = [
-            $index->getIdentifierField()->name
-        ];
 
         $updateIndexResponse = $this->client->index($index->name)
             ->updateSettings($attributes);
@@ -77,12 +74,14 @@ final class MeilisearchSchemaManager implements SchemaManagerInterface
      *
      * @return array{
      *     searchableAttributes: array<string>,
+     *     filterableAttributes: array<string>,
      * }
      */
     private function getAttributes(array $fields): array
     {
         $attributes = [
             'searchableAttributes' => [],
+            'filterableAttributes' => [],
         ];
 
         foreach ($fields as $name => $field) {
@@ -108,6 +107,10 @@ final class MeilisearchSchemaManager implements SchemaManagerInterface
 
             if ($field->searchable) {
                 $attributes['searchableAttributes'][] = $name;
+            }
+
+            if ($field->filterable) {
+                $attributes['filterableAttributes'][] = $name;
             }
         }
 

--- a/packages/seal-opensearch-adapter/OpensearchSchemaManager.php
+++ b/packages/seal-opensearch-adapter/OpensearchSchemaManager.php
@@ -71,10 +71,14 @@ final class OpensearchSchemaManager implements SchemaManagerInterface
                     'type' => 'keyword',
                     'index' => $field->searchable,
                 ],
-                $field instanceof Field\TextField => $properties[$name] = [
+                $field instanceof Field\TextField => $properties[$name] = \array_replace([
                     'type' => 'text',
                     'index' => $field->searchable,
-                ],
+                ], ($field->filterable || $field->sortable) ? [
+                    'fields' => [
+                        'raw' => ['type' => 'keyword'],
+                    ],
+                ] : []),
                 $field instanceof Field\BooleanField => $properties[$name] = [
                     'type' => 'boolean',
                     'index' => $field->searchable,

--- a/packages/seal-opensearch-adapter/Tests/OpensearchSchemaManagerTest.php
+++ b/packages/seal-opensearch-adapter/Tests/OpensearchSchemaManagerTest.php
@@ -146,6 +146,11 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             ],
             'tags' => [
                 'type' => 'text',
+                'fields' => [
+                    'raw' => [
+                        'type' => 'keyword',
+                    ],
+                ],
             ],
             'title' => [
                 'type' => 'text',

--- a/packages/seal/README.md
+++ b/packages/seal/README.md
@@ -322,13 +322,14 @@ use Schranz\Search\SEAL\Search\Condition;
 $documents = $engine->createSearchBuilder()
     ->addIndex('news')
     ->addFilter(new Condition\SearchCondition('New Blog'))
-    ->limit(1)
+    ->limit(10)
     ->offset(0)
     ->getResult();
 ```
 
 > To search in multiple indexes you can use the `addIndex` method multiple times.  
-> Not all adapters support multiple indexes (e.g. [Meilisearch](https://github.com/schranz-search/schranz-search/issues/28)).
+> Not all adapters support multiple indexes (e.g. [Meilisearch](https://github.com/schranz-search/schranz-search/issues/28)).  
+> Use `limit` and `offset` to paginate the results.
 
 ###### IdentifierCondition
 
@@ -350,3 +351,37 @@ If no additional filters are required also the [`getDocument`](#find-a-document)
 ```php
 $document = $engine->getDocument('news', '1');
 ```
+
+###### EqualCondition
+
+The `EqualCondition` can be used to load documents matching a specific value:
+
+```php
+use Schranz\Search\SEAL\Search\Condition;
+
+$documents = $engine->createSearchBuilder()
+    ->addIndex('news')
+    ->addFilter(new Condition\EqualCondition('tags', 'UI'))
+    ->getResult();
+```
+
+The first parameter is the `field` and the second the `value` which need to match.  
+For filtering by object fields use `<object_name>.<field_name>` as field e.g.: `'new Condition\EqualCondition('header.media', 1)`.  
+For filtering by typed fields use `<typed_name>.<type_name>.<field_name>` as field e.g.: `new Condition\EqualCondition('blocks.text.media', 1)`.
+
+###### NotEqualCondition
+
+The `NotEqualCondition` can be used to load documents matching not a specific value:
+
+```php
+use Schranz\Search\SEAL\Search\Condition;
+
+$documents = $engine->createSearchBuilder()
+    ->addIndex('news')
+    ->addFilter(new Condition\NotEqualCondition('tags', 'UI'))
+    ->getResult();
+```
+
+The first parameter is the `field` and the second the `value` which need not match.  
+For filtering by object fields use `<object_name>.<field_name>` as field e.g.: `'new NotEqualCondition('header.media', 1)`.  
+For filtering by typed fields use `<typed_name>.<type_name>.<field_name>` as field e.g.: `new NotEqualCondition('blocks.text.media', 1)`.  

--- a/packages/seal/Schema/Exception/FieldByPathNotFoundException.php
+++ b/packages/seal/Schema/Exception/FieldByPathNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Schranz\Search\SEAL\Schema\Exception;
+
+final class FieldByPathNotFoundException extends \Exception
+{
+    public function __construct(string $indexName, string $path, ?\Throwable $previous = null)
+    {
+        parent::__construct(
+            'Field path "' . $path . '" not found in index "' . $indexName . '"',
+            0,
+            $previous
+        );
+    }
+}

--- a/packages/seal/Search/Condition/EqualCondition.php
+++ b/packages/seal/Search/Condition/EqualCondition.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Schranz\Search\SEAL\Search\Condition;
+
+class EqualCondition
+{
+    public function __construct(
+        public readonly string $field,
+        public readonly string|int|float|bool $value,
+    ) {
+    }
+}

--- a/packages/seal/Search/Condition/NotEqualCondition.php
+++ b/packages/seal/Search/Condition/NotEqualCondition.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Schranz\Search\SEAL\Search\Condition;
+
+class NotEqualCondition
+{
+    public function __construct(
+        public readonly string $field,
+        public readonly string|int|float|bool $value,
+    ) {
+    }
+}


### PR DESCRIPTION
Beside the `SearchCondition`, adapters which supports can supporting filters. Fields which are filterable need to be defined as `filterable` in the Schema. In the first implementation we will implement a `EqualCondition` and `NotEqualCondition` which can look like this:

**EqualCondition**:

```php
$search = (new SearchBuilder($schema, self::$connection));
        addIndex('news');
        addFilter(new Condition\EqualCondition('tags', 'UI'));

$documents = $search->getResult();
```

**NotEqualCondition**:

```php
$search = (new SearchBuilder($schema, self::$connection));
        addIndex('news');
        addFilter(new Condition\NotEqualCondition('tags', 'UI'));

$documents = $search->getResult();
```