### PR TITLE
Add links to search engines in getting started prepare engine docs

### DIFF
--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -835,7 +835,7 @@ search engine.
 
     .. group-tab:: Meilisearch
 
-        A instance of Meilisearch can be started with the following docker-compose file:
+        A instance of `Meilisearch <https://www.meilisearch.com/>`_ can be started with the following docker-compose file:
 
         .. code-block:: yaml
 
@@ -870,7 +870,7 @@ search engine.
 
     .. group-tab:: Algolia
 
-        As Algolia is SaaS, there is nothing to run it required. You can create a free account
+        As `Algolia <https://www.algolia.com/>`_ is SaaS, there is nothing to run it required. You can create a free account
         at `https://www.algolia.com/users/sign_up <https://www.algolia.com/users/sign_up>`_.
         After Signup you will get an ``ALGOLIA_APPLICATION_ID`` and an ``ALGOLIA_ADMIN_API_KEY``.
         Which you need to configure that your engine adapter configuration will then use them like
@@ -878,7 +878,7 @@ search engine.
 
     .. group-tab:: Elasticsearch
 
-        A instance of Elasticsearch can be started with the following docker-compose file:
+        A instance of `Elasticsearch <https://www.elastic.co/what-is/elasticsearch>`_ can be started with the following docker-compose file:
 
         .. code-block:: yaml
 
@@ -915,7 +915,7 @@ search engine.
 
     .. group-tab:: Opensearch
 
-        A instance of Opensearch can be started with the following docker-compose file:
+        A instance of `Opensearch <https://opensearch.org/adapter>`_ can be started with the following docker-compose file:
 
         .. code-block:: yaml
 
@@ -953,7 +953,7 @@ search engine.
 
     .. group-tab:: Redisearch
 
-        A instance of Redisearch can be started with the following docker-compose file.
+        A instance of `Redisearch <https://redis.io/docs/stack/search/>`_ can be started with the following docker-compose file.
         The here used `redis/redis-stack` image contains the required ``Redisearch``
         and ``JSON`` modules to run the search engine:
 
@@ -986,7 +986,7 @@ search engine.
 
     .. group-tab:: Solr
 
-        A instance of Solr can be started with the following docker-compose file.
+        A instance of `Solr <https://solr.apache.org/>`_ can be started with the following docker-compose file.
         It uses the required cloud mode to run the search engine. Running it
         without cloud mode is not supported yet:
 
@@ -1034,7 +1034,7 @@ search engine.
 
     .. group-tab:: Typesense
 
-        A instance of Typesense can be started with the following docker-compose file:
+        A instance of `Typesense <https://typesense.org/>`_ can be started with the following docker-compose file:
 
         .. code-block:: yaml
 


### PR DESCRIPTION
fixes #156. Add links to the different search engines.