### PR TITLE
Fix multi adapter DSN example

### DIFF
--- a/.examples/symfony/config/packages/schranz_search.yaml
+++ b/.examples/symfony/config/packages/schranz_search.yaml
@@ -19,6 +19,6 @@ schranz_search:
 
         # ...
         multi:
-            dsn: 'multi://elasticsearch?opensearch'
+            dsn: 'multi://elasticsearch?adapters[]=opensearch'
         read-write:
             dsn: 'read-write://elasticsearch?write=multi'

--- a/integrations/symfony/README.md
+++ b/integrations/symfony/README.md
@@ -74,7 +74,7 @@ schranz_search:
 
         # ...
         multi:
-            dsn: 'multi://elasticsearch?opensearch'
+            dsn: 'multi://elasticsearch?adapters[]=opensearch'
         read-write:
             dsn: 'read-write://elasticsearch?write=multi'
 ```


### PR DESCRIPTION
The current example is false as it doesn't use the `adapters` query parameter for additional adapters.