### PR TITLE
Add Schema Php File Loader

### DIFF
--- a/packages/seal/Schema/Field/FloatField.php
+++ b/packages/seal/Schema/Field/FloatField.php
@@ -14,7 +14,7 @@ final class FloatField extends AbstractField
     public function __construct(
         string $name,
         bool $multiple = false,
-        bool $searchable = true,
+        bool $searchable = false,
         bool $filterable = false,
         bool $sortable = false,
         array $options = []

--- a/packages/seal/Schema/Field/IntegerField.php
+++ b/packages/seal/Schema/Field/IntegerField.php
@@ -14,7 +14,7 @@ final class IntegerField extends AbstractField
     public function __construct(
         string $name,
         bool $multiple = false,
-        bool $searchable = true,
+        bool $searchable = false,
         bool $filterable = false,
         bool $sortable = false,
         array $options = []

--- a/packages/seal/Schema/Loader/LoaderInterface.php
+++ b/packages/seal/Schema/Loader/LoaderInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Schranz\Search\SEAL\Schema\Loader;
+
+use Schranz\Search\SEAL\Schema\Schema;
+
+interface LoaderInterface
+{
+    public function load(): Schema;
+}

--- a/packages/seal/Schema/Loader/PhpFileLoader.php
+++ b/packages/seal/Schema/Loader/PhpFileLoader.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Schranz\Search\SEAL\Schema\Loader;
+
+use Schranz\Search\SEAL\Schema\Field;
+use Schranz\Search\SEAL\Schema\Index;
+use Schranz\Search\SEAL\Schema\Schema;
+
+final class PhpFileLoader implements LoaderInterface
+{
+    /**
+     * @param string[] $directories
+     */
+    public function __construct(
+        private readonly array $directories,
+    ) {
+    }
+
+    public function load(): Schema
+    {
+        /** @var Index[] $indexes */
+        $indexes = [];
+
+        foreach ($this->directories as $directory) {
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($directory),
+                \RecursiveIteratorIterator::LEAVES_ONLY,
+            );
+
+            foreach ($iterator as $file) {
+                if ($file->getFileInfo()->getExtension() !== 'php') {
+                    continue;
+                }
+
+                $index = require $file->getRealPath();
+
+                if (!$index instanceof Index) {
+                    throw new \RuntimeException(sprintf('File "%s" must return an instance of "%s".', $file->getRealPath(), Index::class));
+                }
+
+                if(isset($indexes[$index->name])) {
+                    $index = new Index($index->name, $this->mergeFields($indexes[$index->name]->fields, $index->fields));
+                }
+
+                $indexes[$index->name] = $index;
+            }
+        }
+
+        return new Schema($indexes);
+    }
+
+    /**
+     * @param Field\AbstractField[] $fields
+     * @param Field\AbstractField[] $newFields
+     *
+     * @return Field\AbstractField[]
+     */
+    private function mergeFields(array $fields, array $newFields): array
+    {
+        foreach ($newFields as $name => $newField) {
+            if (isset($fields[$name])) {
+                if ($newField::class !== $fields[$name]::class) {
+                    throw new \RuntimeException(sprintf('Field "%s" must be of type "%s" but "%s" given.', $name, $fields[$name]::class, $newField::class));
+                }
+
+                $newField = $this->mergeField($fields[$name], $newField);
+            }
+
+            $fields[$newField->name] = $newField;
+        }
+
+        return $fields;
+    }
+
+    /**
+     * @template T of Field\AbstractField
+     *
+     * @param T $field
+     * @param T $newField
+     *
+     * @return T
+     */
+    private function mergeField(Field\AbstractField $field, Field\AbstractField $newField): Field\AbstractField
+    {
+        if ($newField instanceof Field\IdentifierField) {
+            return $newField;
+        }
+
+        if ($newField instanceof Field\TextField) {
+            return new Field\TextField(
+                $newField->name,
+                multiple: $newField->multiple,
+                searchable: $newField->searchable,
+                filterable: $newField->filterable,
+                sortable: $newField->sortable,
+                options: \array_replace_recursive($field->options, $newField->options),
+            );
+        }
+
+        if ($newField instanceof Field\IntegerField) {
+            return new Field\IntegerField(
+                $newField->name,
+                multiple: $newField->multiple,
+                searchable: $newField->searchable,
+                filterable: $newField->filterable,
+                sortable: $newField->sortable,
+                options: \array_replace_recursive($field->options, $newField->options),
+            );
+        }
+
+        if ($newField instanceof Field\FloatField) {
+            return new Field\FloatField(
+                $newField->name,
+                multiple: $newField->multiple,
+                searchable: $newField->searchable,
+                filterable: $newField->filterable,
+                sortable: $newField->sortable,
+                options: \array_replace_recursive($field->options, $newField->options),
+            );
+        }
+
+        if ($newField instanceof Field\DateTimeField) {
+            return new Field\DateTimeField(
+                $newField->name,
+                multiple: $newField->multiple,
+                searchable: $newField->searchable,
+                filterable: $newField->filterable,
+                sortable: $newField->sortable,
+                options: \array_replace_recursive($field->options, $newField->options),
+            );
+        }
+
+        if ($newField instanceof Field\ObjectField) {
+            return new Field\ObjectField(
+                $newField->name,
+                fields: $this->mergeFields($field->fields, $newField->fields),
+                multiple: $newField->multiple,
+                options: \array_replace_recursive($field->options, $newField->options),
+            );
+        }
+
+        if ($newField instanceof Field\TypedField) {
+            $types = $field->types;
+            foreach ($newField->types as $name => $newTypedFields) {
+                if (isset($types[$name])) {
+                    $types[$name] = $this->mergeFields($types[$name], $newTypedFields);
+
+                    continue;
+                }
+
+                $types[$name] = $newTypedFields;
+            }
+
+            return new Field\TypedField(
+                $newField->name,
+                typeField: $newField->typeField,
+                types: $types,
+                multiple: $newField->multiple,
+                options: \array_replace_recursive($field->options, $newField->options),
+            );
+        }
+
+        throw new \RuntimeException(sprintf(
+            'Field "%s" must be of type "%s" but "%s" given.',
+            $field->name,
+            Field\AbstractField::class,
+            get_class($field)
+        ));
+    }
+}

--- a/packages/seal/Tests/Schema/Loader/PhpFileLoaderTest.php
+++ b/packages/seal/Tests/Schema/Loader/PhpFileLoaderTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Schranz\Search\SEAL\Tests\Schema\Loader;
+
+use PHPUnit\Framework\TestCase;
+use Schranz\Search\SEAL\Schema\Loader\PhpFileLoader;
+
+class PhpFileLoaderTest extends TestCase
+{
+    public function testLoadBasic(): void
+    {
+        $schema = (new PhpFileLoader([__DIR__ . '/fixtures/basic']))->load();
+
+        $this->assertEqualsCanonicalizing(
+            [
+                'news',
+                'blog',
+            ],
+            array_keys($schema->indexes),
+        );
+    }
+
+    public function testLoadMerge(): void
+    {
+        $schema = (new PhpFileLoader([__DIR__ . '/fixtures/merge']))->load();
+
+        $this->assertSame(['blog'], array_keys($schema->indexes));
+
+        $this->assertSame(
+            [
+                'id',
+                'title',
+                'description',
+                'blocks',
+                'footerText',
+            ],
+            array_keys($schema->indexes['blog']->fields),
+        );
+
+        $this->assertSame(
+            [
+                'option1' => true,
+                'option2' => true,
+            ],
+            $schema->indexes['blog']->fields['description']->options,
+        );
+
+        $this->assertSame(
+            [
+                'text',
+                'embed',
+                'gallery',
+            ],
+            array_keys($schema->indexes['blog']->fields['blocks']->types),
+        );
+
+        $this->assertTrue(
+            $schema->indexes['blog']->fields['blocks']->types['gallery']['media']->multiple,
+        );
+    }
+}

--- a/packages/seal/Tests/Schema/Loader/fixtures/basic/news.php
+++ b/packages/seal/Tests/Schema/Loader/fixtures/basic/news.php
@@ -1,0 +1,41 @@
+<?php
+
+use Schranz\Search\SEAL\Schema\Field;
+use Schranz\Search\SEAL\Schema\Index;
+
+return new Index('news', [
+    'id' => new Field\IdentifierField('id'),
+    'title' => new Field\TextField('title'),
+    'header' => new Field\TypedField('header', 'type', [
+        'image' => [
+            'media' => new Field\IntegerField('media'),
+        ],
+        'video' => [
+            'media' => new Field\TextField('media'),
+        ],
+    ]),
+    'article' => new Field\TextField('article'),
+    'blocks' => new Field\TypedField('blocks', 'type', [
+        'text' => [
+            'title' => new Field\TextField('title'),
+            'description' => new Field\TextField('description'),
+            'media' => new Field\IntegerField('media', multiple: true),
+        ],
+        'embed' => [
+            'title' => new Field\TextField('title'),
+            'media' => new Field\TextField('media'),
+        ],
+    ], multiple: true),
+    'footer' => new Field\ObjectField('footer', [
+        'title' => new Field\TextField('title'),
+    ]),
+    'created' => new Field\DateTimeField('created'),
+    'commentsCount' => new Field\IntegerField('commentsCount'),
+    'rating' => new Field\FloatField('rating'),
+    'comments' => new Field\ObjectField('comments', [
+        'email' => new Field\TextField('email'),
+        'text' => new Field\TextField('title'),
+    ], multiple: true),
+    'tags' => new Field\TextField('tags', multiple: true),
+    'categoryIds' => new Field\IntegerField('categoryIds', multiple: true),
+]);

--- a/packages/seal/Tests/Schema/Loader/fixtures/basic/subdirectory/blog.php
+++ b/packages/seal/Tests/Schema/Loader/fixtures/basic/subdirectory/blog.php
@@ -1,0 +1,10 @@
+<?php
+
+use Schranz\Search\SEAL\Schema\Field;
+use Schranz\Search\SEAL\Schema\Index;
+
+return new Index('blog', [
+    'id' => new Field\IdentifierField('id'),
+    'title' => new Field\TextField('title'),
+    'description' => new Field\TextField('description'),
+]);

--- a/packages/seal/Tests/Schema/Loader/fixtures/merge/blog_merge_1.php
+++ b/packages/seal/Tests/Schema/Loader/fixtures/merge/blog_merge_1.php
@@ -1,0 +1,21 @@
+<?php
+
+use Schranz\Search\SEAL\Schema\Field;
+use Schranz\Search\SEAL\Schema\Index;
+
+return new Index('blog', [
+    'id' => new Field\IdentifierField('id'),
+    'title' => new Field\TextField('title'),
+    'description' => new Field\TextField('description', options: ['option1' => true]),
+    'blocks' => new Field\TypedField('blocks', 'type', [
+        'text' => [
+            'title' => new Field\TextField('title'),
+            'description' => new Field\TextField('description'),
+            'media' => new Field\IntegerField('media', multiple: true),
+        ],
+        'embed' => [
+            'title' => new Field\TextField('title'),
+            'media' => new Field\TextField('media'),
+        ],
+    ], multiple: true),
+]);

--- a/packages/seal/Tests/Schema/Loader/fixtures/merge/blog_merge_2.php
+++ b/packages/seal/Tests/Schema/Loader/fixtures/merge/blog_merge_2.php
@@ -1,0 +1,14 @@
+<?php
+
+use Schranz\Search\SEAL\Schema\Field;
+use Schranz\Search\SEAL\Schema\Index;
+
+return new Index('blog', [
+    'description' => new Field\TextField('description', options: ['option2' => true]),
+    'blocks' => new Field\TypedField('blocks', 'type', [
+        'gallery' => [
+            'media' => new Field\TextField('media', multiple: true),
+        ],
+    ], multiple: true),
+    'footerText' => new Field\TextField('footerText'),
+]);


### PR DESCRIPTION
As part of the Framework integration #113 and providing formats #115. We first implement the `PhpFileLoader` to load a Index Schema directly from a `.php` file:

```php
<?php

use Schranz\Search\SEAL\Schema\Field;
use Schranz\Search\SEAL\Schema\Index;

return new Index('blog', [
    'id' => new Field\IdentifierField('id'),
    'title' => new Field\TextField('title'),
    'description' => new Field\TextField('description'),
]);
```