### PR TITLE
Fix Algolia drop indexes with sort replicas

### DIFF
--- a/packages/seal/Testing/AbstractAdapterTestCase.php
+++ b/packages/seal/Testing/AbstractAdapterTestCase.php
@@ -129,11 +129,13 @@ abstract class AbstractAdapterTestCase extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        self::getEngine()->dropSchema();
+        $task = self::getEngine()->dropSchema(['return_slow_promise_result' => true]);
+        $task->wait();
     }
 
     public static function tearDownAfterClass(): void
     {
-        self::getEngine()->dropSchema();
+        $task = self::getEngine()->dropSchema(['return_slow_promise_result' => true]);
+        $task->wait();
     }
 }

--- a/packages/seal/Testing/AbstractConnectionTestCase.php
+++ b/packages/seal/Testing/AbstractConnectionTestCase.php
@@ -40,7 +40,8 @@ abstract class AbstractConnectionTestCase extends TestCase
 
     public static function tearDownAfterClass(): void
     {
-        self::$taskHelper = new TaskHelper();
+        self::$taskHelper->waitForAll();
+
         foreach (self::getSchema()->indexes as $index) {
             self::$taskHelper->tasks[] = self::$schemaManager->dropIndex($index, ['return_slow_promise_result' => true]);
         }


### PR DESCRIPTION
Currently the replicas where not removed, but with removing the main index we should also remove the sort replicas. This should also fix parts of #82.