### PR TITLE
Fix order of imported index definition files

### DIFF
--- a/packages/seal/Schema/Loader/PhpFileLoader.php
+++ b/packages/seal/Schema/Loader/PhpFileLoader.php
@@ -27,6 +27,7 @@ final class PhpFileLoader implements LoaderInterface
                 \RecursiveIteratorIterator::LEAVES_ONLY,
             );
 
+            $pathIndexes = [];
             foreach ($iterator as $file) {
                 if ($file->getFileInfo()->getExtension() !== 'php') {
                     continue;
@@ -38,6 +39,12 @@ final class PhpFileLoader implements LoaderInterface
                     throw new \RuntimeException(sprintf('File "%s" must return an instance of "%s".', $file->getRealPath(), Index::class));
                 }
 
+                $pathIndexes[$file->getRealPath()] = $index;
+            }
+
+            \ksort($pathIndexes); // make sure to import the files on all system in the same order
+
+            foreach ($pathIndexes as $index) {
                 if(isset($indexes[$index->name])) {
                     $index = new Index($index->name, $this->mergeFields($indexes[$index->name]->fields, $index->fields));
                 }


### PR DESCRIPTION
The order is currently random and ends so in a strange state. To avoid that we do a ksort by path before doing merging of different indexes. This way CI error in Seal Core of https://github.com/schranz-search/schranz-search/pull/120 should be fixed.