### PR TITLE
Add Flattenmarshaller service

### DIFF
--- a/packages/seal/Marshaller/FlattenMarshaller.php
+++ b/packages/seal/Marshaller/FlattenMarshaller.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Schranz\Search\SEAL\Marshaller;
+
+use Schranz\Search\SEAL\Schema\Field;
+
+/**
+ * @internal This class currently in discussion to be open for all adapters.
+ */
+final class FlattenMarshaller
+{
+    private Marshaller $marshaller;
+
+    public function __construct(
+        bool $dateAsInteger = false,
+    ) {
+        $this->marshaller = new Marshaller($dateAsInteger);
+    }
+    /**
+     * @param Field\AbstractField[] $fields
+     * @param array<string, mixed> $object
+     *
+     * @return array<string, mixed>
+     */
+    public function marshall(array $fields, array $document): array
+    {
+        $rawDocument = $this->marshaller->marshall($fields, $document);
+
+        return $this->flatten($fields, $rawDocument);
+    }
+
+    /**
+     * @param Field\AbstractField[] $fields
+     * @param array<string, mixed> $raw
+     *
+     * @return array<string, mixed>
+     */
+    public function unmarshall(array $fields, array $raw): array
+    {
+        return $this->marshaller->unmarshall($fields, $raw);
+    }
+
+    /**
+     * @param Field\AbstractField[] $fields
+     * @param array<string, mixed> $raw
+     *
+     * @return array<string, mixed>
+     */
+    private function flatten(array $fields, array $raw)
+    {
+        foreach ($fields as $name => $field) {
+            if (!array_key_exists($name, $raw)) {
+                continue;
+            }
+
+            match (true) {
+                $field instanceof Field\ObjectField => $raw = $this->flattenObject($name, $raw, $field),
+                $field instanceof Field\TypedField => $raw = $this->flattenTyped($name, $raw, $field),
+                default => null,
+            };
+        }
+
+        return $raw;
+    }
+
+
+    /**
+     * @param array<string, mixed> $raw
+     *
+     * @return array<string, mixed>
+     */
+    private function flattenObject(string $name, array $raw, Field\ObjectField $field)
+    {
+        $objects = $field->multiple ? $raw[$name] : [$raw[$name]];
+
+        $newRawData = [];
+        foreach ($objects as $index => $object) {
+            foreach ($this->flatten($field->fields, $object) as $key => $value) {
+                if (is_array($value)) {
+                    $newRawData[$name . '.' . $key . '.length'][$index] = count($value);
+                    $filler = array_fill(0, $index + 1, 0);
+                    $newRawData[$name . '.' . $key . '.length'] = array_replace($filler, $newRawData[$name . '.' . $key . '.length']);
+
+                    if (!isset($newRawData[$name . '.' . $key])) {
+                        $newRawData[$name . '.' . $key] = [];
+                    }
+
+                    \array_push($newRawData[$name . '.' . $key], ...($value));
+
+                    $newRawData[$name . '.' . $key] = array_merge($newRawData[$name . '.' . $key] ?? [], $value);
+
+                    continue;
+                } elseif ($field->multiple) {
+                    $newRawData[$name . '.' . $key][] = $value;
+
+                    continue;
+                }
+
+                $newRawData[$name . '.' . $key] = $value;
+            }
+        }
+
+        $keepOrderRaw = [];
+        foreach ($raw as $key => $value) {
+            if ($key === $name) {
+                foreach ($newRawData as $key2 => $value2) {
+                    $keepOrderRaw[$key2] = $value2;
+                }
+
+                continue;
+            }
+
+            $keepOrderRaw[$key] = $value;
+        }
+
+        return $keepOrderRaw;
+    }
+
+
+    /**
+     * @param array<string, mixed> $raw
+     *
+     * @return array<string, mixed>
+     */
+    private function flattenTyped(string $name, array $raw, Field\TypedField $field)
+    {
+        $types = $raw[$name];
+
+        $newRawData = [];
+        foreach ($types as $type => $object) {
+            $objects = $field->multiple ? $object : [$object];
+
+            foreach ($objects as $index => $object) {
+                foreach ($this->flatten($field->types[$type], $object) as $key => $value) {
+                    if (\is_array($value)) {
+                        $newRawData[$name . '.' . $type . '.' . $key . '.length'][$index] = count($value);
+                        $filler = array_fill(0, $index + 1, 0);
+                        $newRawData[$name . '.' . $type . '.' . $key . '.length'] = array_replace($filler, $newRawData[$name . '.' . $type . '.' . $key . '.length']);
+
+                        if (!isset($newRawData[$name . '.' . $type . '.' . $key])) {
+                            $newRawData[$name . '.' . $type . '.' . $key] = [];
+                        }
+
+                        \array_push($newRawData[$name . '.' . $type . '.' . $key], ...$value);
+
+                        continue;
+                    } elseif ($field->multiple) {
+                        $newRawData[$name . '.' . $type . '.' . $key][$index] = $value;
+                        $filler = array_fill(0, $index + 1, null);
+                        $newRawData[$name . '.' . $type . '.' . $key] = array_replace($filler, $newRawData[$name . '.' . $type . '.' . $key]);
+
+                        continue;
+                    }
+
+                    $newRawData[$name . '.' . $type . '.' . $key] = $value;
+                }
+            }
+        }
+
+        $keepOrderRaw = [];
+        foreach ($raw as $key => $value) {
+            if ($key === $name) {
+                foreach ($newRawData as $key2 => $value2) {
+                    $keepOrderRaw[$key2] = $value2;
+                }
+
+                continue;
+            }
+
+            $keepOrderRaw[$key] = $value;
+        }
+
+        return $keepOrderRaw;
+    }
+}

--- a/packages/seal/Marshaller/Marshaller.php
+++ b/packages/seal/Marshaller/Marshaller.php
@@ -176,6 +176,8 @@ final class Marshaller
 
                     $documentFields[$name][$originalIndex] = $documentData;
 
+                    \ksort($documentFields[$name]);
+
                     continue;
                 }
 

--- a/packages/seal/Marshaller/Marshaller.php
+++ b/packages/seal/Marshaller/Marshaller.php
@@ -6,6 +6,8 @@ use Schranz\Search\SEAL\Schema\Field;
 
 /**
  * @internal This class currently in discussion to be open for all adapters.
+ *
+ * The Marshaller will split the typed fields into different subfields and use a `_originalIndex` field to unmarshall it again.
  */
 final class Marshaller
 {

--- a/packages/seal/Testing/TestingHelper.php
+++ b/packages/seal/Testing/TestingHelper.php
@@ -113,12 +113,18 @@ class TestingHelper
                     [
                         'type' => 'text',
                         'title' => 'Titel 2',
-                        'description' => '<p>Description 2</p>',
+                        'description' => null,
                     ],
                     [
                         'type' => 'embed',
                         'title' => 'Video',
                         'media' => 'https://www.youtube.com/watch?v=iYM2zFP3Zn0',
+                    ],
+                    [
+                        'type' => 'text',
+                        'title' => 'Titel 4',
+                        'description' => '<p>Description 4</p>',
+                        'media' => [3, 4],
                     ],
                 ],
                 'footer' => [

--- a/packages/seal/Tests/Marshaller/FlattenMarshallerTest.php
+++ b/packages/seal/Tests/Marshaller/FlattenMarshallerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Schranz\Search\SEAL\Tests\Marshaller;
+
+use PHPUnit\Framework\TestCase;
+use Schranz\Search\SEAL\Marshaller\FlattenMarshaller;
+use Schranz\Search\SEAL\Testing\TestingHelper;
+
+class FlattenMarshallerTest extends TestCase
+{
+    public function testMarshallFlatten(): void
+    {
+        $marshaller = new FlattenMarshaller();
+        $complexIndex = TestingHelper::createSchema()->indexes[TestingHelper::INDEX_COMPLEX];
+        $documents = TestingHelper::createComplexFixtures();
+
+        $rawDocument = $marshaller->marshall($complexIndex->fields, $documents[0]);
+
+        $this->assertSame($this->getRawDocument(), $rawDocument);
+    }
+
+    public function testUnmarshall(): void
+    {
+        $marshaller = new FlattenMarshaller();
+        $complexIndex = TestingHelper::createSchema()->indexes[TestingHelper::INDEX_COMPLEX];
+
+        $document = $marshaller->unmarshall($complexIndex->fields, $this->getRawDocument());
+
+        $documents = TestingHelper::createComplexFixtures();
+        $this->assertSame($documents[0], $document);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getRawDocument(bool $dateAsInteger = false): array
+    {
+        return [
+            'uuid' => '23b30f01-d8fd-4dca-b36a-4710e360a965',
+            'title' => 'New Blog',
+            'header.image.media' => 1,
+            'article' => '<article><h2>New Subtitle</h2><p>A html field with some content</p></article>',
+            'blocks.text._originalIndex' => [0, 1, 3],
+            'blocks.text.title' => ['Titel', 'Titel 2', 'Titel 4'],
+            'blocks.text.description' => ['<p>Description</p>', null, '<p>Description 4</p>'],
+            'blocks.text.media.length' => [2, 0, 2],
+            'blocks.text.media' => [3, 4, 3, 4],
+            'blocks.embed._originalIndex' => [2],
+            'blocks.embed.title' => ['Video'],
+            'blocks.embed.media' => ['https://www.youtube.com/watch?v=iYM2zFP3Zn0'],
+            'footer.title' => 'New Footer',
+            'created' => $dateAsInteger ? 1643022000 : '2022-01-24T12:00:00+01:00',
+            'commentsCount' => 2,
+            'rating' => 3.5,
+            'comments.email' => ['admin.nonesearchablefield@localhost', 'example.nonesearchablefield@localhost'],
+            'comments.text' => ['Awesome blog!', 'Like this blog!'],
+            'tags' => ['Tech', 'UI'],
+            'categoryIds' => [1, 2],
+        ];
+    }
+}

--- a/packages/seal/Tests/Marshaller/FlattenMarshallerTest.php
+++ b/packages/seal/Tests/Marshaller/FlattenMarshallerTest.php
@@ -272,5 +272,134 @@ class FlattenMarshallerTest extends TestCase
                 ]),
             ],
         ];
+
+        yield 'typed_objects' => [
+            [
+                'uuid' => '23b30f01-d8fd-4dca-b36a-4710e360a965',
+                'blocks' => [
+                    [
+                        'type' => 'text',
+                        'title' => 'Titel',
+                        'description' => '<p>Description</p>',
+                        'media' => [3, 4],
+                        'secondaryBlocks' => [
+                            [
+                                'type' => 'text',
+                                'title' => 'Titel',
+                                'description' => '<p>Description</p>',
+                                'media' => [3, 4],
+                            ],
+                            [
+                                'type' => 'text',
+                                'title' => 'Titel 2',
+                                'description' => null,
+                            ],
+                            [
+                                'type' => 'embed',
+                                'title' => 'Video',
+                                'media' => 'https://www.youtube.com/watch?v=iYM2zFP3Zn0',
+                            ],
+                            [
+                                'type' => 'text',
+                                'title' => 'Titel 4',
+                                'description' => '<p>Description 4</p>',
+                                'media' => [3, 4],
+                            ],
+                        ],
+                    ],
+                    [
+                        'type' => 'text',
+                        'title' => 'Titel 2',
+                        'description' => null,
+                    ],
+                    [
+                        'type' => 'embed',
+                        'title' => 'Video',
+                        'media' => 'https://www.youtube.com/watch?v=iYM2zFP3Zn0',
+                    ],
+                    [
+                        'type' => 'text',
+                        'title' => 'Titel 4',
+                        'description' => '<p>Description 4</p>',
+                        'media' => [3, 4],
+                        'secondaryBlocks' => [
+                            [
+                                'type' => 'text',
+                                'title' => 'Titel',
+                                'description' => '<p>Description</p>',
+                                'media' => [3, 4],
+                            ],
+                            [
+                                'type' => 'text',
+                                'title' => 'Titel 2',
+                                'description' => null,
+                            ],
+                            [
+                                'type' => 'embed',
+                                'title' => 'Video',
+                                'media' => 'https://www.youtube.com/watch?v=iYM2zFP3Zn0',
+                            ],
+                            [
+                                'type' => 'text',
+                                'title' => 'Titel 4',
+                                'description' => '<p>Description 4</p>',
+                                'media' => [3, 4],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'uuid' => '23b30f01-d8fd-4dca-b36a-4710e360a965',
+                'blocks.text._originalIndex' => [0, 1, 3],
+                'blocks.text.title' => ['Titel', 'Titel 2', 'Titel 4'],
+                'blocks.text.description' => ['<p>Description</p>', null, '<p>Description 4</p>'],
+                'blocks.text.media._originalLength' => [2, 0, 2],
+                'blocks.text.media' => [3, 4, 3, 4],
+                'blocks.text.secondaryBlocks.text._originalIndex._originalLength' => [3, 0, 3],
+                'blocks.text.secondaryBlocks.text._originalIndex' => [0, 1, 3, 0, 1, 3],
+                'blocks.text.secondaryBlocks.text.title._originalLength' => [3, 0, 3],
+                'blocks.text.secondaryBlocks.text.title' => ['Titel', 'Titel 2', 'Titel 4', 'Titel', 'Titel 2', 'Titel 4'],
+                'blocks.text.secondaryBlocks.text.description._originalLength' => [3, 0, 3],
+                'blocks.text.secondaryBlocks.text.description' => ['<p>Description</p>', null, '<p>Description 4</p>', '<p>Description</p>', null, '<p>Description 4</p>'],
+                'blocks.text.secondaryBlocks.text.media._originalLength._originalLength' => [3, 0, 3],
+                'blocks.text.secondaryBlocks.text.media._originalLength' => [2, 0, 2, 2, 0, 2],
+                'blocks.text.secondaryBlocks.text.media' => [3, 4, 3, 4, 3, 4, 3, 4],
+                'blocks.text.secondaryBlocks.embed._originalIndex._originalLength' => [1, 0, 1],
+                'blocks.text.secondaryBlocks.embed._originalIndex' => [2, 2],
+                'blocks.text.secondaryBlocks.embed.title._originalLength' => [1, 0, 1],
+                'blocks.text.secondaryBlocks.embed.title' => ['Video', 'Video'],
+                'blocks.text.secondaryBlocks.embed.media._originalLength' => [1, 0, 1],
+                'blocks.text.secondaryBlocks.embed.media' => ['https://www.youtube.com/watch?v=iYM2zFP3Zn0', 'https://www.youtube.com/watch?v=iYM2zFP3Zn0'],
+                'blocks.embed._originalIndex' => [2],
+                'blocks.embed.title' => ['Video'],
+                'blocks.embed.media' => ['https://www.youtube.com/watch?v=iYM2zFP3Zn0'],
+            ],
+            [
+                'uuid' => new Field\IdentifierField('uuid'),
+                'blocks' => new Field\TypedField('blocks', 'type', [
+                    'text' => [
+                        'title' => new Field\TextField('title'),
+                        'description' => new Field\TextField('description'),
+                        'media' => new Field\IntegerField('media', multiple: true, searchable: false),
+                        'secondaryBlocks' => new Field\TypedField('secondaryBlocks', 'type', [
+                            'text' => [
+                                'title' => new Field\TextField('title'),
+                                'description' => new Field\TextField('description'),
+                                'media' => new Field\IntegerField('media', multiple: true, searchable: false),
+                            ],
+                            'embed' => [
+                                'title' => new Field\TextField('title'),
+                                'media' => new Field\TextField('media', searchable: false),
+                            ],
+                        ], multiple: true),
+                    ],
+                    'embed' => [
+                        'title' => new Field\TextField('title'),
+                        'media' => new Field\TextField('media', searchable: false),
+                    ],
+                ], multiple: true),
+            ],
+        ];
     }
 }

--- a/packages/seal/Tests/Marshaller/FlattenMarshallerTest.php
+++ b/packages/seal/Tests/Marshaller/FlattenMarshallerTest.php
@@ -4,58 +4,273 @@ namespace Schranz\Search\SEAL\Tests\Marshaller;
 
 use PHPUnit\Framework\TestCase;
 use Schranz\Search\SEAL\Marshaller\FlattenMarshaller;
-use Schranz\Search\SEAL\Testing\TestingHelper;
+use Schranz\Search\SEAL\Schema\Field;
 
 class FlattenMarshallerTest extends TestCase
 {
-    public function testMarshallFlatten(): void
+    /**
+     * @param array<string, mixed> $flattenDocument
+     *
+     * @dataProvider provideData
+     */
+    public function testMarshall(array $document, array $flattenDocument, array $fields): void
     {
         $marshaller = new FlattenMarshaller();
-        $complexIndex = TestingHelper::createSchema()->indexes[TestingHelper::INDEX_COMPLEX];
-        $documents = TestingHelper::createComplexFixtures();
 
-        $rawDocument = $marshaller->marshall($complexIndex->fields, $documents[0]);
+        $marshalledDocument = $marshaller->marshall($fields, $document);
 
-        $this->assertSame($this->getRawDocument(), $rawDocument);
-    }
-
-    public function testUnmarshall(): void
-    {
-        $marshaller = new FlattenMarshaller();
-        $complexIndex = TestingHelper::createSchema()->indexes[TestingHelper::INDEX_COMPLEX];
-
-        $document = $marshaller->unmarshall($complexIndex->fields, $this->getRawDocument());
-
-        $documents = TestingHelper::createComplexFixtures();
-        $this->assertSame($documents[0], $document);
+        $this->assertSame($flattenDocument, $marshalledDocument);
     }
 
     /**
-     * @return array<string, mixed>
+     * @param array<string, mixed> $flattenDocument
+     *
+     * @dataProvider provideData
      */
-    private function getRawDocument(bool $dateAsInteger = false): array
+    public function testUnmarshall(array $document, array $flattenDocument, array $fields): void
     {
-        return [
-            'uuid' => '23b30f01-d8fd-4dca-b36a-4710e360a965',
-            'title' => 'New Blog',
-            'header.image.media' => 1,
-            'article' => '<article><h2>New Subtitle</h2><p>A html field with some content</p></article>',
-            'blocks.text._originalIndex' => [0, 1, 3],
-            'blocks.text.title' => ['Titel', 'Titel 2', 'Titel 4'],
-            'blocks.text.description' => ['<p>Description</p>', null, '<p>Description 4</p>'],
-            'blocks.text.media.length' => [2, 0, 2],
-            'blocks.text.media' => [3, 4, 3, 4],
-            'blocks.embed._originalIndex' => [2],
-            'blocks.embed.title' => ['Video'],
-            'blocks.embed.media' => ['https://www.youtube.com/watch?v=iYM2zFP3Zn0'],
-            'footer.title' => 'New Footer',
-            'created' => $dateAsInteger ? 1643022000 : '2022-01-24T12:00:00+01:00',
-            'commentsCount' => 2,
-            'rating' => 3.5,
-            'comments.email' => ['admin.nonesearchablefield@localhost', 'example.nonesearchablefield@localhost'],
-            'comments.text' => ['Awesome blog!', 'Like this blog!'],
-            'tags' => ['Tech', 'UI'],
-            'categoryIds' => [1, 2],
+        $marshaller = new FlattenMarshaller();
+
+        $unmarshalledDocument = $marshaller->unmarshall($fields, $flattenDocument);
+
+        $this->assertSame($document, $unmarshalledDocument);
+    }
+
+    /**
+     * @return \Generator<array{
+     *     0: array<string, mixed>,
+     *     1: array<string, mixed>,
+     *     2: Field\AbstractField[],
+     * }>
+     */
+    private function provideData(): \Generator
+    {
+        yield 'complex_object' => [
+            [
+                'uuid' => '23b30f01-d8fd-4dca-b36a-4710e360a965',
+                'title' => 'New Blog',
+                'header' => [
+                    'type' => 'image',
+                    'media' => 1,
+                ],
+                'article' => '<article><h2>New Subtitle</h2><p>A html field with some content</p></article>',
+                'blocks' => [
+                    [
+                        'type' => 'text',
+                        'title' => 'Titel',
+                        'description' => '<p>Description</p>',
+                        'media' => [3, 4],
+                    ],
+                    [
+                        'type' => 'text',
+                        'title' => 'Titel 2',
+                        'description' => null,
+                    ],
+                    [
+                        'type' => 'embed',
+                        'title' => 'Video',
+                        'media' => 'https://www.youtube.com/watch?v=iYM2zFP3Zn0',
+                    ],
+                    [
+                        'type' => 'text',
+                        'title' => 'Titel 4',
+                        'description' => '<p>Description 4</p>',
+                        'media' => [3, 4],
+                    ],
+                ],
+                'footer' => [
+                    'title' => 'New Footer',
+                ],
+                'created' => '2022-01-24T12:00:00+01:00',
+                'commentsCount' => 2,
+                'rating' => 3.5,
+                'comments' => [
+                    [
+                        'email' => 'admin.nonesearchablefield@localhost',
+                        'text' => 'Awesome blog!',
+                    ],
+                    [
+                        'email' => 'example.nonesearchablefield@localhost',
+                        'text' => 'Like this blog!',
+                    ],
+                ],
+                'tags' => ['Tech', 'UI'],
+                'categoryIds' => [1, 2],
+            ],
+            [
+                'uuid' => '23b30f01-d8fd-4dca-b36a-4710e360a965',
+                'title' => 'New Blog',
+                'header.image.media' => 1,
+                'article' => '<article><h2>New Subtitle</h2><p>A html field with some content</p></article>',
+                'blocks.text._originalIndex' => [0, 1, 3],
+                'blocks.text.title' => ['Titel', 'Titel 2', 'Titel 4'],
+                'blocks.text.description' => ['<p>Description</p>', null, '<p>Description 4</p>'],
+                'blocks.text.media._originalLength' => [2, 0, 2],
+                'blocks.text.media' => [3, 4, 3, 4],
+                'blocks.embed._originalIndex' => [2],
+                'blocks.embed.title' => ['Video'],
+                'blocks.embed.media' => ['https://www.youtube.com/watch?v=iYM2zFP3Zn0'],
+                'footer.title' => 'New Footer',
+                'created' => '2022-01-24T12:00:00+01:00',
+                'commentsCount' => 2,
+                'rating' => 3.5,
+                'comments.email' => ['admin.nonesearchablefield@localhost', 'example.nonesearchablefield@localhost'],
+                'comments.text' => ['Awesome blog!', 'Like this blog!'],
+                'tags' => ['Tech', 'UI'],
+                'categoryIds' => [1, 2],
+            ],
+            [
+                'uuid' => new Field\IdentifierField('uuid'),
+                'title' => new Field\TextField('title'),
+                'header' => new Field\TypedField('header', 'type', [
+                    'image' => [
+                        'media' => new Field\IntegerField('media', searchable: false),
+                    ],
+                    'video' => [
+                        'media' => new Field\TextField('media', searchable: false),
+                    ],
+                ]),
+                'article' => new Field\TextField('article'),
+                'blocks' => new Field\TypedField('blocks', 'type', [
+                    'text' => [
+                        'title' => new Field\TextField('title'),
+                        'description' => new Field\TextField('description'),
+                        'media' => new Field\IntegerField('media', multiple: true, searchable: false),
+                    ],
+                    'embed' => [
+                        'title' => new Field\TextField('title'),
+                        'media' => new Field\TextField('media', searchable: false),
+                    ],
+                ], multiple: true),
+                'footer' => new Field\ObjectField('footer', [
+                    'title' => new Field\TextField('title'),
+                ]),
+                'created' => new Field\DateTimeField('created', filterable: true, sortable: true),
+                'commentsCount' => new Field\IntegerField('commentsCount', searchable: false, filterable: true, sortable: true),
+                'rating' => new Field\FloatField('rating', searchable: false, filterable: true, sortable: true),
+                'comments' => new Field\ObjectField('comments', [
+                    'email' => new Field\TextField('email', searchable: false),
+                    'text' => new Field\TextField('text'),
+                ], multiple: true),
+                'tags' => new Field\TextField('tags', multiple: true, filterable: true),
+                'categoryIds' => new Field\IntegerField('categoryIds', multiple: true, searchable: false, filterable: true),
+            ],
+        ];
+
+        yield 'nested_object' => [
+            [
+                'uuid' => '23b30f01-d8fd-4dca-b36a-4710e360a965',
+                'object' => [
+                    'title' => 'Title',
+                    'secondaryObject' => [
+                        'title' => 'Secondary Title',
+                        'tertiaryObject' => [
+                            'title' => 'Tertiary Title',
+                            'media' => [1, 2],
+                            'quaternaryObject' => [
+                                'title' => 'Quaternary Title',
+                                'media' => [3, 4],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'uuid' => '23b30f01-d8fd-4dca-b36a-4710e360a965',
+                'object.title' => 'Title',
+                'object.secondaryObject.title' => 'Secondary Title',
+                'object.secondaryObject.tertiaryObject.title' => 'Tertiary Title',
+                'object.secondaryObject.tertiaryObject.media' => [1, 2],
+                'object.secondaryObject.tertiaryObject.quaternaryObject.title' => 'Quaternary Title',
+                'object.secondaryObject.tertiaryObject.quaternaryObject.media' => [3,4],
+            ],
+            [
+                'uuid' => new Field\IdentifierField('uuid'),
+                'object' => new Field\ObjectField('object', [
+                    'title' => new Field\TextField('title'),
+                    'secondaryObject' => new Field\ObjectField('secondaryObject', [
+                        'title' => new Field\TextField('title'),
+                        'tertiaryObject' => new Field\ObjectField('tertiaryObject', [
+                            'title' => new Field\TextField('title'),
+                            'media' => new Field\IntegerField('media', multiple: true, searchable: false),
+                            'quaternaryObject' => new Field\ObjectField('quaternaryObject', [
+                                'title' => new Field\TextField('title'),
+                                'media' => new Field\IntegerField('media', multiple: true, searchable: false),
+                            ]),
+                        ]),
+                    ]),
+                ]),
+            ],
+        ];
+
+        yield 'nested_object_multiple' => [
+            [
+                'uuid' => '23b30f01-d8fd-4dca-b36a-4710e360a965',
+                'object' => [
+                    'title' => 'Title',
+                    'secondaryObject' => [
+                        [
+                            'title' => 'Secondary Title',
+                            'tertiaryObject' => [
+                                'title' => 'Tertiary Title',
+                                'media' => [1, 2],
+                                'quaternaryObject' => [
+                                    'title' => 'Quaternary Title',
+                                    'media' => [3, 4],
+                                ],
+                            ],
+                        ],
+                        [
+                            'title' => null,
+                            'tertiaryObject' => [
+                                'title' => null,
+                                'quaternaryObject' => [
+                                    'title' => null,
+                                ],
+                            ],
+                        ],
+                        [
+                            'title' => 'Secondary Title 3',
+                            'tertiaryObject' => [
+                                'title' => 'Tertiary Title 3',
+                                'media' => [6, 7],
+                                'quaternaryObject' => [
+                                    'title' => 'Quaternary Title 3',
+                                    'media' => [8, 9],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'uuid' => '23b30f01-d8fd-4dca-b36a-4710e360a965',
+                'object.title' => 'Title',
+                'object.secondaryObject.title' => ['Secondary Title', null, 'Secondary Title 3'],
+                'object.secondaryObject.tertiaryObject.title' => ['Tertiary Title', null, 'Tertiary Title 3'],
+                'object.secondaryObject.tertiaryObject.media._originalLength' => [2, 0, 2],
+                'object.secondaryObject.tertiaryObject.media' => [1, 2, 6, 7],
+                'object.secondaryObject.tertiaryObject.quaternaryObject.title' => ['Quaternary Title', null, 'Quaternary Title 3'],
+                'object.secondaryObject.tertiaryObject.quaternaryObject.media._originalLength' => [2, 0, 2],
+                'object.secondaryObject.tertiaryObject.quaternaryObject.media' => [3, 4, 8, 9],
+            ],
+            [
+                'uuid' => new Field\IdentifierField('uuid'),
+                'object' => new Field\ObjectField('object', [
+                    'title' => new Field\TextField('title'),
+                    'secondaryObject' => new Field\ObjectField('secondaryObject', [
+                        'title' => new Field\TextField('title'),
+                        'tertiaryObject' => new Field\ObjectField('tertiaryObject', [
+                            'title' => new Field\TextField('title'),
+                            'media' => new Field\IntegerField('media', multiple: true, searchable: false),
+                            'quaternaryObject' => new Field\ObjectField('quaternaryObject', [
+                                'title' => new Field\TextField('title'),
+                                'media' => new Field\IntegerField('media', multiple: true, searchable: false),
+                            ]),
+                        ]),
+                    ], multiple: true),
+                ]),
+            ],
         ];
     }
 }

--- a/packages/seal/Tests/Marshaller/MarshallerTest.php
+++ b/packages/seal/Tests/Marshaller/MarshallerTest.php
@@ -77,7 +77,13 @@ class MarshallerTest extends TestCase
                     [
                         '_originalIndex' => 1,
                         'title' => 'Titel 2',
-                        'description' => '<p>Description 2</p>',
+                        'description' => null,
+                    ],
+                    [
+                        '_originalIndex' => 3,
+                        'title' => 'Titel 4',
+                        'description' => '<p>Description 4</p>',
+                        'media' => [3, 4],
                     ],
                 ],
                 'embed' => [


### PR DESCRIPTION
For Apache Solr it maybe make sense to simulate a elasticsearch behaviour for nested objects. For this we would need a flatten marshaller which flat the array in basic single or multi fields.

# TODO

 - [x] marshall
 - [x] unmarshall
 - [x] nested objects
 - [x] nested types

------------------

After many tries and fails I wanted to avoid to many _originalLength or _originalIndex fields. So I decided to go with a `_rawDocument` field to save the document raw into the index. This field should be unindexed field.

This service is required and adopted in:

 - https://github.com/schranz-search/schranz-search/pull/73