### PR TITLE
Make schema related classes readonly

### DIFF
--- a/packages/seal/Schema/Field/AbstractField.php
+++ b/packages/seal/Schema/Field/AbstractField.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Schranz\Search\SEAL\Schema\Field;
 
+/**
+ * @readonly
+ */
 abstract class AbstractField
 {
     /**

--- a/packages/seal/Schema/Field/BooleanField.php
+++ b/packages/seal/Schema/Field/BooleanField.php
@@ -8,6 +8,8 @@ namespace Schranz\Search\SEAL\Schema\Field;
  * Type to store true or false flags.
  *
  * @property false $searchable
+ *
+ * @readonly
  */
 final class BooleanField extends AbstractField
 {

--- a/packages/seal/Schema/Field/DateTimeField.php
+++ b/packages/seal/Schema/Field/DateTimeField.php
@@ -8,6 +8,8 @@ namespace Schranz\Search\SEAL\Schema\Field;
  * Type to store date and date times.
  *
  * @property false $searchable
+ *
+ * @readonly
  */
 final class DateTimeField extends AbstractField
 {

--- a/packages/seal/Schema/Field/FloatField.php
+++ b/packages/seal/Schema/Field/FloatField.php
@@ -8,6 +8,8 @@ namespace Schranz\Search\SEAL\Schema\Field;
  * Type to store any PHP float value.
  *
  * @property false $searchable
+ *
+ * @readonly
  */
 final class FloatField extends AbstractField
 {

--- a/packages/seal/Schema/Field/IdentifierField.php
+++ b/packages/seal/Schema/Field/IdentifierField.php
@@ -11,6 +11,8 @@ namespace Schranz\Search\SEAL\Schema\Field;
  * @property false $searchable
  * @property true $filterable
  * @property true $sortable
+ *
+ * @readonly
  */
 final class IdentifierField extends AbstractField
 {

--- a/packages/seal/Schema/Field/IntegerField.php
+++ b/packages/seal/Schema/Field/IntegerField.php
@@ -8,6 +8,8 @@ namespace Schranz\Search\SEAL\Schema\Field;
  * Type to store any PHP int value.
  *
  * @property false $searchable
+ *
+ * @readonly
  */
 final class IntegerField extends AbstractField
 {

--- a/packages/seal/Schema/Field/ObjectField.php
+++ b/packages/seal/Schema/Field/ObjectField.php
@@ -6,6 +6,8 @@ namespace Schranz\Search\SEAL\Schema\Field;
 
 /**
  * Type to store fields inside a nested object.
+ *
+ * @readonly
  */
 final class ObjectField extends AbstractField
 {

--- a/packages/seal/Schema/Field/TextField.php
+++ b/packages/seal/Schema/Field/TextField.php
@@ -11,6 +11,8 @@ final class TextField extends AbstractField
 {
     /**
      * @param array<string, mixed> $options
+     *
+     * @readonly
      */
     public function __construct(
         string $name,

--- a/packages/seal/Schema/Field/TypedField.php
+++ b/packages/seal/Schema/Field/TypedField.php
@@ -12,6 +12,8 @@ final class TypedField extends AbstractField
     /**
      * @param array<string, array<string, AbstractField>> $types
      * @param array<string, mixed> $options
+     *
+     * @readonly
      */
     public function __construct(
         string $name,

--- a/packages/seal/Schema/Schema.php
+++ b/packages/seal/Schema/Schema.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Schranz\Search\SEAL\Schema;
 
+/**
+ * @readonly
+ */
 final class Schema
 {
     /**


### PR DESCRIPTION
The schema classes should be marked as readonly as they should be not able to be modified. In future they should be highly cached via a CachedLoader.