### PR TITLE
Enable strict mapping for Elasticsearch and Opensearch

### DIFF
--- a/packages/seal-elasticsearch-adapter/ElasticsearchSchemaManager.php
+++ b/packages/seal-elasticsearch-adapter/ElasticsearchSchemaManager.php
@@ -46,6 +46,7 @@ final class ElasticsearchSchemaManager implements SchemaManagerInterface
             'index' => $index->name,
             'body' => [
                 'mappings' => [
+                    'dynamic' => 'strict',
                     'properties' => $properties,
                 ],
             ],
@@ -124,6 +125,13 @@ final class ElasticsearchSchemaManager implements SchemaManagerInterface
                 'type' => 'object',
                 'properties' => $this->createPropertiesMapping($fields)
             ];
+
+            if ($field->multiple) {
+                $typedProperties[$type]['properties']['_originalIndex'] = [
+                    'type' => 'integer',
+                    'index' => false,
+                ];
+            }
         }
 
         return [$name => [

--- a/packages/seal-elasticsearch-adapter/Tests/ElasticsearchSchemaManagerTest.php
+++ b/packages/seal-elasticsearch-adapter/Tests/ElasticsearchSchemaManagerTest.php
@@ -66,6 +66,10 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
                 'properties' => [
                     'embed' => [
                         'properties' => [
+                            '_originalIndex' => [
+                                'type' => 'integer',
+                                'index' => false,
+                            ],
                             'media' => [
                                 'type' => 'text',
                                 'index' => false,
@@ -77,6 +81,10 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
                     ],
                     'text' => [
                         'properties' => [
+                            '_originalIndex' => [
+                                'type' => 'integer',
+                                'index' => false,
+                            ],
                             'description' => [
                                 'type' => 'text',
                             ],

--- a/packages/seal-opensearch-adapter/OpensearchSchemaManager.php
+++ b/packages/seal-opensearch-adapter/OpensearchSchemaManager.php
@@ -44,6 +44,7 @@ final class OpensearchSchemaManager implements SchemaManagerInterface
             'index' => $index->name,
             'body' => [
                 'mappings' => [
+                    'dynamic' => 'strict',
                     'properties' => $properties,
                 ],
             ],
@@ -128,6 +129,13 @@ final class OpensearchSchemaManager implements SchemaManagerInterface
                 'type' => 'object',
                 'properties' => $this->createPropertiesMapping($fields)
             ];
+
+            if ($field->multiple) {
+                $typedProperties[$type]['properties']['_originalIndex'] = [
+                    'type' => 'integer',
+                    'index' => false,
+                ];
+            }
         }
 
         return [$name => [

--- a/packages/seal-opensearch-adapter/Tests/OpensearchSchemaManagerTest.php
+++ b/packages/seal-opensearch-adapter/Tests/OpensearchSchemaManagerTest.php
@@ -65,6 +65,10 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
                 'properties' => [
                     'embed' => [
                         'properties' => [
+                            '_originalIndex' => [
+                                'type' => 'integer',
+                                'index' => false,
+                            ],
                             'media' => [
                                 'type' => 'text',
                                 'index' => false,
@@ -76,6 +80,10 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
                     ],
                     'text' => [
                         'properties' => [
+                            '_originalIndex' => [
+                                'type' => 'integer',
+                                'index' => false,
+                            ],
                             'description' => [
                                 'type' => 'text',
                             ],


### PR DESCRIPTION
This should make sure we are not forget to define the mapping correctly and the mapped fields.