### PR TITLE
Add phpstan workaround for not supporting optional function generics

### DIFF
--- a/packages/seal/Adapter/IndexerInterface.php
+++ b/packages/seal/Adapter/IndexerInterface.php
@@ -10,21 +10,17 @@ use Schranz\Search\SEAL\Task\TaskInterface;
 interface IndexerInterface
 {
     /**
-     * @template T of bool
-     *
      * @param array<string, mixed> $document
-     * @param array{return_slow_promise_result?: T} $options
+     * @param array{return_slow_promise_result?: true} $options
      *
-     * @return (T is true ? TaskInterface<array<string, mixed>> : null)
+     * @return ($options is non-empty-array ? TaskInterface<array<string, mixed>> : null)
      */
     public function save(Index $index, array $document, array $options = []): ?TaskInterface;
 
     /**
-     * @template T of bool
+     * @param array{return_slow_promise_result?: true} $options
      *
-     * @param array{return_slow_promise_result?: T} $options
-     *
-     * @return (T is true ? TaskInterface<null|void> : null)
+     * @return ($options is non-empty-array ? TaskInterface<null|void> : null)
      */
     public function delete(Index $index, string $identifier, array $options = []): ?TaskInterface;
 }

--- a/packages/seal/Engine.php
+++ b/packages/seal/Engine.php
@@ -21,12 +21,10 @@ final class Engine
     }
 
     /**
-     * @template T of bool
-     *
      * @param array<string, mixed> $document
-     * @param array{return_slow_promise_result?: T} $options
+     * @param array{return_slow_promise_result?: true} $options
      *
-     * @return (T is true ? TaskInterface<array<string, mixed>> : null)
+     * @return ($options is non-empty-array ? TaskInterface<array<string, mixed>> : null)
      */
     public function saveDocument(string $index, array $document, array $options = []): ?TaskInterface
     {
@@ -38,11 +36,9 @@ final class Engine
     }
 
     /**
-     * @template T of bool
+     * @param array{return_slow_promise_result?: true} $options
      *
-     * @param array{return_slow_promise_result?: T} $options
-     *
-     * @return (T is true ? TaskInterface<null|void> : null)
+     * @return ($options is non-empty-array ? TaskInterface<null|void> : null)
      */
     public function deleteDocument(string $index, string $identifier, array $options = []): ?TaskInterface
     {
@@ -89,11 +85,9 @@ final class Engine
     }
 
     /**
-     * @template T of bool
+     * @param array{return_slow_promise_result?: true} $options
      *
-     * @param array{return_slow_promise_result?: T} $options
-     *
-     * @return (T is true ? TaskInterface<null|void> : null)
+     * @return ($options is non-empty-array ? TaskInterface<null|void> : null)
      */
     public function createIndex(string $index, array $options = []): ?TaskInterface
     {
@@ -101,11 +95,9 @@ final class Engine
     }
 
     /**
-     * @template T of bool
+     * @param array{return_slow_promise_result?: true} $options
      *
-     * @param array{return_slow_promise_result?: T} $options
-     *
-     * @return (T is true ? TaskInterface<null|void> : null)
+     * @return ($options is non-empty-array ? TaskInterface<null|void> : null)
      */
     public function dropIndex(string $index, array $options = []): ?TaskInterface
     {
@@ -118,11 +110,9 @@ final class Engine
     }
 
     /**
-     * @template T of bool
+     * @param array{return_slow_promise_result?: bool} $options
      *
-     * @param array{return_slow_promise_result?: T} $options
-     *
-     * @return (T is true ? TaskInterface<null> : null)
+     * @return ($options is non-empty-array ? TaskInterface<null> : null)
      */
     public function createSchema(array $options = []): ?TaskInterface
     {
@@ -139,11 +129,9 @@ final class Engine
     }
 
     /**
-     * @template T of bool
+     * @param array{return_slow_promise_result?: bool} $options
      *
-     * @param array{return_slow_promise_result?: T} $options
-     *
-     * @return (T is true ? TaskInterface<null> : null)
+     * @return ($options is non-empty-array ? TaskInterface<null> : null)
      */
     public function dropSchema(array $options = []): ?TaskInterface
     {


### PR DESCRIPTION
Currently the `T` is not correctly resolved when `return_slow_promise_result` is not given so we need change this typehint to avoid strange errors on client side which uses this interfaces.