### PR TITLE
Make none text fields currently not searchable

### DIFF
--- a/packages/seal/Schema/Field/BooleanField.php
+++ b/packages/seal/Schema/Field/BooleanField.php
@@ -18,6 +18,10 @@ final class BooleanField extends AbstractField
         bool $sortable = false,
         array $options = []
     ) {
+        if ($searchable === true) {
+            throw new \InvalidArgumentException('Searchability for BooleanField is not yet implemented: https://github.com/schranz-search/schranz-search/issues/97');
+        }
+
         parent::__construct(
             $name,
             $multiple,

--- a/packages/seal/Schema/Field/DateTimeField.php
+++ b/packages/seal/Schema/Field/DateTimeField.php
@@ -18,6 +18,10 @@ final class DateTimeField extends AbstractField
         bool $sortable = false,
         array $options = []
     ) {
+        if ($searchable === true) {
+            throw new \InvalidArgumentException('Searchability for DateTimeField is not yet implemented: https://github.com/schranz-search/schranz-search/issues/97');
+        }
+
         parent::__construct(
             $name,
             $multiple,

--- a/packages/seal/Schema/Field/DateTimeField.php
+++ b/packages/seal/Schema/Field/DateTimeField.php
@@ -13,7 +13,7 @@ final class DateTimeField extends AbstractField
     public function __construct(
         string $name,
         bool $multiple = false,
-        bool $searchable = true,
+        bool $searchable = false,
         bool $filterable = false,
         bool $sortable = false,
         array $options = []

--- a/packages/seal/Schema/Field/FloatField.php
+++ b/packages/seal/Schema/Field/FloatField.php
@@ -18,6 +18,10 @@ final class FloatField extends AbstractField
         bool $sortable = false,
         array $options = []
     ) {
+        if ($searchable === true) {
+            throw new \InvalidArgumentException('Searchability for FloatField is not yet implemented: https://github.com/schranz-search/schranz-search/issues/97');
+        }
+
         parent::__construct(
             $name,
             $multiple,

--- a/packages/seal/Schema/Field/IntegerField.php
+++ b/packages/seal/Schema/Field/IntegerField.php
@@ -18,6 +18,10 @@ final class IntegerField extends AbstractField
         bool $sortable = false,
         array $options = []
     ) {
+        if ($searchable === true) {
+            throw new \InvalidArgumentException('Searchability for IntegerField is not yet implemented: https://github.com/schranz-search/schranz-search/issues/97');
+        }
+
         parent::__construct(
             $name,
             $multiple,

--- a/packages/seal/Testing/TestingHelper.php
+++ b/packages/seal/Testing/TestingHelper.php
@@ -45,7 +45,7 @@ class TestingHelper
             'footer' => new Field\ObjectField('footer', [
                 'title' => new Field\TextField('title'),
             ]),
-            'created' => new Field\DateTimeField('created', searchable: false, filterable: true, sortable: true),
+            'created' => new Field\DateTimeField('created', filterable: true, sortable: true),
             'commentsCount' => new Field\IntegerField('commentsCount', searchable: false, filterable: true, sortable: true),
             'rating' => new Field\FloatField('rating', searchable: false, filterable: true, sortable: true),
             'comments' => new Field\ObjectField('comments', [

--- a/packages/seal/Tests/Marshaller/FlattenMarshallerTest.php
+++ b/packages/seal/Tests/Marshaller/FlattenMarshallerTest.php
@@ -144,7 +144,7 @@ class FlattenMarshallerTest extends TestCase
                 'footer' => new Field\ObjectField('footer', [
                     'title' => new Field\TextField('title'),
                 ]),
-                'created' => new Field\DateTimeField('created', filterable: true, sortable: true),
+                'created' => new Field\DateTimeField('created', searchable: false, filterable: true, sortable: true),
                 'commentsCount' => new Field\IntegerField('commentsCount', searchable: false, filterable: true, sortable: true),
                 'rating' => new Field\FloatField('rating', searchable: false, filterable: true, sortable: true),
                 'comments' => new Field\ObjectField('comments', [

--- a/packages/seal/Tests/Marshaller/FlattenMarshallerTest.php
+++ b/packages/seal/Tests/Marshaller/FlattenMarshallerTest.php
@@ -144,7 +144,7 @@ class FlattenMarshallerTest extends TestCase
                 'footer' => new Field\ObjectField('footer', [
                     'title' => new Field\TextField('title'),
                 ]),
-                'created' => new Field\DateTimeField('created', searchable: false, filterable: true, sortable: true),
+                'created' => new Field\DateTimeField('created', filterable: true, sortable: true),
                 'commentsCount' => new Field\IntegerField('commentsCount', searchable: false, filterable: true, sortable: true),
                 'rating' => new Field\FloatField('rating', searchable: false, filterable: true, sortable: true),
                 'comments' => new Field\ObjectField('comments', [


### PR DESCRIPTION
While most engine support searchability on none text fields. Typesense does not yet #96. For this we currently disable the searchability for date, int, float, bool fields and waiting for some feedback instead if really required.

Issue:
 - https://github.com/schranz-search/schranz-search/issues/97