### PR TITLE
Add index for all filterable, sortable and searchable fields

### DIFF
--- a/packages/seal-elasticsearch-adapter/ElasticsearchSchemaManager.php
+++ b/packages/seal-elasticsearch-adapter/ElasticsearchSchemaManager.php
@@ -68,36 +68,45 @@ final class ElasticsearchSchemaManager implements SchemaManagerInterface
         $properties = [];
 
         foreach ($fields as $name => $field) {
+            // TODO recheck doc_values https://github.com/schranz-search/schranz-search/issues/65
+            $index = $field->searchable || $field->filterable || $field->sortable;
+
             match (true) {
                 $field instanceof Field\IdentifierField => $properties[$name] = [
                     'type' => 'keyword',
-                    'index' => $field->searchable,
+                    'index' => $index,
+                    'doc_values' => $field->filterable,
                 ],
                 $field instanceof Field\TextField => $properties[$name] = \array_replace([
                     'type' => 'text',
-                    'index' => $field->searchable,
+                    'index' => $index,
                 ], ($field->filterable || $field->sortable) ? [
                     'fields' => [
-                        'raw' => ['type' => 'keyword'],
+                        'raw' => [
+                            'type' => 'keyword',
+                            'index' => $field->searchable || $field->filterable,
+                            'doc_values' => $field->filterable,
+                        ],
                     ],
                 ] : []),
                 $field instanceof Field\BooleanField => $properties[$name] = [
                     'type' => 'boolean',
-                    'index' => $field->searchable,
+                    'index' => $index,
+                    'doc_values' => $field->filterable,
                 ],
                 $field instanceof Field\DateTimeField => $properties[$name] = [
                     'type' => 'date',
-                    'index' => $field->searchable,
+                    'index' => $index,
                     'doc_values' => $field->filterable,
                 ],
                 $field instanceof Field\IntegerField => $properties[$name] = [
                     'type' => 'integer',
-                    'index' => $field->searchable,
+                    'index' => $index,
                     'doc_values' => $field->filterable,
                 ],
                 $field instanceof Field\FloatField => $properties[$name] = [
                     'type' => 'float',
-                    'index' => $field->searchable,
+                    'index' => $index,
                     'doc_values' => $field->filterable,
                 ],
                 $field instanceof Field\ObjectField => $properties[$name] = [

--- a/packages/seal-elasticsearch-adapter/README.md
+++ b/packages/seal-elasticsearch-adapter/README.md
@@ -49,3 +49,228 @@ $engine = new Engine(
     $schema,
 );
 ```
+
+## Schema Mapping
+
+This shows how the [Seal Schema](../seal/README.md#schema) is mapped to Elasticsearch.
+
+There is no diff between sortable and filterable fields so that cases are not specific listed.
+
+| searchable | filterable / sortable | description                                                                 |
+|------------|-----------------------|-----------------------------------------------------------------------------|
+| yes        | no                    | Searchable but can not be used for filter or sorting                        |
+| no         | yes                   | Is not keep in mind for search score but can be used for filter and sorting |
+| yes        | yes                   | Is keep in mind for search score and can be used for filter and sorting     |
+| no         | no                    | Just stored no index, analyzing required                                    |
+
+### IdentifierField
+
+Field:
+
+```php
+new IdentifierField('id');
+```
+
+Mapping:
+
+```json
+{
+    "id": {
+        "type": "keyword",
+        "index": true,
+        "doc_values": true
+    }
+}
+```
+
+Also the identifier is used as elasticsearch internal `_id` field.
+
+### TextField
+
+Field:
+
+```php
+new TextField('text_a', searchable: true, filterable: false, sortable: false), // default
+new TextField('text_b', searchable: false, filterable: true, sortable: true),
+```
+
+Mapping:
+
+```json
+{
+    "text_a": {
+        "type": "text",
+        "index": true,
+        "doc_values": false
+    },
+    "text_b": {
+        "type": "text",
+        "index": true,
+        "doc_values": true,
+        "field": {
+            "raw": {
+                "type": "keyword",
+                "index": true,
+                "doc_values": true
+            }
+        }
+    }
+}
+```
+
+### BooleanField
+
+Field:
+
+```php
+new BooleanField('bool_a', searchable: true, filterable: false, sortable: false), // default
+new BooleanField('bool_b', searchable: false, filterable: true, sortable: true),
+```
+
+Mapping:
+
+```json
+{
+    "bool_a": {
+        "type": "boolean",
+        "index": true,
+        "doc_values": false
+    },
+    "bool_b": {
+        "type": "boolean",
+        "index": true,
+        "doc_values": true
+    }
+}
+```
+
+### DateTimeField
+
+Field:
+
+```php
+new DateTimeField('date_a', searchable: true, filterable: false, sortable: false), // default
+new DateTimeField('date_b', searchable: false, filterable: true, sortable: true),
+```
+
+Mapping:
+
+```json
+{
+    "date_a": {
+        "type": "date",
+        "index": true,
+        "doc_values": false
+    },
+    "date_b": {
+        "type": "date",
+        "index": true,
+        "doc_values": true
+    }
+}
+```
+
+### IntegerField
+
+Field:
+
+```php
+new IntegerField('int_a', searchable: true, filterable: false, sortable: false), // default
+new IntegerField('int_b', searchable: false, filterable: true, sortable: true),
+```
+
+Mapping:
+
+```json
+{
+    "int_a": {
+        "type": "integer",
+        "index": true,
+        "doc_values": false
+    },
+    "int_b": {
+        "type": "integer",
+        "index": true,
+        "doc_values": true
+    }
+}
+```
+
+### FloatField
+
+Field:
+
+```php
+new FloatField('float_a', searchable: true, filterable: false, sortable: false), // default
+new FloatField('float_b', searchable: false, filterable: true, sortable: true),
+```
+
+Mapping:
+
+```json
+{
+    "float_a": {
+        "type": "float",
+        "index": true,
+        "doc_values": false
+    },
+    "float_b": {
+        "type": "float",
+        "index": true,
+        "doc_values": true
+    }
+}
+```
+
+### ObjectField
+
+Field:
+
+```php
+new ObjectField('object', /* ... */);
+```
+
+Mapping:
+
+```json
+{
+    "object": {
+        "type": "object",
+        "properties": {
+            /* ... */
+        }
+    }
+}
+```
+
+### TypedField
+
+Field:
+
+```php
+new TypedField('typed', 'type', ['type_a' =>  /* ... */, 'type_b' =>  /* ... */]);
+```
+
+Mapping:
+
+```json
+{
+    "typed": {
+        "type": "object",
+        "properties": {
+            "type_a": {
+                "type": "object",
+                "properties": {
+                    /* ... */
+                }
+            },
+            "type_b": {
+                "type": "object",
+                "properties": {
+                    /* ... */
+                }
+            }
+        }
+    }
+}
+```

--- a/packages/seal-elasticsearch-adapter/Tests/ElasticsearchSchemaManagerTest.php
+++ b/packages/seal-elasticsearch-adapter/Tests/ElasticsearchSchemaManagerTest.php
@@ -147,6 +147,9 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
                     ],
                 ],
             ],
+            'published' => [
+                'type' => 'date',
+            ],
             'rating' => [
                 'type' => 'float',
             ],

--- a/packages/seal-elasticsearch-adapter/Tests/ElasticsearchSchemaManagerTest.php
+++ b/packages/seal-elasticsearch-adapter/Tests/ElasticsearchSchemaManagerTest.php
@@ -35,7 +35,6 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
         $this->assertSame([
             'id' => [
                 'type' => 'keyword',
-                'index' => false,
             ],
             'title' => [
                 'type' => 'text',
@@ -94,7 +93,6 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             ],
             'categoryIds' => [
                 'type' => 'integer',
-                'index' => false,
             ],
             'comments' => [
                 'properties' => [
@@ -109,7 +107,6 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             ],
             'commentsCount' => [
                 'type' => 'integer',
-                'index' => false,
             ],
             'created' => [
                 'type' => 'date',
@@ -142,9 +139,16 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
                     ],
                 ],
             ],
+            'internalTags' => [
+                'type' => 'text',
+                'fields' => [
+                    'raw' => [
+                        'type' => 'keyword',
+                    ],
+                ],
+            ],
             'rating' => [
                 'type' => 'float',
-                'index' => false,
             ],
             'tags' => [
                 'type' => 'text',
@@ -159,7 +163,6 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             ],
             'uuid' => [
                 'type' => 'keyword',
-                'index' => false,
             ],
         ], $mapping[$index->name]['mappings']['properties']);
     }

--- a/packages/seal-opensearch-adapter/OpensearchSchemaManager.php
+++ b/packages/seal-opensearch-adapter/OpensearchSchemaManager.php
@@ -66,42 +66,45 @@ final class OpensearchSchemaManager implements SchemaManagerInterface
         $properties = [];
 
         foreach ($fields as $name => $field) {
+            // TODO recheck doc_values https://github.com/schranz-search/schranz-search/issues/65
+            $index = $field->searchable || $field->filterable || $field->sortable;
+
             match (true) {
                 $field instanceof Field\IdentifierField => $properties[$name] = [
                     'type' => 'keyword',
-                    'index' => $field->searchable || $field->filterable, // TODO recheck doc_values https://github.com/schranz-search/schranz-search/issues/65
+                    'index' => $index,
                     'doc_values' => $field->filterable,
                 ],
                 $field instanceof Field\TextField => $properties[$name] = \array_replace([
                     'type' => 'text',
-                    'index' => $field->searchable || $field->filterable, // TODO recheck doc_values https://github.com/schranz-search/schranz-search/issues/65
+                    'index' => $index,
                 ], ($field->filterable || $field->sortable) ? [
                     'fields' => [
                         'raw' => [
                             'type' => 'keyword',
-                            'index' => $field->searchable || $field->filterable, // TODO recheck doc_values https://github.com/schranz-search/schranz-search/issues/65
+                            'index' => $field->searchable || $field->filterable,
                             'doc_values' => $field->filterable,
                         ],
                     ],
                 ] : []),
                 $field instanceof Field\BooleanField => $properties[$name] = [
                     'type' => 'boolean',
-                    'index' => $field->searchable || $field->filterable, // TODO recheck doc_values https://github.com/schranz-search/schranz-search/issues/65
+                    'index' => $index,
                     'doc_values' => $field->filterable,
                 ],
                 $field instanceof Field\DateTimeField => $properties[$name] = [
                     'type' => 'date',
-                    'index' => $field->searchable || $field->filterable, // TODO recheck doc_values https://github.com/schranz-search/schranz-search/issues/65
+                    'index' => $index,
                     'doc_values' => $field->filterable,
                 ],
                 $field instanceof Field\IntegerField => $properties[$name] = [
                     'type' => 'integer',
-                    'index' => $field->searchable || $field->filterable, // TODO recheck doc_values https://github.com/schranz-search/schranz-search/issues/65
+                    'index' => $index,
                     'doc_values' => $field->filterable,
                 ],
                 $field instanceof Field\FloatField => $properties[$name] = [
                     'type' => 'float',
-                    'index' => $field->searchable || $field->filterable, // TODO recheck doc_values https://github.com/schranz-search/schranz-search/issues/65
+                    'index' => $index,
                     'doc_values' => $field->filterable,
                 ],
                 $field instanceof Field\ObjectField => $properties[$name] = [

--- a/packages/seal-opensearch-adapter/OpensearchSchemaManager.php
+++ b/packages/seal-opensearch-adapter/OpensearchSchemaManager.php
@@ -68,12 +68,13 @@ final class OpensearchSchemaManager implements SchemaManagerInterface
         foreach ($fields as $name => $field) {
             // TODO recheck doc_values https://github.com/schranz-search/schranz-search/issues/65
             $index = $field->searchable || $field->filterable || $field->sortable;
+            $doc_values = $field->filterable || $field->sortable;
 
             match (true) {
                 $field instanceof Field\IdentifierField => $properties[$name] = [
                     'type' => 'keyword',
                     'index' => $index,
-                    'doc_values' => $field->filterable,
+                    'doc_values' => $doc_values,
                 ],
                 $field instanceof Field\TextField => $properties[$name] = \array_replace([
                     'type' => 'text',
@@ -82,30 +83,30 @@ final class OpensearchSchemaManager implements SchemaManagerInterface
                     'fields' => [
                         'raw' => [
                             'type' => 'keyword',
-                            'index' => $field->searchable || $field->filterable,
-                            'doc_values' => $field->filterable,
+                            'index' => true,
+                            'doc_values' => true,
                         ],
                     ],
                 ] : []),
                 $field instanceof Field\BooleanField => $properties[$name] = [
                     'type' => 'boolean',
                     'index' => $index,
-                    'doc_values' => $field->filterable,
+                    'doc_values' => $doc_values,
                 ],
                 $field instanceof Field\DateTimeField => $properties[$name] = [
                     'type' => 'date',
                     'index' => $index,
-                    'doc_values' => $field->filterable,
+                    'doc_values' => $doc_values,
                 ],
                 $field instanceof Field\IntegerField => $properties[$name] = [
                     'type' => 'integer',
                     'index' => $index,
-                    'doc_values' => $field->filterable,
+                    'doc_values' => $doc_values,
                 ],
                 $field instanceof Field\FloatField => $properties[$name] = [
                     'type' => 'float',
                     'index' => $index,
-                    'doc_values' => $field->filterable,
+                    'doc_values' => $doc_values,
                 ],
                 $field instanceof Field\ObjectField => $properties[$name] = [
                     'type' => 'object',

--- a/packages/seal-opensearch-adapter/Tests/OpensearchSchemaManagerTest.php
+++ b/packages/seal-opensearch-adapter/Tests/OpensearchSchemaManagerTest.php
@@ -147,6 +147,9 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
                     ],
                 ],
             ],
+            'published' => [
+                'type' => 'date',
+            ],
             'rating' => [
                 'type' => 'float',
             ],

--- a/packages/seal-opensearch-adapter/Tests/OpensearchSchemaManagerTest.php
+++ b/packages/seal-opensearch-adapter/Tests/OpensearchSchemaManagerTest.php
@@ -139,6 +139,14 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
                     ],
                 ],
             ],
+            'internalTags' => [
+                'type' => 'text',
+                'fields' => [
+                    'raw' => [
+                        'type' => 'keyword',
+                    ],
+                ],
+            ],
             'rating' => [
                 'type' => 'float',
             ],

--- a/packages/seal/Testing/AbstractConnectionTestCase.php
+++ b/packages/seal/Testing/AbstractConnectionTestCase.php
@@ -215,7 +215,7 @@ abstract class AbstractConnectionTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$connection);
         $search->addIndex(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\SearchCondition('admin.nonesearchablefield@localhost'));
+        $search->addFilter(new Condition\SearchCondition('Nonesearchable'));
 
         $this->assertCount(0, [...$search->getResult()]);
     }

--- a/packages/seal/Testing/TestingHelper.php
+++ b/packages/seal/Testing/TestingHelper.php
@@ -53,6 +53,7 @@ class TestingHelper
                 'text' => new Field\TextField('text'),
             ], multiple: true),
             'tags' => new Field\TextField('tags', multiple: true, filterable: true),
+            'internalTags' => new Field\TextField('internalTags', multiple: true, searchable: false, filterable: true),
             'categoryIds' => new Field\IntegerField('categoryIds', multiple: true, searchable: false, filterable: true),
         ];
 
@@ -138,6 +139,7 @@ class TestingHelper
                     ],
                 ],
                 'tags' => ['Tech', 'UI'],
+                'internalTags' => ['Internal', 'Nonesearchable'],
                 'categoryIds' => [1, 2],
             ],
             [

--- a/packages/seal/Testing/TestingHelper.php
+++ b/packages/seal/Testing/TestingHelper.php
@@ -5,7 +5,6 @@ namespace Schranz\Search\SEAL\Testing;
 use Schranz\Search\SEAL\Schema\Index;
 use Schranz\Search\SEAL\Schema\Schema;
 use Schranz\Search\SEAL\Schema\Field;
-use Schranz\Search\SEAL\Task\TaskInterface;
 
 class TestingHelper
 {
@@ -45,7 +44,8 @@ class TestingHelper
             'footer' => new Field\ObjectField('footer', [
                 'title' => new Field\TextField('title'),
             ]),
-            'created' => new Field\DateTimeField('created', filterable: true, sortable: true),
+            'created' => new Field\DateTimeField('created', searchable: false, filterable: true, sortable: true),
+            'published' => new Field\DateTimeField('published', filterable: true, sortable: true),
             'commentsCount' => new Field\IntegerField('commentsCount', searchable: false, filterable: true, sortable: true),
             'rating' => new Field\FloatField('rating', searchable: false, filterable: true, sortable: true),
             'comments' => new Field\ObjectField('comments', [
@@ -125,7 +125,8 @@ class TestingHelper
                 'footer' => [
                     'title' => 'New Footer',
                 ],
-                'created' => '2022-01-24T12:00:00+01:00',
+                'created' => '1998-01-24T12:00:00+01:00',
+                'published' => '2022-01-24T12:00:00+01:00',
                 'commentsCount' => 2,
                 'rating' => 3.5,
                 'comments' => [
@@ -153,7 +154,8 @@ class TestingHelper
                 'footer' => [
                     'title' => 'Other Footer',
                 ],
-                'created' => '2022-12-26T12:00:00+01:00',
+                'created' => '1998-12-26T12:00:00+01:00',
+                'published' => '2022-12-26T12:00:00+01:00',
                 'commentsCount' => 0,
                 'rating' => 2.5,
                 'comments' => [],
@@ -167,7 +169,8 @@ class TestingHelper
                 'footer' => [
                     'title' => 'Other Footer',
                 ],
-                'created' => '2023-02-03T12:00:00+01:00',
+                'created' => '1999-02-03T12:00:00+01:00',
+                'published' => '2023-02-03T12:00:00+01:00',
                 'commentsCount' => 0,
                 'rating' => null,
                 'comments' => [],
@@ -178,21 +181,6 @@ class TestingHelper
                 'uuid' => '97cd3e94-c17f-4c11-a22b-d9da2e5318cd',
             ],
         ];
-    }
-
-    /**
-     * @param \Closure(TaskInterface[]: $tasks) $callback
-     */
-    public static function waitForTasks(\Closure $callback): void
-    {
-        /** @var TaskInterface[] $tasks */
-        $tasks = [];
-
-        ($callback)($tasks);
-
-        foreach ($tasks as $task) {
-            $task->wait();
-        }
     }
 
     /**

--- a/packages/seal/Tests/Marshaller/MarshallerTest.php
+++ b/packages/seal/Tests/Marshaller/MarshallerTest.php
@@ -74,7 +74,8 @@ class MarshallerTest extends TestCase
             'footer' => [
                 'title' => 'New Footer',
             ],
-            'created' => '2022-01-24T12:00:00+01:00',
+            'created' => '1998-01-24T12:00:00+01:00',
+            'published' => '2022-01-24T12:00:00+01:00',
             'commentsCount' => 2,
             'rating' => 3.5,
             'comments' => [

--- a/packages/seal/Tests/Marshaller/MarshallerTest.php
+++ b/packages/seal/Tests/Marshaller/MarshallerTest.php
@@ -88,6 +88,7 @@ class MarshallerTest extends TestCase
                 ],
             ],
             'tags' => ['Tech', 'UI'],
+            'internalTags' => ['Internal', 'Nonesearchable'],
             'categoryIds' => [1, 2],
         ];
     }


### PR DESCRIPTION
Queries on none indexed fields are slow: Reference: https://github.com/elastic/elasticsearch/pull/92606/files -> https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-index.html

So we should add index on all filterable and sortable fields also. This requires us to refractor how we search on the index as currently we did misuse `index: false` to make things not searchable. Which seems not the correct way.