### PR TITLE
Fix MultiEqualCondition for Elasticsearch and Opensearch Adapter

### DIFF
--- a/packages/seal-elasticsearch-adapter/ElasticsearchConnection.php
+++ b/packages/seal-elasticsearch-adapter/ElasticsearchConnection.php
@@ -120,8 +120,8 @@ final class ElasticsearchConnection implements ConnectionInterface
             match (true) {
                 $filter instanceof Condition\IdentifierCondition => $query['ids']['values'][] = $filter->identifier,
                 $filter instanceof Condition\SearchCondition => $query['query_string']['query'] = $filter->query,
-                $filter instanceof Condition\EqualCondition => $query['term'][$this->getFilterField($search->indexes, $filter->field)]['value'] = $filter->value,
-                $filter instanceof Condition\NotEqualCondition => $query['bool']['must_not']['term'][$this->getFilterField($search->indexes, $filter->field)]['value'] = $filter->value,
+                $filter instanceof Condition\EqualCondition => $query['bool']['must'][]['term'][$this->getFilterField($search->indexes, $filter->field)]['value'] = $filter->value,
+                $filter instanceof Condition\NotEqualCondition => $query['bool']['must_not'][]['term'][$this->getFilterField($search->indexes, $filter->field)]['value'] = $filter->value,
                 default => throw new \LogicException($filter::class . ' filter not implemented.'),
             };
         }

--- a/packages/seal-opensearch-adapter/OpensearchConnection.php
+++ b/packages/seal-opensearch-adapter/OpensearchConnection.php
@@ -109,8 +109,8 @@ final class OpensearchConnection implements ConnectionInterface
             match (true) {
                 $filter instanceof Condition\IdentifierCondition => $query['ids']['values'][] = $filter->identifier,
                 $filter instanceof Condition\SearchCondition => $query['query_string']['query'] = $filter->query,
-                $filter instanceof Condition\EqualCondition => $query['term'][$this->getFilterField($search->indexes, $filter->field)]['value'] = $filter->value,
-                $filter instanceof Condition\NotEqualCondition => $query['bool']['must_not']['term'][$this->getFilterField($search->indexes, $filter->field)]['value'] = $filter->value,
+                $filter instanceof Condition\EqualCondition => $query['bool']['must'][]['term'][$this->getFilterField($search->indexes, $filter->field)]['value'] = $filter->value,
+                $filter instanceof Condition\NotEqualCondition => $query['bool']['must_not'][]['term'][$this->getFilterField($search->indexes, $filter->field)]['value'] = $filter->value,
                 default => throw new \LogicException($filter::class . ' filter not implemented.'),
             };
         }

--- a/packages/seal/Testing/TestingHelper.php
+++ b/packages/seal/Testing/TestingHelper.php
@@ -169,7 +169,7 @@ class TestingHelper
                 'commentsCount' => 0,
                 'rating' => null,
                 'comments' => [],
-                'tags' => ['Tech'],
+                'tags' => ['Tech', 'UX'],
                 'categoryIds' => [3, 4],
             ],
             [


### PR DESCRIPTION
Was surprised #62 worked without changes but it seems #62 was leaking important fixtures for this case that both tags should be there multiple times. This is fixed in this pull request.