### PR TITLE
Remove null value from test data

### DIFF
--- a/packages/seal/Testing/TestingHelper.php
+++ b/packages/seal/Testing/TestingHelper.php
@@ -113,7 +113,6 @@ class TestingHelper
                     [
                         'type' => 'text',
                         'title' => 'Titel 2',
-                        'description' => null,
                     ],
                     [
                         'type' => 'embed',

--- a/packages/seal/Tests/Marshaller/MarshallerTest.php
+++ b/packages/seal/Tests/Marshaller/MarshallerTest.php
@@ -77,7 +77,6 @@ class MarshallerTest extends TestCase
                     [
                         '_originalIndex' => 1,
                         'title' => 'Titel 2',
-                        'description' => null,
                     ],
                     [
                         '_originalIndex' => 3,


### PR DESCRIPTION
The `null` is handled differently by different engines. Some don't return it some return it. We remove it from the test data to make the adapter and connection test not fail for this kind of different engines.