### PR TITLE
Add engine registry to SEAL Core

### DIFF
--- a/.examples/symfony/src/Controller/SearchController.php
+++ b/.examples/symfony/src/Controller/SearchController.php
@@ -6,14 +6,17 @@ namespace App\Controller;
 
 use Schranz\Search\SEAL\Adapter\AdapterInterface;
 use Schranz\Search\SEAL\Engine;
+use Schranz\Search\SEAL\EngineRegistry;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 class SearchController
 {
     #[Route('/', name: 'home')]
-    public function index(): Response
+    public function index(EngineRegistry $engineRegistry): Response
     {
+        $engineNames = implode(', ', \array_keys([...$engineRegistry->getEngines()]));
+
         return new Response(
             <<<HTML
             <!doctype html>
@@ -35,9 +38,13 @@ class SearchController
                         <li><a href="/multi">Multi</a></li>
                         <li><a href="/read-write">Read-Write</a></li>
                     </ul>
+                    
+                    <div>
+                        <strong>Registred Engines</strong>: $engineNames
+                    </div>
                 </body>
             </html>
-HTML
+            HTML
         );
     }
 

--- a/integrations/symfony/config/services.php
+++ b/integrations/symfony/config/services.php
@@ -15,11 +15,19 @@ use Schranz\Search\SEAL\Adapter\ReadWrite\ReadWriteAdapterFactory;
 use Schranz\Search\SEAL\Adapter\RediSearch\RediSearchAdapterFactory;
 use Schranz\Search\SEAL\Adapter\Solr\SolrAdapterFactory;
 use Schranz\Search\SEAL\Adapter\Typesense\TypesenseAdapterFactory;
+use Schranz\Search\SEAL\EngineRegistry;
 
 /*
  * @internal
  */
 return static function (ContainerConfigurator $container) {
+    $container->services()
+        ->set('schranz_search.enginy_registry', EngineRegistry::class)
+        ->args([
+            tagged_iterator('schranz_search.engine', 'name'),
+        ])
+        ->alias(EngineRegistry::class, 'schranz_search.enginy_registry');
+
     $container->services()
         ->set('schranz_search.adapter_factory', AdapterFactory::class)
             ->args([

--- a/integrations/symfony/src/SearchBundle.php
+++ b/integrations/symfony/src/SearchBundle.php
@@ -91,7 +91,8 @@ class SearchBundle extends AbstractBundle
                 ->setArguments([
                     new Reference($adapterServiceId),
                     new Reference($schemaId),
-                ]);
+                ])
+                ->addTag('schranz_search.engine', ['name' => $name]);
 
             if ('default' === $name) {
                 $builder->setAlias(Engine::class, $engineServiceId);
@@ -104,6 +105,6 @@ class SearchBundle extends AbstractBundle
             );
         }
 
-        $container->import('../config/services.php');
+        $container->import(\dirname(__DIR__) . '/config/services.php');
     }
 }

--- a/packages/seal/EngineRegistry.php
+++ b/packages/seal/EngineRegistry.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Schranz\Search\SEAL;
+
+final class EngineRegistry
+{
+    /**
+     * @var array<string, Engine>
+     */
+    private array $engines;
+
+    /**
+     * @param iterable<string, Engine> $engines
+     */
+    public function __construct(
+        iterable $engines,
+    ) {
+        $this->engines = [...$engines];
+    }
+
+    /**
+     * @return iterable<string, Engine>
+     */
+    public function getEngines(): iterable
+    {
+        return $this->engines;
+    }
+
+    public function getEngine(string $name): Engine
+    {
+        if (!isset($this->engines[$name])) {
+            throw new \InvalidArgumentException(
+                'Unknown Search engine: "' . $name . '" available engines are "' . \implode('", "', \array_keys($this->engines)) . '".',
+            );
+        }
+
+        return $this->engines[$name];
+    }
+}


### PR DESCRIPTION
The `EngineRegistry` allow in the Integrations that example a CLI command can access easily all engines.