### PR TITLE
Type none text fields searchable as false

### DIFF
--- a/packages/seal/Schema/Field/BooleanField.php
+++ b/packages/seal/Schema/Field/BooleanField.php
@@ -8,6 +8,7 @@ namespace Schranz\Search\SEAL\Schema\Field;
 final class BooleanField extends AbstractField
 {
     /**
+     * @param false $searchable
      * @param array<string, mixed> $options
      */
     public function __construct(

--- a/packages/seal/Schema/Field/DateTimeField.php
+++ b/packages/seal/Schema/Field/DateTimeField.php
@@ -8,6 +8,7 @@ namespace Schranz\Search\SEAL\Schema\Field;
 final class DateTimeField extends AbstractField
 {
     /**
+     * @param false $searchable
      * @param array<string, mixed> $options
      */
     public function __construct(

--- a/packages/seal/Schema/Field/FloatField.php
+++ b/packages/seal/Schema/Field/FloatField.php
@@ -8,6 +8,7 @@ namespace Schranz\Search\SEAL\Schema\Field;
 final class FloatField extends AbstractField
 {
     /**
+     * @param false $searchable
      * @param array<string, mixed> $options
      */
     public function __construct(

--- a/packages/seal/Schema/Field/IntegerField.php
+++ b/packages/seal/Schema/Field/IntegerField.php
@@ -8,6 +8,7 @@ namespace Schranz\Search\SEAL\Schema\Field;
 final class IntegerField extends AbstractField
 {
     /**
+     * @param false $searchable
      * @param array<string, mixed> $options
      */
     public function __construct(


### PR DESCRIPTION
After some discussion with @wachterjohannes I decided that none text fields should not be searchable. This is part of #97 issue.