### PR TITLE
Update meilisearch Adapter to support 1.0

### DIFF
--- a/.examples/symfony/composer.lock
+++ b/.examples/symfony/composer.lock
@@ -3675,16 +3675,16 @@
         },
         {
             "name": "meilisearch/meilisearch-php",
-            "version": "v0.26.1",
+            "version": "v1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/meilisearch/meilisearch-php.git",
-                "reference": "05db1b22821dc34a9b71cfbe78189ec4abe600ce"
+                "reference": "11f12a2e36a6c616ffa5c6ed32272f8c870aaf69"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/meilisearch/meilisearch-php/zipball/05db1b22821dc34a9b71cfbe78189ec4abe600ce",
-                "reference": "05db1b22821dc34a9b71cfbe78189ec4abe600ce",
+                "url": "https://api.github.com/repos/meilisearch/meilisearch-php/zipball/11f12a2e36a6c616ffa5c6ed32272f8c870aaf69",
+                "reference": "11f12a2e36a6c616ffa5c6ed32272f8c870aaf69",
                 "shasum": ""
             },
             "require": {
@@ -3699,7 +3699,7 @@
                 "guzzlehttp/guzzle": "^7.1",
                 "http-interop/http-factory-guzzle": "^1.0",
                 "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "1.9.3",
+                "phpstan/phpstan": "1.9.14",
                 "phpstan/phpstan-deprecation-rules": "^1.0",
                 "phpstan/phpstan-phpunit": "^1.0",
                 "phpstan/phpstan-strict-rules": "^1.1",
@@ -3737,9 +3737,9 @@
             ],
             "support": {
                 "issues": "https://github.com/meilisearch/meilisearch-php/issues",
-                "source": "https://github.com/meilisearch/meilisearch-php/tree/v0.26.1"
+                "source": "https://github.com/meilisearch/meilisearch-php/tree/v1.0.0"
             },
-            "time": "2022-12-16T17:11:53+00:00"
+            "time": "2023-02-06T13:25:35+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -5430,10 +5430,10 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-meilisearch-adapter",
-                "reference": "fb8d9e8f5b0d15f88ed3d493fcbd93099bf8bc3a"
+                "reference": "14d57dd14777a9cd379dbc9ff61dfe076b467d1f"
             },
             "require": {
-                "meilisearch/meilisearch-php": "^0.26.1",
+                "meilisearch/meilisearch-php": "^1.0.0",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "schranz-search/seal": "^0.1"

--- a/.examples/symfony/docker-compose.yml
+++ b/.examples/symfony/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - elasticsearch-data:/usr/share/elasticsearch/data
 
   meilisearch:
-    image: getmeili/meilisearch:v0.30
+    image: getmeili/meilisearch:v1.0
     environment:
       MEILI_ENV: development
     ports:

--- a/integrations/symfony/composer.lock
+++ b/integrations/symfony/composer.lock
@@ -2295,16 +2295,16 @@
         },
         {
             "name": "meilisearch/meilisearch-php",
-            "version": "v0.26.1",
+            "version": "v1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/meilisearch/meilisearch-php.git",
-                "reference": "05db1b22821dc34a9b71cfbe78189ec4abe600ce"
+                "reference": "11f12a2e36a6c616ffa5c6ed32272f8c870aaf69"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/meilisearch/meilisearch-php/zipball/05db1b22821dc34a9b71cfbe78189ec4abe600ce",
-                "reference": "05db1b22821dc34a9b71cfbe78189ec4abe600ce",
+                "url": "https://api.github.com/repos/meilisearch/meilisearch-php/zipball/11f12a2e36a6c616ffa5c6ed32272f8c870aaf69",
+                "reference": "11f12a2e36a6c616ffa5c6ed32272f8c870aaf69",
                 "shasum": ""
             },
             "require": {
@@ -2319,7 +2319,7 @@
                 "guzzlehttp/guzzle": "^7.1",
                 "http-interop/http-factory-guzzle": "^1.0",
                 "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "1.9.3",
+                "phpstan/phpstan": "1.9.14",
                 "phpstan/phpstan-deprecation-rules": "^1.0",
                 "phpstan/phpstan-phpunit": "^1.0",
                 "phpstan/phpstan-strict-rules": "^1.1",
@@ -2357,9 +2357,9 @@
             ],
             "support": {
                 "issues": "https://github.com/meilisearch/meilisearch-php/issues",
-                "source": "https://github.com/meilisearch/meilisearch-php/tree/v0.26.1"
+                "source": "https://github.com/meilisearch/meilisearch-php/tree/v1.0.0"
             },
-            "time": "2022-12-16T17:11:53+00:00"
+            "time": "2023-02-06T13:25:35+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -4128,10 +4128,10 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-meilisearch-adapter",
-                "reference": "fb8d9e8f5b0d15f88ed3d493fcbd93099bf8bc3a"
+                "reference": "14d57dd14777a9cd379dbc9ff61dfe076b467d1f"
             },
             "require": {
-                "meilisearch/meilisearch-php": "^0.26.1",
+                "meilisearch/meilisearch-php": "^1.0.0",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "schranz-search/seal": "^0.1"

--- a/packages/seal-meilisearch-adapter/composer.json
+++ b/packages/seal-meilisearch-adapter/composer.json
@@ -32,7 +32,7 @@
     "require": {
         "php": "^8.1",
         "schranz-search/seal": "^0.1",
-        "meilisearch/meilisearch-php": "^0.26.1",
+        "meilisearch/meilisearch-php": "^1.0.0",
         "psr/container": "^1.0 || ^2.0"
     },
     "require-dev": {

--- a/packages/seal-meilisearch-adapter/composer.lock
+++ b/packages/seal-meilisearch-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dd8b72e42d90c51566195a07f318e55d",
+    "content-hash": "4e269b4ecb13255a2a15652040cace8e",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -75,16 +75,16 @@
         },
         {
             "name": "meilisearch/meilisearch-php",
-            "version": "v0.26.1",
+            "version": "v1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/meilisearch/meilisearch-php.git",
-                "reference": "05db1b22821dc34a9b71cfbe78189ec4abe600ce"
+                "reference": "11f12a2e36a6c616ffa5c6ed32272f8c870aaf69"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/meilisearch/meilisearch-php/zipball/05db1b22821dc34a9b71cfbe78189ec4abe600ce",
-                "reference": "05db1b22821dc34a9b71cfbe78189ec4abe600ce",
+                "url": "https://api.github.com/repos/meilisearch/meilisearch-php/zipball/11f12a2e36a6c616ffa5c6ed32272f8c870aaf69",
+                "reference": "11f12a2e36a6c616ffa5c6ed32272f8c870aaf69",
                 "shasum": ""
             },
             "require": {
@@ -99,7 +99,7 @@
                 "guzzlehttp/guzzle": "^7.1",
                 "http-interop/http-factory-guzzle": "^1.0",
                 "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "1.9.3",
+                "phpstan/phpstan": "1.9.14",
                 "phpstan/phpstan-deprecation-rules": "^1.0",
                 "phpstan/phpstan-phpunit": "^1.0",
                 "phpstan/phpstan-strict-rules": "^1.1",
@@ -137,9 +137,9 @@
             ],
             "support": {
                 "issues": "https://github.com/meilisearch/meilisearch-php/issues",
-                "source": "https://github.com/meilisearch/meilisearch-php/tree/v0.26.1"
+                "source": "https://github.com/meilisearch/meilisearch-php/tree/v1.0.0"
             },
-            "time": "2022-12-16T17:11:53+00:00"
+            "time": "2023-02-06T13:25:35+00:00"
         },
         {
             "name": "php-http/client-common",

--- a/packages/seal-meilisearch-adapter/docker-compose.yml
+++ b/packages/seal-meilisearch-adapter/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   meilisearch:
-    image: getmeili/meilisearch:v0.30
+    image: getmeili/meilisearch:v1.0
     environment:
       MEILI_ENV: development
     ports:


### PR DESCRIPTION
The meilisearch adapter now support the 1.0 version php client and server of meilisearch.