### PR TITLE
Add conflict for not supported integration versions

### DIFF
--- a/.examples/symfony/composer.lock
+++ b/.examples/symfony/composer.lock
@@ -424,7 +424,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../integrations/symfony",
-                "reference": "b0893245a535cc07e3adff39dcdf48a0202985b7"
+                "reference": "c00bd4c75e95c42584dc4966250c4494d6c96e1a"
             },
             "require": {
                 "php": "^8.1",
@@ -432,6 +432,18 @@
                 "symfony/config": "^6.1",
                 "symfony/dependency-injection": "^6.1",
                 "symfony/http-kernel": "^6.1"
+            },
+            "conflict": {
+                "schranz-search/seal-algolia-adapter": "<0.1, >=0.2",
+                "schranz-search/seal-elasticsearch-adapter": "<0.1, >=0.2",
+                "schranz-search/seal-meilisearch-adapter": "<0.1, >=0.2",
+                "schranz-search/seal-memory-adapter": "<0.1, >=0.2",
+                "schranz-search/seal-multi-adapter": "<0.1, >=0.2",
+                "schranz-search/seal-opensearch-adapter": "<0.1, >=0.2",
+                "schranz-search/seal-read-write-adapter": "<0.1, >=0.2",
+                "schranz-search/seal-redisearch-adapter": "<0.1, >=0.2",
+                "schranz-search/seal-solr-adapter": "<0.1, >=0.2",
+                "schranz-search/seal-typesense-adapter": "<0.1, >=0.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5.27",
@@ -479,6 +491,7 @@
             "keywords": [
                 "abstraction",
                 "algolia",
+                "bundle",
                 "elasticsearch",
                 "integration",
                 "meilisearch",

--- a/integrations/symfony/composer.json
+++ b/integrations/symfony/composer.json
@@ -19,6 +19,7 @@
         "redisearch",
         "algolia",
         "integration",
+        "bundle",
         "symfony"
     ],
     "autoload": {
@@ -59,6 +60,18 @@
         "schranz-search/seal-redisearch-adapter": "^0.1",
         "schranz-search/seal-solr-adapter": "^0.1",
         "schranz-search/seal-typesense-adapter": "^0.1"
+    },
+    "conflict": {
+        "schranz-search/seal-algolia-adapter": "<0.1, >=0.2",
+        "schranz-search/seal-elasticsearch-adapter": "<0.1, >=0.2",
+        "schranz-search/seal-meilisearch-adapter": "<0.1, >=0.2",
+        "schranz-search/seal-memory-adapter": "<0.1, >=0.2",
+        "schranz-search/seal-multi-adapter": "<0.1, >=0.2",
+        "schranz-search/seal-opensearch-adapter": "<0.1, >=0.2",
+        "schranz-search/seal-read-write-adapter": "<0.1, >=0.2",
+        "schranz-search/seal-redisearch-adapter": "<0.1, >=0.2",
+        "schranz-search/seal-solr-adapter": "<0.1, >=0.2",
+        "schranz-search/seal-typesense-adapter": "<0.1, >=0.2"
     },
     "scripts": {
         "test": [

--- a/integrations/symfony/composer.lock
+++ b/integrations/symfony/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "72f6b85b8996f68bda168dfaa6214e64",
+    "content-hash": "cd7ed3f27f11942836562cc49dc7effa",
     "packages": [
         {
             "name": "psr/container",


### PR DESCRIPTION
If we are not conflicting not supported adapter versions it could happen that the `symfony-integration` package is used with a not supported version. This way we make sure that this kind of `optional-dependencies` work like expected.