### PR TITLE
Fix AdapterFactory for Meilisearch and Redisearch

### DIFF
--- a/packages/seal-meilisearch-adapter/MeilisearchAdapterFactory.php
+++ b/packages/seal-meilisearch-adapter/MeilisearchAdapterFactory.php
@@ -33,6 +33,7 @@ class MeilisearchAdapterFactory implements AdapterFactoryInterface
      *     host: string,
      *     port?: int,
      *     user?: string,
+     *     query: array<string, string>,
      * } $dsn
      */
     public function createClient(array $dsn): Client
@@ -47,10 +48,11 @@ class MeilisearchAdapterFactory implements AdapterFactoryInterface
             return $client;
         }
 
-        $apiKey = $dsn['user'] ?? '';
+        $apiKey = $dsn['user'] ?? null;
+        $tls = $dsn['query']['tls'] ?? false;
 
         return new Client(
-            $dsn['host'] . ':' . ($dsn['port'] ?? 7700),
+            ($tls ? 'https' : 'http') . '://' . $dsn['host'] . ':' . ($dsn['port'] ?? 7700),
             $apiKey,
         );
     }

--- a/packages/seal-redisearch-adapter/RediSearchAdapterFactory.php
+++ b/packages/seal-redisearch-adapter/RediSearchAdapterFactory.php
@@ -49,9 +49,7 @@ class RediSearchAdapterFactory implements AdapterFactoryInterface
 
         $user = $dsn['user'] ?? '';
         $password = $dsn['pass'] ?? '';
-        if ('' !== $password) {
-            $password = [$user, $password];
-        }
+        $password = '' !== $password ? [$user, $password] : $user;
 
         $client = new \Redis();
         $client->pconnect($dsn['host'], $dsn['port'] ?? 6379);


### PR DESCRIPTION
Not sure why but it seems `http` / `https` is now required for meilisearch connection which was not in the past.

The Redisearch did currently not handle the user of dsn as password which was also fixed.