### PR TITLE
Change commands to use options instead of arguments

### DIFF
--- a/integrations/laravel/src/Console/IndexCreateCommand.php
+++ b/integrations/laravel/src/Console/IndexCreateCommand.php
@@ -17,7 +17,7 @@ final class IndexCreateCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'schranz:search:index-create {engine? : The name of the engine} {index? : The name of the index}';
+    protected $signature = 'schranz:search:index-create {--engine= : The name of the engine} {--index= : The name of the index}';
 
     /**
      * The console command description.
@@ -32,9 +32,9 @@ final class IndexCreateCommand extends Command
     public function handle(EngineRegistry $engineRegistry): int
     {
         /** @var string|null $engineName */
-        $engineName = $this->argument('engine');
+        $engineName = $this->option('engine');
         /** @var string|null $indexName */
-        $indexName = $this->argument('index');
+        $indexName = $this->option('index');
 
         foreach ($engineRegistry->getEngines() as $name => $engine) {
             if ($engineName && $engineName !== $name) {

--- a/integrations/laravel/src/Console/IndexDropCommand.php
+++ b/integrations/laravel/src/Console/IndexDropCommand.php
@@ -17,7 +17,7 @@ final class IndexDropCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'schranz:search:index-drop {engine? : The name of the engine} {index? : The name of the index} {--force : Force to drop the indexes}';
+    protected $signature = 'schranz:search:index-drop {--engine= : The name of the engine} {--index= : The name of the index} {--force : Force to drop the indexes}';
 
     /**
      * The console command description.
@@ -32,9 +32,9 @@ final class IndexDropCommand extends Command
     public function handle(EngineRegistry $engineRegistry): int
     {
         /** @var string|null $engineName */
-        $engineName = $this->argument('engine');
+        $engineName = $this->option('engine');
         /** @var string|null $indexName */
-        $indexName = $this->argument('index');
+        $indexName = $this->option('index');
         /** @var bool $force */
         $force = $this->option('force') ?: false;
 

--- a/integrations/mezzio/src/Command/IndexCreateCommand.php
+++ b/integrations/mezzio/src/Command/IndexCreateCommand.php
@@ -8,6 +8,7 @@ use Schranz\Search\SEAL\EngineRegistry;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -24,17 +25,17 @@ final class IndexCreateCommand extends Command
     protected function configure()
     {
         $this->setDescription('Create configured search indexes.');
-        $this->addArgument('engine', InputArgument::OPTIONAL, 'The name of the engine to create the schema for.');
-        $this->addArgument('index', InputArgument::OPTIONAL, 'The name of the index to create the schema for.');
+        $this->addOption('engine', null, InputOption::VALUE_REQUIRED, 'The name of the engine to create the schema for.');
+        $this->addOption('index', null, InputOption::VALUE_REQUIRED, 'The name of the index to create the schema for.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $ui = new SymfonyStyle($input, $output);
         /** @var string|null $engineName */
-        $engineName = $input->getArgument('engine');
+        $engineName = $input->getOption('engine');
         /** @var string|null $indexName */
-        $indexName = $input->getArgument('index');
+        $indexName = $input->getOption('index');
 
         foreach ($this->engineRegistry->getEngines() as $name => $engine) {
             if ($engineName && $engineName !== $name) {

--- a/integrations/mezzio/src/Command/IndexCreateCommand.php
+++ b/integrations/mezzio/src/Command/IndexCreateCommand.php
@@ -6,7 +6,6 @@ namespace Schranz\Search\Integration\Mezzio\Command;
 
 use Schranz\Search\SEAL\EngineRegistry;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/integrations/mezzio/src/Command/IndexDropCommand.php
+++ b/integrations/mezzio/src/Command/IndexDropCommand.php
@@ -25,8 +25,8 @@ final class IndexDropCommand extends Command
     protected function configure()
     {
         $this->setDescription('Drop configured search indexes.');
-        $this->addArgument('engine', InputArgument::OPTIONAL, 'The name of the engine to create the schema for.');
-        $this->addArgument('index', InputArgument::OPTIONAL, 'The name of the index to create the schema for.');
+        $this->addOption('engine', null, InputOption::VALUE_REQUIRED, 'The name of the engine to create the schema for.');
+        $this->addOption('index', null, InputOption::VALUE_REQUIRED, 'The name of the index to create the schema for.');
         $this->addOption('force', 'f', InputOption::VALUE_NONE, 'Without force nothing will happen in this command.');
     }
 
@@ -34,9 +34,9 @@ final class IndexDropCommand extends Command
     {
         $ui = new SymfonyStyle($input, $output);
         /** @var string|null $engineName */
-        $engineName = $input->getArgument('engine');
+        $engineName = $input->getOption('engine');
         /** @var string|null $indexName */
-        $indexName = $input->getArgument('index');
+        $indexName = $input->getOption('index');
         $force = $input->getOption('force');
 
         if (!$force) {

--- a/integrations/mezzio/src/Command/IndexDropCommand.php
+++ b/integrations/mezzio/src/Command/IndexDropCommand.php
@@ -6,7 +6,6 @@ namespace Schranz\Search\Integration\Mezzio\Command;
 
 use Schranz\Search\SEAL\EngineRegistry;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/integrations/spiral/phpstan-baseline.neon
+++ b/integrations/spiral/phpstan-baseline.neon
@@ -1,13 +1,13 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Class Spiral\\\\Console\\\\Attribute\\\\Argument is not an Attribute class\\.$#"
-			count: 2
+			message: "#^Class Spiral\\\\Console\\\\Attribute\\\\AsCommand is not an Attribute class\\.$#"
+			count: 1
 			path: src/Console/IndexCreateCommand.php
 
 		-
-			message: "#^Class Spiral\\\\Console\\\\Attribute\\\\AsCommand is not an Attribute class\\.$#"
-			count: 1
+			message: "#^Class Spiral\\\\Console\\\\Attribute\\\\Option is not an Attribute class\\.$#"
+			count: 2
 			path: src/Console/IndexCreateCommand.php
 
 		-
@@ -16,18 +16,13 @@ parameters:
 			path: src/Console/IndexCreateCommand.php
 
 		-
-			message: "#^Class Spiral\\\\Console\\\\Attribute\\\\Argument is not an Attribute class\\.$#"
-			count: 2
-			path: src/Console/IndexDropCommand.php
-
-		-
 			message: "#^Class Spiral\\\\Console\\\\Attribute\\\\AsCommand is not an Attribute class\\.$#"
 			count: 1
 			path: src/Console/IndexDropCommand.php
 
 		-
 			message: "#^Class Spiral\\\\Console\\\\Attribute\\\\Option is not an Attribute class\\.$#"
-			count: 1
+			count: 3
 			path: src/Console/IndexDropCommand.php
 
 		-

--- a/integrations/spiral/src/Console/IndexCreateCommand.php
+++ b/integrations/spiral/src/Console/IndexCreateCommand.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Schranz\Search\Integration\Spiral\Console;
 
 use Schranz\Search\SEAL\EngineRegistry;
-use Spiral\Console\Attribute\Option;
-use Symfony\Component\Console\Input\InputOption;
 use Spiral\Console\Attribute\AsCommand;
+use Spiral\Console\Attribute\Option;
 use Spiral\Console\Command;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * @experimental

--- a/integrations/spiral/src/Console/IndexCreateCommand.php
+++ b/integrations/spiral/src/Console/IndexCreateCommand.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Schranz\Search\Integration\Spiral\Console;
 
 use Schranz\Search\SEAL\EngineRegistry;
-use Spiral\Console\Attribute\Argument;
+use Spiral\Console\Attribute\Option;
+use Symfony\Component\Console\Input\InputOption;
 use Spiral\Console\Attribute\AsCommand;
 use Spiral\Console\Command;
 
@@ -18,10 +19,10 @@ use Spiral\Console\Command;
 )]
 final class IndexCreateCommand extends Command
 {
-    #[Argument(name: 'engine', description: 'The name of the engine')]
+    #[Option(name: 'engine', mode: InputOption::VALUE_REQUIRED, description: 'The name of the engine')]
     private string|null $engineName = null;
 
-    #[Argument(name: 'index', description: 'The name of the index')]
+    #[Option(name: 'index', mode: InputOption::VALUE_REQUIRED, description: 'The name of the index')]
     private string|null $indexName = null;
 
     public function __invoke(EngineRegistry $engineRegistry): int

--- a/integrations/spiral/src/Console/IndexDropCommand.php
+++ b/integrations/spiral/src/Console/IndexDropCommand.php
@@ -10,6 +10,7 @@ use Spiral\Console\Attribute\Argument;
 use Spiral\Console\Attribute\AsCommand;
 use Spiral\Console\Attribute\Option;
 use Spiral\Console\Command;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * @experimental
@@ -20,10 +21,10 @@ use Spiral\Console\Command;
 )]
 final class IndexDropCommand extends Command
 {
-    #[Argument(name: 'engine', description: 'The name of the engine')]
+    #[Option(name: 'engine', mode: InputOption::VALUE_REQUIRED, description: 'The name of the engine')]
     private string|null $engineName = null;
 
-    #[Argument(name: 'index', description: 'The name of the index')]
+    #[Option(name: 'index', mode: InputOption::VALUE_REQUIRED, description: 'The name of the index')]
     private string|null $indexName = null;
 
     #[Option(shortcut: 'f', description: 'Force to drop the indexes')]

--- a/integrations/spiral/src/Console/IndexDropCommand.php
+++ b/integrations/spiral/src/Console/IndexDropCommand.php
@@ -6,7 +6,6 @@ namespace Schranz\Search\Integration\Spiral\Console;
 
 use Schranz\Search\SEAL\EngineRegistry;
 use Spiral\Boot\Environment\AppEnvironment;
-use Spiral\Console\Attribute\Argument;
 use Spiral\Console\Attribute\AsCommand;
 use Spiral\Console\Attribute\Option;
 use Spiral\Console\Command;

--- a/integrations/symfony/src/Command/IndexCreateCommand.php
+++ b/integrations/symfony/src/Command/IndexCreateCommand.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -25,17 +26,17 @@ final class IndexCreateCommand extends Command
 
     protected function configure()
     {
-        $this->addArgument('engine', InputArgument::OPTIONAL, 'The name of the engine to create the schema for.');
-        $this->addArgument('index', InputArgument::OPTIONAL, 'The name of the index to create the schema for.');
+        $this->addOption('engine', null, InputOption::VALUE_REQUIRED, 'The name of the engine to create the schema for.');
+        $this->addOption('index', null, InputOption::VALUE_REQUIRED, 'The name of the index to create the schema for.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $ui = new SymfonyStyle($input, $output);
         /** @var string|null $engineName */
-        $engineName = $input->getArgument('engine');
+        $engineName = $input->getOption('engine');
         /** @var string|null $indexName */
-        $indexName = $input->getArgument('index');
+        $indexName = $input->getOption('index');
 
         foreach ($this->engineRegistry->getEngines() as $name => $engine) {
             if ($engineName && $engineName !== $name) {

--- a/integrations/symfony/src/Command/IndexCreateCommand.php
+++ b/integrations/symfony/src/Command/IndexCreateCommand.php
@@ -7,7 +7,6 @@ namespace Schranz\Search\Integration\Symfony\Command;
 use Schranz\Search\SEAL\EngineRegistry;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/integrations/yii/src/Command/IndexCreateCommand.php
+++ b/integrations/yii/src/Command/IndexCreateCommand.php
@@ -8,6 +8,7 @@ use Schranz\Search\SEAL\EngineRegistry;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -24,17 +25,17 @@ final class IndexCreateCommand extends Command
     protected function configure()
     {
         $this->setDescription('Create configured search indexes.');
-        $this->addArgument('engine', InputArgument::OPTIONAL, 'The name of the engine to create the schema for.');
-        $this->addArgument('index', InputArgument::OPTIONAL, 'The name of the index to create the schema for.');
+        $this->addOption('engine', null, InputOption::VALUE_REQUIRED, 'The name of the engine to create the schema for.');
+        $this->addOption('index', null, InputOption::VALUE_REQUIRED, 'The name of the index to create the schema for.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $ui = new SymfonyStyle($input, $output);
         /** @var string|null $engineName */
-        $engineName = $input->getArgument('engine');
+        $engineName = $input->getOption('engine');
         /** @var string|null $indexName */
-        $indexName = $input->getArgument('index');
+        $indexName = $input->getOption('index');
 
         foreach ($this->engineRegistry->getEngines() as $name => $engine) {
             if ($engineName && $engineName !== $name) {

--- a/integrations/yii/src/Command/IndexCreateCommand.php
+++ b/integrations/yii/src/Command/IndexCreateCommand.php
@@ -6,7 +6,6 @@ namespace Schranz\Search\Integration\Yii\Command;
 
 use Schranz\Search\SEAL\EngineRegistry;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;


### PR DESCRIPTION
Documentaiton already uses options instead of arguments. This is now fixed and used now correctly in the code.