### PR TITLE
Improve by set PHPUnit timezone, remove empty rating in fixtures and support Marshaller to convert date to integers

### DIFF
--- a/packages/seal-algolia-adapter/phpunit.xml.dist
+++ b/packages/seal-algolia-adapter/phpunit.xml.dist
@@ -7,6 +7,7 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
+        <ini name="date.timezone" value="Europe/Berlin" />
         <server name="SHELL_VERBOSITY" value="-1" />
         <env name="ALGOLIA_APPLICATION_ID" value="" />
         <env name="ALGOLIA_ADMIN_API_KEY" value="" />

--- a/packages/seal-elasticsearch-adapter/phpunit.xml.dist
+++ b/packages/seal-elasticsearch-adapter/phpunit.xml.dist
@@ -7,6 +7,7 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
+        <ini name="date.timezone" value="Europe/Berlin" />
         <server name="SHELL_VERBOSITY" value="-1" />
         <env name="ELASTICSEARCH_HOST" value="127.0.0.1:9200" />
     </php>

--- a/packages/seal-meilisearch-adapter/phpunit.xml.dist
+++ b/packages/seal-meilisearch-adapter/phpunit.xml.dist
@@ -7,6 +7,7 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
+        <ini name="date.timezone" value="Europe/Berlin" />
         <server name="SHELL_VERBOSITY" value="-1" />
         <env name="MEILISEARCH_HOST" value="127.0.0.1:7700" />
     </php>

--- a/packages/seal-memory-adapter/phpunit.xml.dist
+++ b/packages/seal-memory-adapter/phpunit.xml.dist
@@ -7,6 +7,7 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
+        <ini name="date.timezone" value="Europe/Berlin" />
         <server name="SHELL_VERBOSITY" value="-1" />
     </php>
 

--- a/packages/seal-opensearch-adapter/phpunit.xml.dist
+++ b/packages/seal-opensearch-adapter/phpunit.xml.dist
@@ -7,6 +7,7 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
+        <ini name="date.timezone" value="Europe/Berlin" />
         <server name="SHELL_VERBOSITY" value="-1" />
         <env name="OPENSEARCH_HOST" value="127.0.0.1:9200" />
     </php>

--- a/packages/seal/Testing/TestingHelper.php
+++ b/packages/seal/Testing/TestingHelper.php
@@ -167,7 +167,6 @@ class TestingHelper
                 ],
                 'created' => '2023-02-03T12:00:00+01:00',
                 'commentsCount' => 0,
-                'rating' => null,
                 'comments' => [],
                 'tags' => ['Tech', 'UX'],
                 'categoryIds' => [3, 4],

--- a/packages/seal/Tests/Marshaller/MarshallerTest.php
+++ b/packages/seal/Tests/Marshaller/MarshallerTest.php
@@ -8,28 +8,45 @@ use Schranz\Search\SEAL\Testing\TestingHelper;
 
 class MarshallerTest extends TestCase
 {
-    private Marshaller $marshaller;
-
-    public function setUp(): void
-    {
-        $this->marshaller = new Marshaller();
-    }
-
     public function testMarshall(): void
     {
+        $marshaller = new Marshaller();
         $complexIndex = TestingHelper::createSchema()->indexes[TestingHelper::INDEX_COMPLEX];
         $documents = TestingHelper::createComplexFixtures();
 
-        $rawDocument = $this->marshaller->marshall($complexIndex->fields, $documents[0]);
+        $rawDocument = $marshaller->marshall($complexIndex->fields, $documents[0]);
 
         $this->assertSame($this->getRawDocument(), $rawDocument);
     }
 
     public function testUnmarshall(): void
     {
+        $marshaller = new Marshaller();
         $complexIndex = TestingHelper::createSchema()->indexes[TestingHelper::INDEX_COMPLEX];
 
-        $document = $this->marshaller->unmarshall($complexIndex->fields, $this->getRawDocument());
+        $document = $marshaller->unmarshall($complexIndex->fields, $this->getRawDocument());
+
+        $documents = TestingHelper::createComplexFixtures();
+        $this->assertSame($documents[0], $document);
+    }
+
+    public function testMarshallDateAsInt(): void
+    {
+        $marshaller = new Marshaller(dateAsInteger: true);
+        $complexIndex = TestingHelper::createSchema()->indexes[TestingHelper::INDEX_COMPLEX];
+        $documents = TestingHelper::createComplexFixtures();
+
+        $rawDocument = $marshaller->marshall($complexIndex->fields, $documents[0]);
+
+        $this->assertSame($this->getRawDocument(dateAsInteger: true), $rawDocument);
+    }
+
+    public function testUnmarshallDateAsInt(): void
+    {
+        $marshaller = new Marshaller(dateAsInteger: true);
+        $complexIndex = TestingHelper::createSchema()->indexes[TestingHelper::INDEX_COMPLEX];
+
+        $document = $marshaller->unmarshall($complexIndex->fields, $this->getRawDocument(dateAsInteger: true));
 
         $documents = TestingHelper::createComplexFixtures();
         $this->assertSame($documents[0], $document);
@@ -38,7 +55,7 @@ class MarshallerTest extends TestCase
     /**
      * @return array<string, mixed>
      */
-    private function getRawDocument(): array
+    private function getRawDocument($dateAsInteger = false): array
     {
         return [
             'uuid' => '23b30f01-d8fd-4dca-b36a-4710e360a965',
@@ -74,7 +91,7 @@ class MarshallerTest extends TestCase
             'footer' => [
                 'title' => 'New Footer',
             ],
-            'created' => '2022-01-24T12:00:00+01:00',
+            'created' => $dateAsInteger ? 1643022000 : '2022-01-24T12:00:00+01:00',
             'commentsCount' => 2,
             'rating' => 3.5,
             'comments' => [

--- a/packages/seal/phpunit.xml.dist
+++ b/packages/seal/phpunit.xml.dist
@@ -7,9 +7,8 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
+        <ini name="date.timezone" value="Europe/Berlin" />
         <server name="SHELL_VERBOSITY" value="-1" />
-        <env name="ALGOLIA_APPLICATION_ID" value="" />
-        <env name="ALGOLIA_ADMIN_API_KEY" value="" />
     </php>
 
     <testsuites>


### PR DESCRIPTION
This are all improvements which were implemented in #76 part of Typesense, but as we can not currently continue here. I cherry picked this changes out of that pull request so we already have them available in the core.