### PR TITLE
Wait some seconds before dropping Algolia replica indexes

### DIFF
--- a/packages/seal-algolia-adapter/.gitattributes
+++ b/packages/seal-algolia-adapter/.gitattributes
@@ -1,4 +1,5 @@
 .gitattributes export-ignore
 .gitignore export-ignore
 composer.lock export-ignore
+/bin/drop_all_indexes.php export-ignore
 /Tests export-ignore

--- a/packages/seal-algolia-adapter/AlgoliaSchemaManager.php
+++ b/packages/seal-algolia-adapter/AlgoliaSchemaManager.php
@@ -34,6 +34,10 @@ final class AlgoliaSchemaManager implements SchemaManagerInterface
             // we need to wait for removing of primary index
             // see also: https://www.algolia.com/doc/guides/sending-and-managing-data/manage-indices-and-apps/manage-indices/how-to/delete-indices/#delete-multiple-indices
             $indexResponse->wait();
+
+            // wait a little bit until replicas are converted to primary indices
+            // see also: https://support.algolia.com/hc/en-us/requests/540200
+            usleep(10_000_000);
         }
 
         foreach ($index->sortableFields as $field) {

--- a/packages/seal-algolia-adapter/bin/drop_all_indexes.php
+++ b/packages/seal-algolia-adapter/bin/drop_all_indexes.php
@@ -1,0 +1,42 @@
+#!/usr/bin/env php
+<?php
+
+// internal script to cleanup old algolia indices because of
+// https://github.com/schranz-search/schranz-search/issues/82
+
+/** @internal */
+
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+if (!isset($_ENV['ALGOLIA_APPLICATION_ID'])) {
+    if (!file_exists(dirname(__DIR__) . '/phpunit.xml')) {
+        throw new \Exception('phpunit.xml not found');
+    }
+
+    $data = file_get_contents(dirname(__DIR__) . '/phpunit.xml');
+
+    $xml = simplexml_load_string($data);
+
+    $applicationId = $xml->xpath('//env[@name="ALGOLIA_APPLICATION_ID"]')[0]['value']->__toString();
+    $adminId = $xml->xpath('//env[@name="ALGOLIA_ADMIN_API_KEY"]')[0]['value']->__toString();
+}
+
+$_ENV['ALGOLIA_APPLICATION_ID'] = $applicationId;
+$_ENV['ALGOLIA_ADMIN_API_KEY'] = $adminId;
+
+$client = \Schranz\Search\SEAL\Adapter\Algolia\Tests\ClientHelper::getClient();
+
+$return = 0;
+foreach ($client->listIndices()['items'] as $key => $value) {
+    echo 'Delete ... ' . ($value['name']) . PHP_EOL;
+
+    try {
+        $client->initIndex($value['name'])
+            ->delete();
+    } catch (\Exception $e) {
+        echo 'Errored ... ' . ($value['name']) . PHP_EOL;
+        $return = 1;
+    }
+}
+
+exit($return);

--- a/packages/seal-algolia-adapter/composer.json
+++ b/packages/seal-algolia-adapter/composer.json
@@ -39,7 +39,10 @@
         "phpunit/phpunit": "^9.5.27"
     },
     "scripts": {
-        "test": "vendor/bin/phpunit"
+        "test": [
+            "Composer\\Config::disableProcessTimeout",
+            "vendor/bin/phpunit"
+        ]
     },
     "repositories": [
         {

--- a/packages/seal-elasticsearch-adapter/composer.json
+++ b/packages/seal-elasticsearch-adapter/composer.json
@@ -42,7 +42,10 @@
         "php-http/message": "^1.0"
     },
     "scripts": {
-        "test": "vendor/bin/phpunit"
+        "test": [
+            "Composer\\Config::disableProcessTimeout",
+            "vendor/bin/phpunit"
+        ]
     },
     "repositories": [
         {

--- a/packages/seal-meilisearch-adapter/composer.json
+++ b/packages/seal-meilisearch-adapter/composer.json
@@ -41,7 +41,10 @@
         "http-interop/http-factory-guzzle": "^1.0"
     },
     "scripts": {
-        "test": "vendor/bin/phpunit"
+        "test": [
+            "Composer\\Config::disableProcessTimeout",
+            "vendor/bin/phpunit"
+        ]
     },
     "repositories": [
         {

--- a/packages/seal-memory-adapter/composer.json
+++ b/packages/seal-memory-adapter/composer.json
@@ -36,7 +36,10 @@
         "phpunit/phpunit": "^9.5.27"
     },
     "scripts": {
-        "test": "vendor/bin/phpunit"
+        "test": [
+            "Composer\\Config::disableProcessTimeout",
+            "vendor/bin/phpunit"
+        ]
     },
     "repositories": [
         {

--- a/packages/seal-opensearch-adapter/composer.json
+++ b/packages/seal-opensearch-adapter/composer.json
@@ -42,7 +42,10 @@
         "php-http/message": "^1.0"
     },
     "scripts": {
-        "test": "vendor/bin/phpunit"
+        "test": [
+            "Composer\\Config::disableProcessTimeout",
+            "vendor/bin/phpunit"
+        ]
     },
     "repositories": [
         {

--- a/packages/seal-redisearch-adapter/composer.json
+++ b/packages/seal-redisearch-adapter/composer.json
@@ -41,7 +41,10 @@
         "phpunit/phpunit": "^9.5.27"
     },
     "scripts": {
-        "test": "vendor/bin/phpunit"
+        "test": [
+            "Composer\\Config::disableProcessTimeout",
+            "vendor/bin/phpunit"
+        ]
     },
     "repositories": [
         {

--- a/packages/seal-solr-adapter/composer.json
+++ b/packages/seal-solr-adapter/composer.json
@@ -41,7 +41,10 @@
         "symfony/event-dispatcher": "^5.4 || ^6.0"
     },
     "scripts": {
-        "test": "vendor/bin/phpunit"
+        "test": [
+            "Composer\\Config::disableProcessTimeout",
+            "vendor/bin/phpunit"
+        ]
     },
     "repositories": [
         {

--- a/packages/seal-typesense-adapter/composer.json
+++ b/packages/seal-typesense-adapter/composer.json
@@ -45,7 +45,10 @@
         "monolog/monolog": "<2.0"
     },
     "scripts": {
-        "test": "vendor/bin/phpunit"
+        "test": [
+            "Composer\\Config::disableProcessTimeout",
+            "vendor/bin/phpunit"
+        ]
     },
     "repositories": [
         {

--- a/packages/seal/composer.json
+++ b/packages/seal/composer.json
@@ -40,7 +40,10 @@
         "phpunit/phpunit": "^9.5"
     },
     "scripts": {
-        "test": "vendor/bin/phpunit"
+        "test": [
+            "Composer\\Config::disableProcessTimeout",
+            "vendor/bin/phpunit"
+        ]
     },
     "minimum-stability": "dev"
 }


### PR DESCRIPTION
Currently the CI is failing a lot of times when try to drop the indices. That is why we currently add a workaround for manually waiting some seconds.

Algolia Ticket: https://support.algolia.com/hc/en-us/requests/540200