### PR TITLE
Define RediSearch Adapter as experimental

### DIFF
--- a/.github/workflows/callable-lint.yml
+++ b/.github/workflows/callable-lint.yml
@@ -12,13 +12,6 @@ jobs:
         name: "Lint"
         runs-on: ubuntu-latest
 
-        strategy:
-            fail-fast: false
-            matrix:
-                include:
-                    - php-version: '8.1'
-                      dependency-versions: 'highest'
-
         steps:
             - name: Checkout project
               uses: actions/checkout@v3
@@ -26,7 +19,7 @@ jobs:
             - name: Install and configure PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: ${{ matrix.php-version }}
+                  php-version: '8.1'
                   tools: 'composer:v2'
                   ini-values: memory_limit=-1
                   coverage: none
@@ -37,7 +30,7 @@ jobs:
                   COMPOSER_ROOT_VERSION: 0.1-dev
               with:
                   working-directory: ${{ inputs.directory }}
-                  dependency-versions: ${{ matrix.dependency-versions }}
+                  dependency-versions: 'highest'
 
             - name: Run lints
               run: composer lint

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The following adapters are available:
 - [MeilisearchAdapter](packages/seal-meilisearch-adapter): `schranz-search/seal-meilisearch-adapter`
 - [AlgoliaAdapter](packages/seal-algolia-adapter): `schranz-search/seal-algolia-adapter`
 - [SolrAdapter](packages/seal-solr-adapter): `schranz-search/seal-solr-adapter`
-- [RediSearchAdapter](packages/seal-redisearch-adapter): `schranz-search/seal-redisearch-adapter`
+- [RediSearchAdapter](packages/seal-redisearch-adapter): `schranz-search/seal-redisearch-adapter` (experimental)
 - [TypesenseAdapter](packages/seal-typesense-adapter): `schranz-search/seal-typesense-adapter`
 - ... more coming soon
 

--- a/packages/seal-redisearch-adapter/README.md
+++ b/packages/seal-redisearch-adapter/README.md
@@ -23,6 +23,10 @@ Use [composer](https://getcomposer.org/) for install the package:
 composer require schranz-search/seal schranz-search/seal-redisearch-adapter
 ```
 
+> **Warning**
+> Because of some [issues](https://github.com/schranz-search/schranz-search/issues/92) on RediSearch side, this Adapter
+> is in a stage which we can not recommend it to use it for production, and so marked as `@experimental`.
+
 ## Usage.
 
 The following code shows how to create an Engine using this Adapter:

--- a/packages/seal-redisearch-adapter/RediSearchAdapter.php
+++ b/packages/seal-redisearch-adapter/RediSearchAdapter.php
@@ -9,6 +9,9 @@ use Schranz\Search\SEAL\Adapter\IndexerInterface;
 use Schranz\Search\SEAL\Adapter\SchemaManagerInterface;
 use Schranz\Search\SEAL\Adapter\SearcherInterface;
 
+/**
+ * @experimental
+ */
 final class RediSearchAdapter implements AdapterInterface
 {
     private readonly SchemaManagerInterface $schemaManager;

--- a/packages/seal-redisearch-adapter/RediSearchIndexer.php
+++ b/packages/seal-redisearch-adapter/RediSearchIndexer.php
@@ -10,6 +10,9 @@ use Schranz\Search\SEAL\Schema\Index;
 use Schranz\Search\SEAL\Task\SyncTask;
 use Schranz\Search\SEAL\Task\TaskInterface;
 
+/**
+ * @experimental
+ */
 final class RediSearchIndexer implements IndexerInterface
 {
     private readonly Marshaller $marshaller;

--- a/packages/seal-redisearch-adapter/RediSearchSchemaManager.php
+++ b/packages/seal-redisearch-adapter/RediSearchSchemaManager.php
@@ -10,6 +10,9 @@ use Schranz\Search\SEAL\Schema\Index;
 use Schranz\Search\SEAL\Task\SyncTask;
 use Schranz\Search\SEAL\Task\TaskInterface;
 
+/**
+ * @experimental
+ */
 final class RediSearchSchemaManager implements SchemaManagerInterface
 {
     public function __construct(

--- a/packages/seal-redisearch-adapter/RediSearchSearcher.php
+++ b/packages/seal-redisearch-adapter/RediSearchSearcher.php
@@ -11,6 +11,9 @@ use Schranz\Search\SEAL\Search\Condition;
 use Schranz\Search\SEAL\Search\Result;
 use Schranz\Search\SEAL\Search\Search;
 
+/**
+ * @experimental
+ */
 final class RediSearchSearcher implements SearcherInterface
 {
     private readonly Marshaller $marshaller;

--- a/packages/seal/README.md
+++ b/packages/seal/README.md
@@ -42,7 +42,7 @@ The following adapters are available:
  - [MeilisearchAdapter](../seal-meilisearch-adapter): `schranz-search/seal-meilisearch-adapter`
  - [AlgoliaAdapter](../seal-algolia-adapter): `schranz-search/seal-algolia-adapter`
  - [SolrAdapter](../seal-solr-adapter): `schranz-search/seal-solr-adapter`
- - [RediSearchAdapter](../seal-redisearch-adapter): `schranz-search/seal-redisearch-adapter`
+ - [RediSearchAdapter](../seal-redisearch-adapter): `schranz-search/seal-redisearch-adapter` (experimental)
  - [TypesenseAdapter](../seal-typesense-adapter): `schranz-search/seal-typesense-adapter`
  - ... more coming soon
 


### PR DESCRIPTION
> **Warning**
> Because of some [issues](https://github.com/schranz-search/schranz-search/issues/92) on RediSearch side, the RediSearchAdapter is in a stage which we can not recommend it to use it for production, and so marked as `@experimental`.
