### PR TITLE
Add Reindex functionality via ReindexProviders

### DIFF
--- a/.examples/laravel/app/Providers/AppServiceProvider.php
+++ b/.examples/laravel/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Search\BlogReindexProvider;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -20,5 +21,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        $this->app->singleton(BlogReindexProvider::class, fn () => new BlogReindexProvider());
+
+        $this->app->tag(BlogReindexProvider::class, 'schranz_search.reindex_provider');
     }
 }

--- a/.examples/laravel/app/Search/BlogReindexProvider.php
+++ b/.examples/laravel/app/Search/BlogReindexProvider.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Search;
+
+use Schranz\Search\SEAL\Reindex\ReindexProviderInterface;
+
+class BlogReindexProvider implements ReindexProviderInterface
+{
+    public function total(): ?int
+    {
+        return 3;
+    }
+
+    public function provide(): \Generator
+    {
+        yield [
+            'id' => 1,
+            'title' => 'Title 1',
+            'description' => 'Description 1',
+        ];
+
+        yield [
+            'id' => 2,
+            'title' => 'Title 2',
+            'description' => 'Description 2',
+        ];
+
+        yield [
+            'id' => 3,
+            'title' => 'Title 3',
+            'description' => 'Description 3',
+        ];
+    }
+
+    public static function getIndex(): string
+    {
+        return 'blog';
+    }
+}

--- a/.examples/laravel/tests/CommandTest.php
+++ b/.examples/laravel/tests/CommandTest.php
@@ -11,3 +11,9 @@ it('test drop', function () {
     $this->artisan('schranz:search:index-drop --force')
         ->assertExitCode(0);
 });
+
+it('test reindex', function () {
+    $this->artisan('schranz:search:reindex --drop')
+        ->assertExitCode(0)
+        ->expectsOutputToContain('3/3');
+});

--- a/.examples/mezzio/src/App/src/ConfigProvider.php
+++ b/.examples/mezzio/src/App/src/ConfigProvider.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App;
 
+use App\Search\BlogReindexProvider;
+
 /**
  * The configuration provider for the App module.
  *
@@ -92,6 +94,9 @@ class ConfigProvider
                         'adapter' => 'read-write://elasticsearch?write=multi',
                     ],
                 ],
+                'reindex_providers' => [
+                    BlogReindexProvider::class,
+                ],
             ],
         ];
     }
@@ -106,6 +111,7 @@ class ConfigProvider
         return [
             'invokables' => [
                 Handler\PingHandler::class => Handler\PingHandler::class,
+                BlogReindexProvider::class => BlogReindexProvider::class,
             ],
             'factories' => [
                 Handler\SearchHandler::class => Handler\SearchHandlerFactory::class,

--- a/.examples/mezzio/src/App/src/Search/BlogReindexProvider.php
+++ b/.examples/mezzio/src/App/src/Search/BlogReindexProvider.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Search;
+
+use Schranz\Search\SEAL\Reindex\ReindexProviderInterface;
+
+class BlogReindexProvider implements ReindexProviderInterface
+{
+    public function total(): ?int
+    {
+        return 3;
+    }
+
+    public function provide(): \Generator
+    {
+        yield [
+            'id' => 1,
+            'title' => 'Title 1',
+            'description' => 'Description 1',
+        ];
+
+        yield [
+            'id' => 2,
+            'title' => 'Title 2',
+            'description' => 'Description 2',
+        ];
+
+        yield [
+            'id' => 3,
+            'title' => 'Title 3',
+            'description' => 'Description 3',
+        ];
+    }
+
+    public static function getIndex(): string
+    {
+        return 'blog';
+    }
+}

--- a/.examples/mezzio/test/AppTest/Command/CommandTest.php
+++ b/.examples/mezzio/test/AppTest/Command/CommandTest.php
@@ -7,6 +7,7 @@ namespace AppTest\Command;
 use AppTest\FunctionalTestCase;
 use Schranz\Search\Integration\Mezzio\Command\IndexCreateCommand;
 use Schranz\Search\Integration\Mezzio\Command\IndexDropCommand;
+use Schranz\Search\Integration\Mezzio\Command\ReindexCommand;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 
@@ -38,5 +39,23 @@ final class CommandTest extends FunctionalTestCase
         $this->assertSame(0, $command->run($input, $output));
 
         $this->assertStringContainsString('Search indexes dropped.', $output->fetch());
+    }
+
+    public function testReindex(): void
+    {
+        /** @var IndexDropCommand $command */
+        $command = $this->container->get(ReindexCommand::class);
+
+        $input = new ArrayInput([
+            '--drop' => true,
+        ]);
+        $output = new BufferedOutput();
+
+        $this->assertSame(0, $command->run($input, $output));
+
+        $outputText = $output->fetch();
+
+        $this->assertStringContainsString('3/3', $outputText);
+        $this->assertStringContainsString('Search indexes reindexed.', $outputText);
     }
 }

--- a/.examples/spiral/app/config/schranz_search.php
+++ b/.examples/spiral/app/config/schranz_search.php
@@ -71,4 +71,7 @@ return [
             'adapter' => 'read-write://elasticsearch?write=multi',
         ],
     ],
+    'reindex_providers' => [
+        \App\Search\BlogReindexProvider::class,
+    ],
 ];

--- a/.examples/spiral/app/src/Search/BlogReindexProvider.php
+++ b/.examples/spiral/app/src/Search/BlogReindexProvider.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Search;
+
+use Schranz\Search\SEAL\Reindex\ReindexProviderInterface;
+
+class BlogReindexProvider implements ReindexProviderInterface
+{
+    public function total(): ?int
+    {
+        return 3;
+    }
+
+    public function provide(): \Generator
+    {
+        yield [
+            'id' => 1,
+            'title' => 'Title 1',
+            'description' => 'Description 1',
+        ];
+
+        yield [
+            'id' => 2,
+            'title' => 'Title 2',
+            'description' => 'Description 2',
+        ];
+
+        yield [
+            'id' => 3,
+            'title' => 'Title 3',
+            'description' => 'Description 3',
+        ];
+    }
+
+    public static function getIndex(): string
+    {
+        return 'blog';
+    }
+}

--- a/.examples/spiral/tests/CommandTest.php
+++ b/.examples/spiral/tests/CommandTest.php
@@ -21,4 +21,13 @@ final class CommandTest extends TestCase
 
         $this->assertStringContainsString('Search indexes dropped.', $output);
     }
+
+    public function testReindex(): void
+    {
+        $this->assertCommandRegistered('schranz:search:reindex');
+        $output = $this->runCommand('schranz:search:reindex', ['--drop' => true]);
+
+        $this->assertStringContainsString('3/3', $output);
+        $this->assertStringContainsString('Search indexes reindexed.', $output);
+    }
 }

--- a/.examples/symfony/src/Search/BlogReindexProvider.php
+++ b/.examples/symfony/src/Search/BlogReindexProvider.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Search;
+
+use Schranz\Search\SEAL\Reindex\ReindexProviderInterface;
+
+class BlogReindexProvider implements ReindexProviderInterface
+{
+    public function total(): ?int
+    {
+        return 3;
+    }
+
+    public function provide(): \Generator
+    {
+        yield [
+            'id' => 1,
+            'title' => 'Title 1',
+            'description' => 'Description 1',
+        ];
+
+        yield [
+            'id' => 2,
+            'title' => 'Title 2',
+            'description' => 'Description 2',
+        ];
+
+        yield [
+            'id' => 3,
+            'title' => 'Title 3',
+            'description' => 'Description 3',
+        ];
+    }
+
+    public static function getIndex(): string
+    {
+        return 'blog';
+    }
+}

--- a/.examples/symfony/tests/CommandTest.php
+++ b/.examples/symfony/tests/CommandTest.php
@@ -35,4 +35,19 @@ final class CommandTest extends KernelTestCase
 
         $commandTester->assertCommandIsSuccessful();
     }
+
+    public function testReindex(): void
+    {
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+
+        $command = $application->find('schranz:search:reindex');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            '--drop' => true,
+        ]);
+
+        $commandTester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('3/3', $commandTester->getDisplay());
+    }
 }

--- a/.examples/yii/composer.json
+++ b/.examples/yii/composer.json
@@ -53,7 +53,7 @@
         "ext-intl": "*",
         "httpsoft/http-message": "^1.0.5",
         "psr/container": "^2.0",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0|^2.0",
         "psr/http-server-handler": "^1.0",
         "symfony/console": "^6.0",
         "vlucas/phpdotenv": "^5.3",

--- a/.examples/yii/composer.lock
+++ b/.examples/yii/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0abe9f5c4da027ac547c3aa926eaad3d",
+    "content-hash": "382ee58f467431668950a6ba5876ef94",
     "packages": [
         {
             "name": "alexkart/curl-builder",
@@ -296,29 +296,29 @@
         },
         {
             "name": "httpsoft/http-message",
-            "version": "1.0.12",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/httpsoft/http-message.git",
-                "reference": "d2e085532fb6e65a4331d4f1a9c86f45174bc685"
+                "reference": "6d86446b9d8f92cc06c60375d3e67cf3407a57a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/httpsoft/http-message/zipball/d2e085532fb6e65a4331d4f1a9c86f45174bc685",
-                "reference": "d2e085532fb6e65a4331d4f1a9c86f45174bc685",
+                "url": "https://api.github.com/repos/httpsoft/http-message/zipball/6d86446b9d8f92cc06c60375d3e67cf3407a57a5",
+                "reference": "6d86446b9d8f92cc06c60375d3e67cf3407a57a5",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
                 "psr/http-factory": "^1.0",
-                "psr/http-message": "^1.0"
+                "psr/http-message": "^1.1|^2.0"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
-                "php-http/psr7-integration-tests": "1.2",
+                "php-http/psr7-integration-tests": "^1.3",
                 "phpunit/phpunit": "^9.5",
                 "squizlabs/php_codesniffer": "^3.7",
                 "vimeo/psalm": "^4.9|^5.2"
@@ -355,7 +355,7 @@
                 "issues": "https://github.com/httpsoft/http-message/issues",
                 "source": "https://github.com/httpsoft/http-message"
             },
-            "time": "2023-04-17T16:50:19+00:00"
+            "time": "2023-05-06T16:34:44+00:00"
         },
         {
             "name": "jetbrains/phpstorm-attributes",
@@ -5191,12 +5191,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/yiisoft/yii-middleware.git",
-                "reference": "8cc1293a48165dfbf8bc86773eda5ec6d61197f4"
+                "reference": "919811a3f7d7e68c8d9935581a1d2b596e7df9ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yiisoft/yii-middleware/zipball/8cc1293a48165dfbf8bc86773eda5ec6d61197f4",
-                "reference": "8cc1293a48165dfbf8bc86773eda5ec6d61197f4",
+                "url": "https://api.github.com/repos/yiisoft/yii-middleware/zipball/919811a3f7d7e68c8d9935581a1d2b596e7df9ca",
+                "reference": "919811a3f7d7e68c8d9935581a1d2b596e7df9ca",
                 "shasum": ""
             },
             "require": {
@@ -5265,7 +5265,7 @@
                     "type": "opencollective"
                 }
             ],
-            "time": "2023-04-16T14:31:39+00:00"
+            "time": "2023-05-07T08:52:43+00:00"
         },
         {
             "name": "yiisoft/yii-runner",
@@ -7378,16 +7378,16 @@
         },
         {
             "name": "elasticsearch/elasticsearch",
-            "version": "v8.7.0",
+            "version": "v8.7.1",
             "source": {
                 "type": "git",
                 "url": "git@github.com:elastic/elasticsearch-php.git",
-                "reference": "a4563130aa3ab608621ba22717d61c91b418454f"
+                "reference": "b499484115efc08db352c3d5c566648492b1e892"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elastic/elasticsearch-php/zipball/a4563130aa3ab608621ba22717d61c91b418454f",
-                "reference": "a4563130aa3ab608621ba22717d61c91b418454f",
+                "url": "https://api.github.com/repos/elastic/elasticsearch-php/zipball/b499484115efc08db352c3d5c566648492b1e892",
+                "reference": "b499484115efc08db352c3d5c566648492b1e892",
                 "shasum": ""
             },
             "require": {
@@ -7426,7 +7426,7 @@
                 "elasticsearch",
                 "search"
             ],
-            "time": "2023-03-27T08:05:35+00:00"
+            "time": "2023-03-30T09:02:44+00:00"
         },
         {
             "name": "evenement/evenement",
@@ -8873,21 +8873,20 @@
         },
         {
             "name": "nyholm/psr7",
-            "version": "1.7.0",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Nyholm/psr7.git",
-                "reference": "ed7cf98f6562831dbc3c962406b5e49dc8179c8c"
+                "reference": "3cb4d163b58589e47b35103e8e5e6a6a475b47be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Nyholm/psr7/zipball/ed7cf98f6562831dbc3c962406b5e49dc8179c8c",
-                "reference": "ed7cf98f6562831dbc3c962406b5e49dc8179c8c",
+                "url": "https://api.github.com/repos/Nyholm/psr7/zipball/3cb4d163b58589e47b35103e8e5e6a6a475b47be",
+                "reference": "3cb4d163b58589e47b35103e8e5e6a6a475b47be",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "php-http/message-factory": "^1.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0"
             },
@@ -8898,14 +8897,15 @@
             },
             "require-dev": {
                 "http-interop/http-factory-tests": "^0.9",
-                "php-http/psr7-integration-tests": "^1.0@dev",
-                "phpunit/phpunit": "^7.5 || 8.5 || 9.4",
+                "php-http/message-factory": "^1.0",
+                "php-http/psr7-integration-tests": "^1.0",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.4",
                 "symfony/error-handler": "^4.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7-dev"
+                    "dev-master": "1.8-dev"
                 }
             },
             "autoload": {
@@ -8935,7 +8935,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Nyholm/psr7/issues",
-                "source": "https://github.com/Nyholm/psr7/tree/1.7.0"
+                "source": "https://github.com/Nyholm/psr7/tree/1.8.0"
             },
             "funding": [
                 {
@@ -8947,7 +8947,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-04-20T08:38:48+00:00"
+            "time": "2023-05-02T11:26:24+00:00"
         },
         {
             "name": "ocramius/package-versions",
@@ -9391,16 +9391,16 @@
         },
         {
             "name": "php-http/discovery",
-            "version": "1.17.0",
+            "version": "1.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/discovery.git",
-                "reference": "bd810d15957cf165230e65d9e1a130793265e3b7"
+                "reference": "29ae6fae35f4116bbfe4c8b96ccc3f687eb07cd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/discovery/zipball/bd810d15957cf165230e65d9e1a130793265e3b7",
-                "reference": "bd810d15957cf165230e65d9e1a130793265e3b7",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/29ae6fae35f4116bbfe4c8b96ccc3f687eb07cd9",
+                "reference": "29ae6fae35f4116bbfe4c8b96ccc3f687eb07cd9",
                 "shasum": ""
             },
             "require": {
@@ -9463,9 +9463,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-http/discovery/issues",
-                "source": "https://github.com/php-http/discovery/tree/1.17.0"
+                "source": "https://github.com/php-http/discovery/tree/1.18.0"
             },
-            "time": "2023-04-26T15:39:13+00:00"
+            "time": "2023-05-03T14:49:12+00:00"
         },
         {
             "name": "php-http/httplug",
@@ -9923,16 +9923,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.20.3",
+            "version": "1.20.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "6c04009f6cae6eda2f040745b6b846080ef069c2"
+                "reference": "7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/6c04009f6cae6eda2f040745b6b846080ef069c2",
-                "reference": "6c04009f6cae6eda2f040745b6b846080ef069c2",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd",
+                "reference": "7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd",
                 "shasum": ""
             },
             "require": {
@@ -9962,22 +9962,22 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.20.3"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.20.4"
             },
-            "time": "2023-04-25T09:01:03+00:00"
+            "time": "2023-05-02T09:19:37+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.14",
+            "version": "1.10.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "d232901b09e67538e5c86a724be841bea5768a7c"
+                "reference": "762c4dac4da6f8756eebb80e528c3a47855da9bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d232901b09e67538e5c86a724be841bea5768a7c",
-                "reference": "d232901b09e67538e5c86a724be841bea5768a7c",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/762c4dac4da6f8756eebb80e528c3a47855da9bd",
+                "reference": "762c4dac4da6f8756eebb80e528c3a47855da9bd",
                 "shasum": ""
             },
             "require": {
@@ -10026,7 +10026,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-19T13:47:27+00:00"
+            "time": "2023-05-09T15:28:01+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -10552,16 +10552,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.11.16",
+            "version": "v0.11.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "151b145906804eea8e5d71fea23bfb470c904bfb"
+                "reference": "3dc5d4018dabd80bceb8fe1e3191ba8460569f0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/151b145906804eea8e5d71fea23bfb470c904bfb",
-                "reference": "151b145906804eea8e5d71fea23bfb470c904bfb",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/3dc5d4018dabd80bceb8fe1e3191ba8460569f0a",
+                "reference": "3dc5d4018dabd80bceb8fe1e3191ba8460569f0a",
                 "shasum": ""
             },
             "require": {
@@ -10622,39 +10622,37 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/v0.11.16"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.11.17"
             },
-            "time": "2023-04-26T12:53:57+00:00"
+            "time": "2023-05-05T20:02:42+00:00"
         },
         {
             "name": "react/event-loop",
-            "version": "v1.3.0",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/event-loop.git",
-                "reference": "187fb56f46d424afb6ec4ad089269c72eec2e137"
+                "reference": "6e7e587714fff7a83dcc7025aee42ab3b265ae05"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/187fb56f46d424afb6ec4ad089269c72eec2e137",
-                "reference": "187fb56f46d424afb6ec4ad089269c72eec2e137",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/6e7e587714fff7a83dcc7025aee42ab3b265ae05",
+                "reference": "6e7e587714fff7a83dcc7025aee42ab3b265ae05",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
             },
             "suggest": {
-                "ext-event": "~1.0 for ExtEventLoop",
-                "ext-pcntl": "For signal handling support when using the StreamSelectLoop",
-                "ext-uv": "* for ExtUvLoop"
+                "ext-pcntl": "For signal handling support when using the StreamSelectLoop"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "React\\EventLoop\\": "src"
+                    "React\\EventLoop\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -10690,39 +10688,35 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/event-loop/issues",
-                "source": "https://github.com/reactphp/event-loop/tree/v1.3.0"
+                "source": "https://github.com/reactphp/event-loop/tree/v1.4.0"
             },
             "funding": [
                 {
-                    "url": "https://github.com/WyriHaximus",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/clue",
-                    "type": "github"
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
                 }
             ],
-            "time": "2022-03-17T11:10:22+00:00"
+            "time": "2023-05-05T10:11:24+00:00"
         },
         {
             "name": "react/promise",
-            "version": "v2.9.0",
+            "version": "v2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/promise.git",
-                "reference": "234f8fd1023c9158e2314fa9d7d0e6a83db42910"
+                "reference": "f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/234f8fd1023c9158e2314fa9d7d0e6a83db42910",
-                "reference": "234f8fd1023c9158e2314fa9d7d0e6a83db42910",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38",
+                "reference": "f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.36"
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.36"
             },
             "type": "library",
             "autoload": {
@@ -10766,19 +10760,15 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/promise/issues",
-                "source": "https://github.com/reactphp/promise/tree/v2.9.0"
+                "source": "https://github.com/reactphp/promise/tree/v2.10.0"
             },
             "funding": [
                 {
-                    "url": "https://github.com/WyriHaximus",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/clue",
-                    "type": "github"
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
                 }
             ],
-            "time": "2022-02-11T10:27:51+00:00"
+            "time": "2023-05-02T15:15:43+00:00"
         },
         {
             "name": "react/stream",
@@ -10980,12 +10970,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "a31b8b0ce0409fca4e8fcdda046e8d4b603dc739"
+                "reference": "f86a07b7eb07f9297e939d8c5f97178b2c189dfe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/a31b8b0ce0409fca4e8fcdda046e8d4b603dc739",
-                "reference": "a31b8b0ce0409fca4e8fcdda046e8d4b603dc739",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/f86a07b7eb07f9297e939d8c5f97178b2c189dfe",
+                "reference": "f86a07b7eb07f9297e939d8c5f97178b2c189dfe",
                 "shasum": ""
             },
             "conflict": {
@@ -11013,7 +11003,7 @@
                 "automad/automad": "<1.8",
                 "awesome-support/awesome-support": "<=6.0.7",
                 "aws/aws-sdk-php": ">=3,<3.2.1",
-                "azuracast/azuracast": "<0.18",
+                "azuracast/azuracast": "<0.18.3",
                 "backdrop/backdrop": "<1.24.2",
                 "badaso/core": "<2.7",
                 "bagisto/bagisto": "<0.1.5",
@@ -11061,7 +11051,7 @@
                 "contao/core-bundle": "<4.9.40|>=4.10,<4.11.7|>=4.13,<4.13.21|>=5.1,<5.1.4|= 4.10.0",
                 "contao/listing-bundle": ">=4,<4.4.8",
                 "contao/managed-edition": "<=1.5",
-                "craftcms/cms": "<3.7.68|>= 4.0.0-RC1, < 4.3.7|>= 4.0.0-RC1, < 4.2.1",
+                "craftcms/cms": "<=3.8.3|>=4,<=4.4.3|>= 4.0.0-RC1, < 4.3.7|>= 4.0.0-RC1, < 4.2.1",
                 "croogo/croogo": "<3.0.7",
                 "cuyz/valinor": "<0.12",
                 "czproject/git-php": "<4.0.3",
@@ -11248,7 +11238,7 @@
                 "modx/revolution": "<= 2.8.3-pl|<2.8",
                 "mojo42/jirafeau": "<4.4",
                 "monolog/monolog": ">=1.8,<1.12",
-                "moodle/moodle": "<4.0.7|>=4.1-beta,<4.1.2|= 3.11",
+                "moodle/moodle": "<4.2-rc.2|= 3.11",
                 "mustache/mustache": ">=2,<2.14.1",
                 "namshi/jose": "<2.2",
                 "neoan3-apps/template": "<1.1.1",
@@ -11260,7 +11250,7 @@
                 "netgen/tagsbundle": ">=3.4,<3.4.11|>=4,<4.0.15",
                 "nette/application": ">=2,<2.0.19|>=2.1,<2.1.13|>=2.2,<2.2.10|>=2.3,<2.3.14|>=2.4,<2.4.16|>=3,<3.0.6",
                 "nette/nette": ">=2,<2.0.19|>=2.1,<2.1.13",
-                "nilsteampassnet/teampass": "<3.0.3",
+                "nilsteampassnet/teampass": "<3.0.7",
                 "notrinos/notrinos-erp": "<=0.7",
                 "noumo/easyii": "<=0.9",
                 "nukeviet/nukeviet": "<4.5.2",
@@ -11450,7 +11440,7 @@
                 "thelia/thelia": ">=2.1-beta.1,<2.1.3",
                 "theonedemon/phpwhois": "<=4.2.5",
                 "thinkcmf/thinkcmf": "<=5.1.7",
-                "thorsten/phpmyfaq": "<3.1.12",
+                "thorsten/phpmyfaq": "<3.1.13",
                 "tinymce/tinymce": "<5.10.7|>=6,<6.3.1",
                 "tinymighty/wiki-seo": "<1.2.2",
                 "titon/framework": ">=0,<9.9.99",
@@ -11577,7 +11567,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-28T21:04:09+00:00"
+            "time": "2023-05-06T00:13:11+00:00"
         },
         {
             "name": "sanmai/later",
@@ -11889,7 +11879,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-meilisearch-adapter",
-                "reference": "c39b0ebdf3bb0350059baa75813c20364740ef1d"
+                "reference": "5490700fd0f86b78efad76be2874a4b328c89a85"
             },
             "require": {
                 "meilisearch/meilisearch-php": "^1.0",
@@ -11915,7 +11905,7 @@
             },
             "autoload-dev": {
                 "psr-4": {
-                    "Schranz\\Search\\SEAL\\Adapter\\Meilisearch\\Tests\\": "Tests"
+                    "Schranz\\Search\\SEAL\\Adapter\\Meilisearch\\Tests\\": "tests"
                 }
             },
             "scripts": {
@@ -12903,16 +12893,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
                 "shasum": ""
             },
             "require": {
@@ -12957,7 +12947,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
             },
             "funding": [
                 {
@@ -12965,7 +12955,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:10:38+00:00"
+            "time": "2023-05-07T05:35:17+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -14894,16 +14884,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.9.0",
+            "version": "5.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "8b9ad1eb9e8b7d3101f949291da2b9f7767cd163"
+                "reference": "c9b192ab8400fdaf04b2b13d110575adc879aa90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/8b9ad1eb9e8b7d3101f949291da2b9f7767cd163",
-                "reference": "8b9ad1eb9e8b7d3101f949291da2b9f7767cd163",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/c9b192ab8400fdaf04b2b13d110575adc879aa90",
+                "reference": "c9b192ab8400fdaf04b2b13d110575adc879aa90",
                 "shasum": ""
             },
             "require": {
@@ -14994,9 +14984,9 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/5.9.0"
+                "source": "https://github.com/vimeo/psalm/tree/5.11.0"
             },
-            "time": "2023-03-29T21:38:21+00:00"
+            "time": "2023-05-04T21:35:44+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/.examples/yii/config/common/di/router.php
+++ b/.examples/yii/config/common/di/router.php
@@ -18,7 +18,7 @@ return [
             ->middleware(CsrfMiddleware::class)
             ->middleware(FormatDataResponse::class)
             ->addGroup(
-                Group::create('/{_language}')
+                Group::create('') // TODO should be /{_language}: https://github.com/schranz-search/schranz-search/issues/165#issuecomment-1540964696
                     ->routes(...$config->get('routes')),
             );
 

--- a/.examples/yii/config/common/params.php
+++ b/.examples/yii/config/common/params.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Search\BlogReindexProvider;
 use App\ViewInjection\CommonViewInjection;
 use App\ViewInjection\LayoutViewInjection;
 use App\ViewInjection\TranslatorViewInjection;
@@ -102,6 +103,9 @@ return [
             'read-write' => [
                 'adapter' => 'read-write://elasticsearch?write=multi',
             ],
+        ],
+        'reindex_providers' => [
+            BlogReindexProvider::class,
         ],
     ],
 ];

--- a/.examples/yii/config/web/di/application.php
+++ b/.examples/yii/config/web/di/application.php
@@ -23,6 +23,6 @@ return [
             'locales' => $params['locale']['locales'],
             'ignoredRequests' => $params['locale']['ignoredRequests'],
         ],
-        'withEnableSaveLocale()' => [false],
+        'withSaveLocale()' => [false],
     ],
 ];

--- a/.examples/yii/config/web/di/application.php
+++ b/.examples/yii/config/web/di/application.php
@@ -23,6 +23,6 @@ return [
             'locales' => $params['locale']['locales'],
             'ignoredRequests' => $params['locale']['ignoredRequests'],
         ],
-        'withSaveLocale()' => [false],
+        'withSaveLocale()' => [true],
     ],
 ];

--- a/.examples/yii/src/Search/BlogReindexProvider.php
+++ b/.examples/yii/src/Search/BlogReindexProvider.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Search;
+
+use Schranz\Search\SEAL\Reindex\ReindexProviderInterface;
+
+class BlogReindexProvider implements ReindexProviderInterface
+{
+    public function total(): ?int
+    {
+        return 3;
+    }
+
+    public function provide(): \Generator
+    {
+        yield [
+            'id' => 1,
+            'title' => 'Title 1',
+            'description' => 'Description 1',
+        ];
+
+        yield [
+            'id' => 2,
+            'title' => 'Title 2',
+            'description' => 'Description 2',
+        ];
+
+        yield [
+            'id' => 3,
+            'title' => 'Title 3',
+            'description' => 'Description 3',
+        ];
+    }
+
+    public static function getIndex(): string
+    {
+        return 'blog';
+    }
+}

--- a/.examples/yii/tests/Cli/CommandCest.php
+++ b/.examples/yii/tests/Cli/CommandCest.php
@@ -21,4 +21,11 @@ final class CommandCest
         $I->runShellCommand($command . ' schranz:search:index-drop --force');
         $I->seeInShellOutput('Search indexes dropped.');
     }
+
+    public function testReindex(CliTester $I): void
+    {
+        $command = \dirname(__DIR__, 2) . '/yii';
+        $I->runShellCommand($command . ' schranz:search:reindex --drop');
+        $I->seeInShellOutput('Search indexes reindexed.');
+    }
 }

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -69,7 +69,7 @@ integration of the package or the ``Standalone`` version.
 
     .. group-tab:: Meilisearch
 
-        Install the `Meilisearch <https://www.meilisearch.com/>`_ adapter:
+        Install the `Meilisearch <https://www.meilisearch.com/>`__ adapter:
 
         .. code-block:: bash
 
@@ -77,7 +77,7 @@ integration of the package or the ``Standalone`` version.
 
     .. group-tab:: Algolia
 
-        Install the `Algolia <https://www.algolia.com/>`_ adapter:
+        Install the `Algolia <https://www.algolia.com/>`__ adapter:
 
         .. code-block:: bash
 
@@ -85,7 +85,7 @@ integration of the package or the ``Standalone`` version.
 
     .. group-tab:: Elasticsearch
 
-        Install the `Elasticsearch <https://www.elastic.co/what-is/elasticsearch>`_ adapter:
+        Install the `Elasticsearch <https://www.elastic.co/what-is/elasticsearch>`__ adapter:
 
         .. code-block:: bash
 
@@ -93,7 +93,7 @@ integration of the package or the ``Standalone`` version.
 
     .. group-tab:: Opensearch
 
-        Install the `Opensearch <https://opensearch.org>`_ adapter:
+        Install the `Opensearch <https://opensearch.org>`__ adapter:
 
         .. code-block:: bash
 
@@ -101,7 +101,7 @@ integration of the package or the ``Standalone`` version.
 
     .. group-tab:: Redisearch
 
-        Install the `Redisearch <https://redis.io/docs/stack/search/>`_ adapter:
+        Install the `Redisearch <https://redis.io/docs/stack/search/>`__ adapter:
 
         .. code-block:: bash
 
@@ -109,7 +109,7 @@ integration of the package or the ``Standalone`` version.
 
     .. group-tab:: Solr
 
-        Install the `Solr <https://solr.apache.org/>`_ adapter:
+        Install the `Solr <https://solr.apache.org/>`__ adapter:
 
         .. code-block:: bash
 
@@ -117,7 +117,7 @@ integration of the package or the ``Standalone`` version.
 
     .. group-tab:: Typesense
 
-        Install the `Typesense <https://typesense.org/>`_ adapter:
+        Install the `Typesense <https://typesense.org/>`__ adapter:
 
         .. code-block:: bash
 
@@ -1296,14 +1296,14 @@ Prepare Search Engine
 ----------------------
 
 If you already have your search engine running you can skip this step. Still we want to
-provide here different `docker-compose <https://www.docker.com/products/docker-desktop/>`_ files to get you started quickly with your favorite
+provide here different `docker-compose <https://www.docker.com/products/docker-desktop/>`__ files to get you started quickly with your favorite
 search engine.
 
 .. tabs::
 
     .. group-tab:: Meilisearch
 
-        A instance of `Meilisearch <https://www.meilisearch.com/>`_ can be started with the following docker-compose file:
+        A instance of `Meilisearch <https://www.meilisearch.com/>`__ can be started with the following docker-compose file:
 
         .. code-block:: yaml
 
@@ -1338,15 +1338,15 @@ search engine.
 
     .. group-tab:: Algolia
 
-        As `Algolia <https://www.algolia.com/>`_ is SaaS, there is nothing to run it required. You can create a free account
-        at `https://www.algolia.com/users/sign_up <https://www.algolia.com/users/sign_up>`_.
+        As `Algolia <https://www.algolia.com/>`__ is SaaS, there is nothing to run it required. You can create a free account
+        at `https://www.algolia.com/users/sign_up <https://www.algolia.com/users/sign_up>`__.
         After Signup you will get an ``ALGOLIA_APPLICATION_ID`` and an ``ALGOLIA_ADMIN_API_KEY``.
         Which you need to configure that your engine adapter configuration will then use them like
         above.
 
     .. group-tab:: Elasticsearch
 
-        A instance of `Elasticsearch <https://www.elastic.co/what-is/elasticsearch>`_ can be started with the following docker-compose file:
+        A instance of `Elasticsearch <https://www.elastic.co/what-is/elasticsearch>`__ can be started with the following docker-compose file:
 
         .. code-block:: yaml
 
@@ -1383,7 +1383,7 @@ search engine.
 
     .. group-tab:: Opensearch
 
-        A instance of `Opensearch <https://opensearch.org/>`_ can be started with the following docker-compose file:
+        A instance of `Opensearch <https://opensearch.org/>`__ can be started with the following docker-compose file:
 
         .. code-block:: yaml
 
@@ -1421,7 +1421,7 @@ search engine.
 
     .. group-tab:: Redisearch
 
-        A instance of `Redisearch <https://redis.io/docs/stack/search/>`_ can be started with the following docker-compose file.
+        A instance of `Redisearch <https://redis.io/docs/stack/search/>`__ can be started with the following docker-compose file.
         The here used `redis/redis-stack` image contains the required ``Redisearch``
         and ``JSON`` modules to run the search engine:
 
@@ -1454,7 +1454,7 @@ search engine.
 
     .. group-tab:: Solr
 
-        A instance of `Solr <https://solr.apache.org/>`_ can be started with the following docker-compose file.
+        A instance of `Solr <https://solr.apache.org/>`__ can be started with the following docker-compose file.
         It uses the required cloud mode to run the search engine. Running it
         without cloud mode is not supported yet:
 
@@ -1502,7 +1502,7 @@ search engine.
 
     .. group-tab:: Typesense
 
-        A instance of `Typesense <https://typesense.org/>`_ can be started with the following docker-compose file:
+        A instance of `Typesense <https://typesense.org/>`__ can be started with the following docker-compose file:
 
         .. code-block:: yaml
 
@@ -1733,6 +1733,228 @@ we will filter by the ``tags`` field and get all documents which have the tag ``
     }
 
 For all kind of search and filters have a look at the :doc:`../search-and-filters/index` documentation.
+
+Reindex Documents
+-----------------
+
+If you have changed the schema or need to index or reindex all your documents
+the reindex functionality can be used.
+
+First you need to create a ``ReindexProvider`` providing all your documents.
+
+.. code-block:: php
+
+    <?php
+
+    class BlogReindexProvider implements ReindexProviderInterface
+    {
+        public function total(): ?int
+        {
+            return 2;
+        }
+
+        public function provide(): \Generator
+        {
+            yield [
+                'id' => 1,
+                'title' => 'Title 1',
+                'description' => 'Description 1',
+            ];
+
+            yield [
+                'id' => 2,
+                'title' => 'Title 2',
+                'description' => 'Description 2',
+            ];
+        }
+
+        public static function getIndex(): string
+        {
+            return 'blog';
+        }
+    }
+
+After that you can use the ``reindex`` to index all documents:
+
+.. tabs::
+
+    .. group-tab:: Standalone use
+
+        When using the ``Standalone`` version you need to reindex the documents
+        in your search engines via the ``Engine`` instance which was created before:
+
+        .. code-block:: php
+
+            <?php
+
+            $reindexProviders = [
+                new BlogReindexProvider(),
+            ];
+
+            // reindex all indexes
+            $engine->reindex($reindexProviders);
+
+            // reindex specific index and drop data before
+            $engine->reindex($reindexProviders, 'blog', dropIndex: true);
+
+    .. group-tab:: Laravel
+
+        In Laravel the new created ``ReindexProvider`` need to be tagged correctly:
+
+        .. code-block:: php
+
+            <?php // app/Providers/AppServiceProvider.php
+
+            namespace App\Providers;
+
+            class AppServiceProvider extends \Illuminate\Support\ServiceProvider
+            {
+                // ...
+
+                public function boot(): void
+                {
+                    $this->app->singleton(\App\Search\BlogReindexProvider::class, fn () => new \App\Search\BlogReindexProvider());
+
+                    $this->app->tag(\App\Search\BlogReindexProvider::class, 'schranz_search.reindex_provider');
+                }
+            }
+
+        After correctly tagging the ``ReindexProvider`` with ``schranz_search.reindex_provider`` the
+        ``schranz:search:reindex`` command can be used to index all documents:
+
+        .. code-block:: bash
+
+            # reindex all indexes
+            php artisan schranz:search:reindex
+
+            # reindex specific index and drop data before
+            php artisan schranz:search:reindex --index=blog --drop
+
+    .. group-tab:: Symfony
+
+        In Symfony the ``autoconfigure`` feature should already tag the new ``ReindexProvider`` correctly
+        with the ``schranz_search.reindex_provider`` tag. If not you can tag it manually:
+
+        .. code-block:: yaml
+
+            # config/services.yaml
+
+            services:
+                App\Search\BlogReindexProvider:
+                    tags:
+                        - { name: schranz_search.reindex_provider }
+
+        After correctly tagging the ``ReindexProvider`` use the following command to index all documents:
+
+        .. code-block:: bash
+
+            # reindex all indexes
+            bin/console schranz:search:reindex
+
+            # reindex specific index and drop data before
+            bin/console schranz:search:reindex --index=blog --drop
+
+    .. group-tab:: Spiral
+
+        In Spiral the new created ``ReindexProvider`` need to be registered correctly as reindex provider:
+
+        .. code-block:: php
+
+            <?php // app/config/schranz_search.php
+
+            return [
+                // ...
+
+                'reindex_providers' => [
+                    \App\Search\BlogReindexProvider::class,
+                ],
+            ];
+
+        After correctly registering the ``ReindexProvider`` use the following command to index all documents:
+
+        .. code-block:: bash
+
+            # reindex all indexes
+            php app.php schranz:search:reindex
+
+            # reindex specific index and drop data before
+            php app.php schranz:search:reindex --index=blog --drop
+
+    .. group-tab:: Mezzio
+
+        In Mezzio the new created ``ReindexProvider`` need to be registered correctly as reindex provider:
+
+        .. code-block:: php
+
+            <?php // src/App/src/ConfigProvider.php
+
+            class ConfigProvider
+            {
+                public function __invoke(): array
+                {
+                    return [
+                        // ...
+                        'schranz_search' => [
+                            // ...
+                            'reindex_providers' => [
+                                \App\Search\BlogReindexProvider::class,
+                            ],
+                        ],
+                    ];
+                }
+
+                public function getDependencies(): array
+                {
+                    return [
+                        // ...
+
+                        'invokables' => [
+                            \App\Search\BlogReindexProvider::class => \App\Search\BlogReindexProvider::class,
+                        ],
+
+                        // ...
+                    ];
+                }
+            }
+
+        After correctly registering the ``ReindexProvider`` use the following command to index all documents:
+
+        .. code-block:: bash
+
+            # reindex all indexes
+            vendor/bin/laminas schranz:search:reindex
+
+            # reindex specific index and drop data before
+            vendor/bin/laminas schranz:search:reindex --index=blog --drop
+
+    .. group-tab:: Yii
+
+        In Yii the new created ``ReindexProvider`` need to be registered correctly as reindex provider:
+
+        .. code-block:: php
+
+            <?php // config/common/params.php
+
+            return [
+                // ...
+                'schranz-search/yii-module' => [
+                    // ...
+
+                    'reindex_providers' => [
+                        \App\Search\BlogReindexProvider::class,
+                    ],
+                ],
+            ];
+
+        After correctly registering the ``ReindexProvider`` use the following command to index all documents:
+
+        .. code-block:: bash
+
+            # reindex all indexes
+            ./yii schranz:search:reindex
+
+            # reindex specific index and drop data before
+            ./yii schranz:search:reindex --index=blog --drop
 
 Help needed?
 ------------

--- a/docs/indexing/index.rst
+++ b/docs/indexing/index.rst
@@ -47,18 +47,234 @@ the name of the index and the identifier of the document which should be removed
 
     $this->engine->deleteDocument('blog', '1');
 
+Reindex operations
+------------------
+
+To reindex documents it is required to create atleast one ReindexProvider for
+the index you want to reindex. The ReindexProvider is a class which implements
+the ``ReindexProviderInterface`` and provides the documents for your index.
+
+.. code-block:: php
+
+    <?php
+
+    class BlogReindexProvider implements ReindexProviderInterface
+    {
+        public function total(): ?int
+        {
+            return 3;
+        }
+
+        public function provide(): \Generator
+        {
+            yield [
+                'id' => 1,
+                'title' => 'Title 1',
+                'description' => 'Description 1',
+            ];
+
+            yield [
+                'id' => 2,
+                'title' => 'Title 2',
+                'description' => 'Description 2',
+            ];
+
+            yield [
+                'id' => 3,
+                'title' => 'Title 3',
+                'description' => 'Description 3',
+            ];
+        }
+
+        public static function getIndex(): string
+        {
+            return 'blog';
+        }
+    }
+
+After that you can use the ``reindex`` to index all documents:
+
+.. tabs::
+
+    .. group-tab:: Standalone use
+
+        When using the ``Standalone`` version you need to reindex the documents
+        in your search engines via the ``Engine`` instance which was created before:
+
+        .. code-block:: php
+
+            <?php
+
+            $reindexProviders = [
+                new BlogReindexProvider(),
+            ];
+
+            // reindex all indexes
+            $engine->reindex($reindexProviders);
+
+            // reindex specific index and drop data before
+            $engine->reindex($reindexProviders, 'blog', dropIndex: true);
+
+    .. group-tab:: Laravel
+
+        In Laravel the new created ``ReindexProvider`` need to be tagged correctly:
+
+        .. code-block:: php
+
+            <?php // app/Providers/AppServiceProvider.php
+
+            namespace App\Providers;
+
+            class AppServiceProvider extends \Illuminate\Support\ServiceProvider
+            {
+                // ...
+
+                public function boot(): void
+                {
+                    $this->app->singleton(\App\Search\BlogReindexProvider::class, fn () => new \App\Search\BlogReindexProvider());
+
+                    $this->app->tag(\App\Search\BlogReindexProvider::class, 'schranz_search.reindex_provider');
+                }
+            }
+
+        After correctly tagging the ``ReindexProvider`` with ``schranz_search.reindex_provider`` the
+        ``schranz:search:reindex`` command can be used to index all documents:
+
+        .. code-block:: bash
+
+            # reindex all indexes
+            php artisan schranz:search:reindex
+
+            # reindex specific index and drop data before
+            php artisan schranz:search:reindex --index=blog --drop
+
+    .. group-tab:: Symfony
+
+        In Symfony ``autoconfigure`` feature should already tag the new ``ReindexProvider`` correctly
+        with the ``schranz_search.reindex_provider`` tag. If not you can tag it manually:
+
+        .. code-block:: yaml
+
+            # config/services.yaml
+
+            services:
+                App\Search\BlogReindexProvider:
+                    tags:
+                        - { name: schranz_search.reindex_provider }
+
+        After correctly tagging the ``ReindexProvider`` use the following command to index all documents:
+
+        .. code-block:: bash
+
+            # reindex all indexes
+            bin/console schranz:search:reindex
+
+            bin/console schranz:search:reindex --index=blog --drop
+
+    .. group-tab:: Spiral
+
+        In Spiral the new created ``ReindexProvider`` need to be registered correctly as reindex provider:
+
+        .. code-block:: php
+
+            <?php // app/config/schranz_search.php
+
+            return [
+                // ...
+
+                'reindex_providers' => [
+                    \App\Search\BlogReindexProvider::class,
+                ],
+            ];
+
+        After correctly registering the ``ReindexProvider`` use the following command to index all documents:
+
+        .. code-block:: bash
+
+            # reindex all indexes
+            php app.php schranz:search:reindex
+
+            php app.php schranz:search:reindex --index=blog --drop
+
+    .. group-tab:: Mezzio
+
+        In Mezzio the new created ``ReindexProvider`` need to be registered correctly as reindex provider:
+
+        .. code-block:: php
+
+            <?php // src/App/src/ConfigProvider.php
+
+            class ConfigProvider
+            {
+                public function __invoke(): array
+                {
+                    return [
+                        // ...
+                        'schranz_search' => [
+                            // ...
+                            'reindex_providers' => [
+                                \App\Search\BlogReindexProvider::class,
+                            ],
+                        ],
+                    ];
+                }
+
+                public function getDependencies(): array
+                {
+                    return [
+                        // ...
+
+                        'invokables' => [
+                            \App\Search\BlogReindexProvider::class => \App\Search\BlogReindexProvider::class,
+                        ],
+
+                        // ...
+                    ];
+                }
+            }
+
+        After correctly registering the ``ReindexProvider`` use the following command to index all documents:
+
+        .. code-block:: bash
+
+            # reindex all indexes
+            vendor/bin/laminas schranz:search:reindex
+
+            vendor/bin/laminas schranz:search:reindex --index=blog --drop
+
+    .. group-tab:: Yii
+
+        In Yii the new created ``ReindexProvider`` need to be registered correctly as reindex provider:
+
+        .. code-block:: php
+
+            <?php // config/common/params.php
+
+            return [
+                // ...
+                'schranz-search/yii-module' => [
+                    // ...
+
+                    'reindex_providers' => [
+                        \App\Search\BlogReindexProvider::class,
+                    ],
+                ],
+            ];
+
+        After correctly registering the ``ReindexProvider`` use the following command to index all documents:
+
+        .. code-block:: bash
+
+            # reindex all indexes
+            ./yii schranz:search:reindex
+
+            ./yii schranz:search:reindex --index=blog --drop
+
 Bulk operations
 ---------------
 
 Currently no bulk operations are implemented. Add your opinion to the
 `Bulk issue <https://github.com/schranz-search/schranz-search/issues/24>`_
-on Github.
-
-Reindex operations
-------------------
-
-Currently no reindex operations are implemented. Add your opinion to the
-`Reindex issue <https://github.com/schranz-search/schranz-search/issues/16>`_
 on Github.
 
 Next Steps

--- a/integrations/laravel/src/Console/ReindexCommand.php
+++ b/integrations/laravel/src/Console/ReindexCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Schranz Search package.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Schranz\Search\Integration\Laravel\Console;
+
+use Illuminate\Console\Command;
+use Schranz\Search\SEAL\EngineRegistry;
+
+/**
+ * @experimental
+ */
+final class ReindexCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'schranz:search:reindex {--engine= : The name of the engine} {--index= : The name of the index} {--drop : Drop the index before reindexing}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Reindex configured search indexes.';
+
+    public function __construct(
+        private readonly iterable $reindexProviders, // TODO move to handle method: https://discord.com/channels/297040613688475649/1105593000664498336
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(
+        EngineRegistry $engineRegistry,
+    ): int {
+        /** @var string|null $engineName */
+        $engineName = $this->option('engine');
+        /** @var string|null $indexName */
+        $indexName = $this->option('index');
+        /** @var bool $drop */
+        $drop = $this->option('drop');
+
+        foreach ($engineRegistry->getEngines() as $name => $engine) {
+            if ($engineName && $engineName !== $name) {
+                continue;
+            }
+
+            $this->line('Engine: ' . $name);
+
+            $progressBar = $this->output->createProgressBar();
+
+            $engine->reindex(
+                $this->reindexProviders,
+                $indexName,
+                $drop,
+                function (string $index, int $count, ?int $total) use ($progressBar) {
+                    $progressBar->setMessage($index);
+                    $progressBar->setProgress($count);
+
+                    if (null !== $total) {
+                        $progressBar->setMaxSteps($total);
+                    }
+                },
+            );
+
+            $progressBar->finish();
+            $this->line('');
+            $this->line('');
+        }
+
+        $this->info('Search indexes reindexed.');
+
+        return 0;
+    }
+}

--- a/integrations/laravel/src/Console/ReindexCommand.php
+++ b/integrations/laravel/src/Console/ReindexCommand.php
@@ -15,6 +15,7 @@ namespace Schranz\Search\Integration\Laravel\Console;
 
 use Illuminate\Console\Command;
 use Schranz\Search\SEAL\EngineRegistry;
+use Schranz\Search\SEAL\Reindex\ReindexProviderInterface;
 
 /**
  * @experimental
@@ -35,6 +36,9 @@ final class ReindexCommand extends Command
      */
     protected $description = 'Reindex configured search indexes.';
 
+    /**
+     * @param iterable<ReindexProviderInterface> $reindexProviders
+     */
     public function __construct(
         private readonly iterable $reindexProviders, // TODO move to handle method: https://discord.com/channels/297040613688475649/1105593000664498336
     ) {

--- a/integrations/laravel/src/SearchProvider.php
+++ b/integrations/laravel/src/SearchProvider.php
@@ -16,6 +16,7 @@ namespace Schranz\Search\Integration\Laravel;
 use Illuminate\Support\ServiceProvider;
 use Schranz\Search\Integration\Laravel\Console\IndexCreateCommand;
 use Schranz\Search\Integration\Laravel\Console\IndexDropCommand;
+use Schranz\Search\Integration\Laravel\Console\ReindexCommand;
 use Schranz\Search\SEAL\Adapter\AdapterFactory;
 use Schranz\Search\SEAL\Adapter\AdapterFactoryInterface;
 use Schranz\Search\SEAL\Adapter\AdapterInterface;
@@ -61,6 +62,7 @@ final class SearchProvider extends ServiceProvider
         $this->commands([
             IndexCreateCommand::class,
             IndexDropCommand::class,
+            ReindexCommand::class,
         ]);
 
         /** @var array{schranz_search: mixed[]} $globalConfig */
@@ -137,6 +139,12 @@ final class SearchProvider extends ServiceProvider
         });
 
         $this->app->alias('schranz_search.engine_factory', EngineRegistry::class);
+
+        $this->app->when(ReindexCommand::class)
+            ->needs('$reindexProviders')
+            ->giveTagged('schranz_search.reindex_provider');
+
+        $this->app->tagged('schranz_search.reindex_provider');
     }
 
     private function createAdapterFactories(): void

--- a/integrations/mezzio/src/Command/ReindexCommand.php
+++ b/integrations/mezzio/src/Command/ReindexCommand.php
@@ -11,11 +11,10 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Schranz\Search\Integration\Symfony\Command;
+namespace Schranz\Search\Integration\Mezzio\Command;
 
 use Schranz\Search\SEAL\EngineRegistry;
 use Schranz\Search\SEAL\Reindex\ReindexProviderInterface;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -25,7 +24,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * @experimental
  */
-#[AsCommand(name: 'schranz:search:reindex', description: 'Reindex configured search indexes.')]
 final class ReindexCommand extends Command
 {
     /**
@@ -40,6 +38,7 @@ final class ReindexCommand extends Command
 
     protected function configure()
     {
+        $this->setDescription('Reindex configured search indexes.');
         $this->addOption('engine', null, InputOption::VALUE_REQUIRED, 'The name of the engine to create the schema for.');
         $this->addOption('index', null, InputOption::VALUE_REQUIRED, 'The name of the index to create the schema for.');
         $this->addOption('drop', null, InputOption::VALUE_NONE, 'Drop the index before reindexing.');

--- a/integrations/mezzio/src/ConfigProvider.php
+++ b/integrations/mezzio/src/ConfigProvider.php
@@ -47,6 +47,7 @@ final class ConfigProvider
                 'prefix' => '',
                 'schemas' => [],
                 'engines' => [],
+                'reindex_providers' => [],
             ],
         ];
     }
@@ -62,6 +63,7 @@ final class ConfigProvider
             'commands' => [
                 'schranz:search:index-create' => Command\IndexCreateCommand::class,
                 'schranz:search:index-drop' => Command\IndexDropCommand::class,
+                'schranz:search:reindex' => Command\ReindexCommand::class,
             ],
         ];
     }
@@ -87,6 +89,7 @@ final class ConfigProvider
                 SealContainer::class => SealContainerFactory::class,
                 Command\IndexCreateCommand::class => CommandAbstractFactory::class,
                 Command\IndexDropCommand::class => CommandAbstractFactory::class,
+                Command\ReindexCommand::class => CommandAbstractFactory::class,
                 ...$adapterFactories,
             ],
         ];

--- a/integrations/mezzio/src/Service/SealContainerFactory.php
+++ b/integrations/mezzio/src/Service/SealContainerFactory.php
@@ -44,6 +44,7 @@ final class SealContainerFactory
          *         adapter: string,
          *     }>,
          *     adapter_factories: array<class-string, class-string<AdapterFactoryInterface>>,
+         *     reindex_providers: string[],
          * } $config
          */
         $config = $config['schranz_search'];

--- a/integrations/spiral/phpstan-baseline.neon
+++ b/integrations/spiral/phpstan-baseline.neon
@@ -29,3 +29,18 @@ parameters:
 			message: "#^Parameter \\#1 \\$index of method Schranz\\\\Search\\\\SEAL\\\\EngineInterface\\:\\:dropIndex\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/Console/IndexDropCommand.php
+
+		-
+			message: "#^Cannot call method createProgressBar\\(\\) on Symfony\\\\Component\\\\Console\\\\Style\\\\SymfonyStyle\\|null\\.$#"
+			count: 1
+			path: src/Console/ReindexCommand.php
+
+		-
+			message: "#^Class Spiral\\\\Console\\\\Attribute\\\\AsCommand is not an Attribute class\\.$#"
+			count: 1
+			path: src/Console/ReindexCommand.php
+
+		-
+			message: "#^Class Spiral\\\\Console\\\\Attribute\\\\Option is not an Attribute class\\.$#"
+			count: 3
+			path: src/Console/ReindexCommand.php

--- a/integrations/spiral/src/Bootloader/SearchBootloader.php
+++ b/integrations/spiral/src/Bootloader/SearchBootloader.php
@@ -33,6 +33,7 @@ use Schranz\Search\SEAL\Adapter\Typesense\TypesenseAdapterFactory;
 use Schranz\Search\SEAL\Engine;
 use Schranz\Search\SEAL\EngineInterface;
 use Schranz\Search\SEAL\EngineRegistry;
+use Schranz\Search\SEAL\Reindex\ReindexProviderInterface;
 use Schranz\Search\SEAL\Schema\Loader\LoaderInterface;
 use Schranz\Search\SEAL\Schema\Loader\PhpFileLoader;
 use Schranz\Search\SEAL\Schema\Schema;
@@ -173,7 +174,17 @@ final class SearchBootloader extends Bootloader
             static function (Container $container) use ($reindexProviderNames): ReindexCommand {
                 $reindexProviders = [];
                 foreach ($reindexProviderNames as $reindexProviderName) {
-                    $reindexProviders[] = $container->get($reindexProviderName);
+                    $reindexProvider = $container->get($reindexProviderName);
+
+                    if (!$reindexProvider instanceof ReindexProviderInterface) {
+                        throw new \RuntimeException(\sprintf(
+                            'Reindex provider "%s" does not implement "%s".',
+                            $reindexProviderName,
+                            ReindexProviderInterface::class,
+                        ));
+                    }
+
+                    $reindexProviders[] = $reindexProvider;
                 }
 
                 return new ReindexCommand($reindexProviders);

--- a/integrations/spiral/src/Bootloader/SearchBootloader.php
+++ b/integrations/spiral/src/Bootloader/SearchBootloader.php
@@ -16,6 +16,7 @@ namespace Schranz\Search\Integration\Spiral\Bootloader;
 use Schranz\Search\Integration\Spiral\Config\SearchConfig;
 use Schranz\Search\Integration\Spiral\Console\IndexCreateCommand;
 use Schranz\Search\Integration\Spiral\Console\IndexDropCommand;
+use Schranz\Search\Integration\Spiral\Console\ReindexCommand;
 use Schranz\Search\SEAL\Adapter\AdapterFactory;
 use Schranz\Search\SEAL\Adapter\AdapterFactoryInterface;
 use Schranz\Search\SEAL\Adapter\AdapterInterface;
@@ -73,6 +74,7 @@ final class SearchBootloader extends Bootloader
     ): void {
         $console->addCommand(IndexCreateCommand::class);
         $console->addCommand(IndexDropCommand::class);
+        $console->addCommand(ReindexCommand::class);
 
         $this->config->setDefaults(
             SearchConfig::CONFIG,
@@ -161,6 +163,20 @@ final class SearchBootloader extends Bootloader
                 }
 
                 return new EngineRegistry($engines);
+            },
+        );
+
+        $reindexProviderNames = $config->getReindexProviders(); // TODO tagged services would make this easier
+
+        $container->bindSingleton(
+            ReindexCommand::class,
+            static function (Container $container) use ($reindexProviderNames): ReindexCommand {
+                $reindexProviders = [];
+                foreach ($reindexProviderNames as $reindexProviderName) {
+                    $reindexProviders[] = $container->get($reindexProviderName);
+                }
+
+                return new ReindexCommand($reindexProviders);
             },
         );
     }

--- a/integrations/spiral/src/Config/SearchConfig.php
+++ b/integrations/spiral/src/Config/SearchConfig.php
@@ -32,12 +32,14 @@ final class SearchConfig extends InjectableConfig
      *     engines: array<string, array{
      *         adapter: string,
      *     }>,
+     *     reindex_providers: string[],
      * }
      */
     protected array $config = [
         'prefix' => '',
         'schemas' => [],
         'engines' => [],
+        'reindex_providers' => [],
     ];
 
     public function getPrefix(): string
@@ -64,5 +66,13 @@ final class SearchConfig extends InjectableConfig
     public function getEngines(): array
     {
         return $this->config['engines'];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getReindexProviders(): array
+    {
+        return $this->config['reindex_providers'];
     }
 }

--- a/integrations/spiral/src/Console/ReindexCommand.php
+++ b/integrations/spiral/src/Console/ReindexCommand.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Schranz Search package.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Schranz\Search\Integration\Spiral\Console;
+
+use Schranz\Search\SEAL\EngineRegistry;
+use Schranz\Search\SEAL\Reindex\ReindexProviderInterface;
+use Spiral\Console\Attribute\AsCommand;
+use Spiral\Console\Attribute\Option;
+use Spiral\Console\Command;
+use Symfony\Component\Console\Input\InputOption;
+
+/**
+ * @experimental
+ */
+#[AsCommand(name: 'schranz:search:reindex', description: 'Reindex configured search indexes.')]
+final class ReindexCommand extends Command
+{
+    #[Option(name: 'engine', mode: InputOption::VALUE_REQUIRED, description: 'The name of the engine')]
+    private string|null $engineName = null;
+
+    #[Option(name: 'index', mode: InputOption::VALUE_REQUIRED, description: 'The name of the index')]
+    private string|null $indexName = null;
+
+    #[Option(shortcut: 'd', description: 'Drop the index before reindexing.')]
+    private bool $drop = false;
+
+    /**
+     * @param iterable<ReindexProviderInterface> $reindexProviders
+     */
+    public function __construct(
+        private readonly iterable $reindexProviders, // TODO move to __invoke method
+    ) {
+        parent::__construct();
+    }
+
+    public function __invoke(
+        EngineRegistry $engineRegistry,
+    ): int {
+        foreach ($engineRegistry->getEngines() as $name => $engine) {
+            if ($this->engineName && $this->engineName !== $name) {
+                continue;
+            }
+
+            $this->line('Engine: ' . $name);
+
+            $progressBar = $this->output->createProgressBar();
+
+            $engine->reindex(
+                $this->reindexProviders,
+                $this->indexName,
+                $this->drop,
+                function (string $index, int $count, ?int $total) use ($progressBar) {
+                    $progressBar->setMessage($index);
+                    $progressBar->setProgress($count);
+
+                    if (null !== $total) {
+                        $progressBar->setMaxSteps($total);
+                    }
+                },
+            );
+
+            $progressBar->finish();
+
+            $this->line('');
+            $this->line('');
+        }
+
+        $this->info('Search indexes reindexed.');
+
+        return self::SUCCESS;
+    }
+}

--- a/integrations/symfony/config/services.php
+++ b/integrations/symfony/config/services.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Schranz\Search\Integration\Symfony\Command\IndexCreateCommand;
 use Schranz\Search\Integration\Symfony\Command\IndexDropCommand;
+use Schranz\Search\Integration\Symfony\Command\ReindexCommand;
 use Schranz\Search\SEAL\Adapter\AdapterFactory;
 use Schranz\Search\SEAL\Adapter\Algolia\AlgoliaAdapterFactory;
 use Schranz\Search\SEAL\Adapter\Elasticsearch\ElasticsearchAdapterFactory;
@@ -46,6 +47,14 @@ return static function (ContainerConfigurator $container) {
         ->set('schranz_search.index_drop_command', IndexDropCommand::class)
         ->args([
             service('schranz_search.engine_registry'),
+        ])
+        ->tag('console.command');
+
+    $container->services()
+        ->set('schranz_search.reindex_command', ReindexCommand::class)
+        ->args([
+            service('schranz_search.engine_registry'),
+            tagged_iterator('schranz_search.reindex_provider'),
         ])
         ->tag('console.command');
 

--- a/integrations/symfony/src/Command/ReindexCommand.php
+++ b/integrations/symfony/src/Command/ReindexCommand.php
@@ -68,7 +68,7 @@ final class ReindexCommand extends Command
                 $this->reindexProviders,
                 $indexName,
                 $drop,
-                function (string $index, int $count, ?int $total) use ($ui, $progressBar, $name) {
+                function (string $index, int $count, ?int $total) use ($progressBar, $name) {
                     $progressBar->setMessage($index);
                     $progressBar->setProgress($count);
 

--- a/integrations/symfony/src/Command/ReindexCommand.php
+++ b/integrations/symfony/src/Command/ReindexCommand.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Schranz Search package.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Schranz\Search\Integration\Symfony\Command;
+
+use Schranz\Search\SEAL\EngineRegistry;
+use Schranz\Search\SEAL\Reindex\ReindexProviderInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * @experimental
+ */
+#[AsCommand(name: 'schranz:search:reindex', description: 'Reindex configured search indexes.')]
+final class ReindexCommand extends Command
+{
+    /**
+     * @param iterable<ReindexProviderInterface> $reindexProviders
+     */
+    public function __construct(
+        private readonly EngineRegistry $engineRegistry,
+        private readonly iterable $reindexProviders,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this->addOption('engine', null, InputOption::VALUE_REQUIRED, 'The name of the engine to create the schema for.');
+        $this->addOption('index', null, InputOption::VALUE_REQUIRED, 'The name of the index to create the schema for.');
+        $this->addOption('drop', null, InputOption::VALUE_NONE, 'Drop the index before reindexing.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $ui = new SymfonyStyle($input, $output);
+        /** @var string|null $engineName */
+        $engineName = $input->getOption('engine');
+        /** @var string|null $indexName */
+        $indexName = $input->getOption('index');
+        /** @var bool $drop */
+        $drop = $input->getOption('drop');
+
+        foreach ($this->engineRegistry->getEngines() as $name => $engine) {
+            if ($engineName && $engineName !== $name) {
+                continue;
+            }
+
+            $ui->section('Engine: ' . $name);
+
+            $progressBar = $ui->createProgressBar();
+
+            $engine->reindex(
+                $this->reindexProviders,
+                $indexName,
+                $drop,
+                function (string $index, int $count, ?int $total) use ($ui, $progressBar, $name) {
+                    $progressBar->setMessage($index);
+                    $progressBar->setProgress($count);
+
+                    if ($total !== null) {
+                        $progressBar->setMaxSteps($total);
+                    }
+                }
+            );
+
+            $progressBar->finish();
+            $ui->writeln('');
+            $ui->writeln('');
+        }
+
+        $ui->success('Search indexes reindexed.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/integrations/symfony/src/SearchBundle.php
+++ b/integrations/symfony/src/SearchBundle.php
@@ -18,6 +18,7 @@ use Schranz\Search\SEAL\Adapter\Multi\MultiAdapterFactory;
 use Schranz\Search\SEAL\Adapter\ReadWrite\ReadWriteAdapterFactory;
 use Schranz\Search\SEAL\Engine;
 use Schranz\Search\SEAL\EngineInterface;
+use Schranz\Search\SEAL\Reindex\ReindexProviderInterface;
 use Schranz\Search\SEAL\Schema\Loader\PhpFileLoader;
 use Schranz\Search\SEAL\Schema\Schema;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
@@ -118,6 +119,9 @@ final class SearchBundle extends AbstractBundle
                 $name . 'Engine',
             );
         }
+
+        $builder->registerForAutoconfiguration(ReindexProviderInterface::class)
+            ->addTag('schranz_search.reindex_provider');
 
         $container->import(\dirname(__DIR__) . '/config/services.php');
     }

--- a/integrations/yii/composer.lock
+++ b/integrations/yii/composer.lock
@@ -263,12 +263,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "609351c91141cb1afcb0e0ac5fedf7f8c5d5e7c1"
+                "reference": "ea11261501f3b6afa1e782648e2a870af0a13c48"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/609351c91141cb1afcb0e0ac5fedf7f8c5d5e7c1",
-                "reference": "609351c91141cb1afcb0e0ac5fedf7f8c5d5e7c1",
+                "url": "https://api.github.com/repos/symfony/console/zipball/ea11261501f3b6afa1e782648e2a870af0a13c48",
+                "reference": "ea11261501f3b6afa1e782648e2a870af0a13c48",
                 "shasum": ""
             },
             "require": {
@@ -345,7 +345,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-28T15:51:51+00:00"
+            "time": "2023-05-05T10:58:01+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2332,17 +2332,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Nyholm/psr7.git",
-                "reference": "7f77c0eaefdb849630df611ba2204ce92dfe5ef5"
+                "reference": "3cb4d163b58589e47b35103e8e5e6a6a475b47be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Nyholm/psr7/zipball/7f77c0eaefdb849630df611ba2204ce92dfe5ef5",
-                "reference": "7f77c0eaefdb849630df611ba2204ce92dfe5ef5",
+                "url": "https://api.github.com/repos/Nyholm/psr7/zipball/3cb4d163b58589e47b35103e8e5e6a6a475b47be",
+                "reference": "3cb4d163b58589e47b35103e8e5e6a6a475b47be",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "php-http/message-factory": "^1.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0"
             },
@@ -2353,15 +2352,16 @@
             },
             "require-dev": {
                 "http-interop/http-factory-tests": "^0.9",
-                "php-http/psr7-integration-tests": "^1.0@dev",
-                "phpunit/phpunit": "^7.5 || 8.5 || 9.4",
+                "php-http/message-factory": "^1.0",
+                "php-http/psr7-integration-tests": "^1.0",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.4",
                 "symfony/error-handler": "^4.4"
             },
             "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7-dev"
+                    "dev-master": "1.8-dev"
                 }
             },
             "autoload": {
@@ -2391,7 +2391,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Nyholm/psr7/issues",
-                "source": "https://github.com/Nyholm/psr7/tree/master"
+                "source": "https://github.com/Nyholm/psr7/tree/1.8.0"
             },
             "funding": [
                 {
@@ -2403,7 +2403,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-04-20T10:02:22+00:00"
+            "time": "2023-05-02T11:26:24+00:00"
         },
         {
             "name": "opensearch-project/opensearch-php",
@@ -2720,12 +2720,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/discovery.git",
-                "reference": "5e1ace82a771f01396680704d59cb63ebc1c84e6"
+                "reference": "29ae6fae35f4116bbfe4c8b96ccc3f687eb07cd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/discovery/zipball/5e1ace82a771f01396680704d59cb63ebc1c84e6",
-                "reference": "5e1ace82a771f01396680704d59cb63ebc1c84e6",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/29ae6fae35f4116bbfe4c8b96ccc3f687eb07cd9",
+                "reference": "29ae6fae35f4116bbfe4c8b96ccc3f687eb07cd9",
                 "shasum": ""
             },
             "require": {
@@ -2789,9 +2789,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-http/discovery/issues",
-                "source": "https://github.com/php-http/discovery/tree/1.x"
+                "source": "https://github.com/php-http/discovery/tree/1.18.0"
             },
-            "time": "2023-04-28T12:44:47+00:00"
+            "time": "2023-05-03T14:49:12+00:00"
         },
         {
             "name": "php-http/httplug",
@@ -3094,12 +3094,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "b621ec03070bd237d87baf93c81c82f5e1058ca5"
+                "reference": "34e2e311539e619470357fd6c85b657a522f57ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b621ec03070bd237d87baf93c81c82f5e1058ca5",
-                "reference": "b621ec03070bd237d87baf93c81c82f5e1058ca5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/34e2e311539e619470357fd6c85b657a522f57ed",
+                "reference": "34e2e311539e619470357fd6c85b657a522f57ed",
                 "shasum": ""
             },
             "require": {
@@ -3149,7 +3149,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-30T14:21:21+00:00"
+            "time": "2023-05-09T17:41:47+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -3209,12 +3209,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "db887088b40ae43d17b9913886df860a7035145d"
+                "reference": "565b4df47bb8992d1adbe06cb4c2e36df5517f54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/db887088b40ae43d17b9913886df860a7035145d",
-                "reference": "db887088b40ae43d17b9913886df860a7035145d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/565b4df47bb8992d1adbe06cb4c2e36df5517f54",
+                "reference": "565b4df47bb8992d1adbe06cb4c2e36df5517f54",
                 "shasum": ""
             },
             "require": {
@@ -3279,7 +3279,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-04-04T09:22:25+00:00"
+            "time": "2023-05-07T06:58:20+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3528,12 +3528,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2"
+                "reference": "71b53aef431cb3bb5af542b171907bed662b2e17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
-                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/71b53aef431cb3bb5af542b171907bed662b2e17",
+                "reference": "71b53aef431cb3bb5af542b171907bed662b2e17",
                 "shasum": ""
             },
             "require": {
@@ -3607,7 +3607,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.7"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6"
             },
             "funding": [
                 {
@@ -3623,7 +3623,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-14T08:58:40+00:00"
+            "time": "2023-05-09T06:51:41+00:00"
         },
         {
             "name": "psr/http-client",
@@ -3889,12 +3889,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/promise.git",
-                "reference": "d47bd60659fa7ce58f4a7ec3ea959c05326ef7fa"
+                "reference": "f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/d47bd60659fa7ce58f4a7ec3ea959c05326ef7fa",
-                "reference": "d47bd60659fa7ce58f4a7ec3ea959c05326ef7fa",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38",
+                "reference": "f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38",
                 "shasum": ""
             },
             "require": {
@@ -3945,19 +3945,15 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/promise/issues",
-                "source": "https://github.com/reactphp/promise/tree/2.x"
+                "source": "https://github.com/reactphp/promise/tree/v2.10.0"
             },
             "funding": [
                 {
-                    "url": "https://github.com/WyriHaximus",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/clue",
-                    "type": "github"
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
                 }
             ],
-            "time": "2022-10-31T09:13:55+00:00"
+            "time": "2023-05-02T15:15:43+00:00"
         },
         {
             "name": "rector/rector",
@@ -3965,12 +3961,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "d5a112d946d50ed2fbf2ae44eaccdff36b186277"
+                "reference": "bf29cbeb9e670779b3d463cec30b23380422883b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/d5a112d946d50ed2fbf2ae44eaccdff36b186277",
-                "reference": "d5a112d946d50ed2fbf2ae44eaccdff36b186277",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/bf29cbeb9e670779b3d463cec30b23380422883b",
+                "reference": "bf29cbeb9e670779b3d463cec30b23380422883b",
                 "shasum": ""
             },
             "require": {
@@ -4019,7 +4015,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-04-30T12:47:54+00:00"
+            "time": "2023-05-09T19:13:23+00:00"
         },
         {
             "name": "schranz-search/seal-algolia-adapter",
@@ -4208,7 +4204,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-meilisearch-adapter",
-                "reference": "c39b0ebdf3bb0350059baa75813c20364740ef1d"
+                "reference": "5490700fd0f86b78efad76be2874a4b328c89a85"
             },
             "require": {
                 "meilisearch/meilisearch-php": "^1.0",
@@ -4234,7 +4230,7 @@
             },
             "autoload-dev": {
                 "psr-4": {
-                    "Schranz\\Search\\SEAL\\Adapter\\Meilisearch\\Tests\\": "Tests"
+                    "Schranz\\Search\\SEAL\\Adapter\\Meilisearch\\Tests\\": "tests"
                 }
             },
             "scripts": {
@@ -5222,16 +5218,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.4",
+            "version": "4.0.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
                 "shasum": ""
             },
             "require": {
@@ -5276,7 +5272,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0"
             },
             "funding": [
                 {
@@ -5284,7 +5280,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:10:38+00:00"
+            "time": "2023-05-07T05:35:17+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -5958,12 +5954,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "e435847c4c5ebbc2ba81273a6bb834cb56f73f49"
+                "reference": "b2f7a1d6d34532f59446f82b924dc1cb67c5dbb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/e435847c4c5ebbc2ba81273a6bb834cb56f73f49",
-                "reference": "e435847c4c5ebbc2ba81273a6bb834cb56f73f49",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/b2f7a1d6d34532f59446f82b924dc1cb67c5dbb7",
+                "reference": "b2f7a1d6d34532f59446f82b924dc1cb67c5dbb7",
                 "shasum": ""
             },
             "require": {
@@ -5974,6 +5970,7 @@
                 "symfony/service-contracts": "^2.5|^3"
             },
             "conflict": {
+                "php-http/discovery": "<1.15",
                 "symfony/http-foundation": "<6.3"
             },
             "provide": {
@@ -6041,7 +6038,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-28T15:57:00+00:00"
+            "time": "2023-05-07T17:34:16+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -6131,12 +6128,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "2fdfd4259397b1300da21c04ba52a673763b73c9"
+                "reference": "f5663428e4af961a6d55bfd5e901823304c483d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/2fdfd4259397b1300da21c04ba52a673763b73c9",
-                "reference": "2fdfd4259397b1300da21c04ba52a673763b73c9",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/f5663428e4af961a6d55bfd5e901823304c483d8",
+                "reference": "f5663428e4af961a6d55bfd5e901823304c483d8",
                 "shasum": ""
             },
             "require": {
@@ -6190,7 +6187,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-14T09:04:20+00:00"
+            "time": "2023-05-02T16:26:33+00:00"
         },
         {
             "name": "symfony/polyfill-php80",

--- a/integrations/yii/config/di-console.php
+++ b/integrations/yii/config/di-console.php
@@ -14,7 +14,12 @@ declare(strict_types=1);
 use Psr\Container\ContainerInterface;
 use Schranz\Search\Integration\Yii\Command\IndexCreateCommand;
 use Schranz\Search\Integration\Yii\Command\IndexDropCommand;
+use Schranz\Search\Integration\Yii\Command\ReindexCommand;
 use Schranz\Search\SEAL\EngineRegistry;
+
+/** @var \Yiisoft\Config\Config $config */
+/** @var array{"schranz-search/yii-module": array{reindex_providers: string[]}} $params */
+$reindexProviderNames = $params['schranz-search/yii-module']['reindex_providers'];
 
 $diConfig[IndexCreateCommand::class] = static function (ContainerInterface $container) {
     /** @var EngineRegistry $engineRegistry */
@@ -28,6 +33,18 @@ $diConfig[IndexDropCommand::class] = static function (ContainerInterface $contai
     $engineRegistry = $container->get(EngineRegistry::class);
 
     return new IndexDropCommand($engineRegistry);
+};
+
+$diConfig[ReindexCommand::class] = static function (ContainerInterface $container) use ($reindexProviderNames) {
+    /** @var EngineRegistry $engineRegistry */
+    $engineRegistry = $container->get(EngineRegistry::class);
+
+    $reindexProviders = [];
+    foreach ($reindexProviderNames as $reindexProviderName) {
+        $reindexProviders[] = $container->get($reindexProviderName);
+    }
+
+    return new ReindexCommand($engineRegistry, $reindexProviders);
 };
 
 return $diConfig;

--- a/integrations/yii/config/params.php
+++ b/integrations/yii/config/params.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 use Schranz\Search\Integration\Yii\Command\IndexCreateCommand;
 use Schranz\Search\Integration\Yii\Command\IndexDropCommand;
+use Schranz\Search\Integration\Yii\Command\ReindexCommand;
 
 return [
     'schranz-search/yii-module' => [
@@ -29,11 +30,13 @@ return [
             ],
             */
         ],
+        'reindex_providers' => [],
     ],
     'yiisoft/yii-console' => [
         'commands' => [
             'schranz:search:index-create' => IndexCreateCommand::class,
             'schranz:search:index-drop' => IndexDropCommand::class,
+            'schranz:search:reindex' => ReindexCommand::class,
         ],
     ],
 ];

--- a/integrations/yii/src/Command/ReindexCommand.php
+++ b/integrations/yii/src/Command/ReindexCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Schranz Search package.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Schranz\Search\Integration\Yii\Command;
+
+use Schranz\Search\SEAL\EngineRegistry;
+use Schranz\Search\SEAL\Reindex\ReindexProviderInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * @experimental
+ */
+final class ReindexCommand extends Command
+{
+    /**
+     * @param iterable<ReindexProviderInterface> $reindexProviders
+     */
+    public function __construct(
+        private readonly EngineRegistry $engineRegistry,
+        private readonly iterable $reindexProviders,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this->setDescription('Reindex configured search indexes.');
+        $this->addOption('engine', null, InputOption::VALUE_REQUIRED, 'The name of the engine to create the schema for.');
+        $this->addOption('index', null, InputOption::VALUE_REQUIRED, 'The name of the index to create the schema for.');
+        $this->addOption('drop', null, InputOption::VALUE_NONE, 'Drop the index before reindexing.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $ui = new SymfonyStyle($input, $output);
+        /** @var string|null $engineName */
+        $engineName = $input->getOption('engine');
+        /** @var string|null $indexName */
+        $indexName = $input->getOption('index');
+        /** @var bool $drop */
+        $drop = $input->getOption('drop');
+
+        foreach ($this->engineRegistry->getEngines() as $name => $engine) {
+            if ($engineName && $engineName !== $name) {
+                continue;
+            }
+
+            $ui->section('Engine: ' . $name);
+
+            $progressBar = $ui->createProgressBar();
+
+            $engine->reindex(
+                $this->reindexProviders,
+                $indexName,
+                $drop,
+                function (string $index, int $count, ?int $total) use ($progressBar) {
+                    $progressBar->setMessage($index);
+                    $progressBar->setProgress($count);
+
+                    if (null !== $total) {
+                        $progressBar->setMaxSteps($total);
+                    }
+                },
+            );
+
+            $progressBar->finish();
+            $ui->writeln('');
+            $ui->writeln('');
+        }
+
+        $ui->success('Search indexes reindexed.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/seal/src/EngineInterface.php
+++ b/packages/seal/src/EngineInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Schranz\Search\SEAL;
 
 use Schranz\Search\SEAL\Exception\DocumentNotFoundException;
+use Schranz\Search\SEAL\Reindex\ReindexProviderInterface;
 use Schranz\Search\SEAL\Search\SearchBuilder;
 use Schranz\Search\SEAL\Task\TaskInterface;
 
@@ -72,4 +73,20 @@ interface EngineInterface
      * @return ($options is non-empty-array ? TaskInterface<null> : null)
      */
     public function dropSchema(array $options = []): ?TaskInterface;
+
+    /**
+     * @experimental This method is experimental and may change in future versions, we are not sure if it stays here or the syntax change completely.
+     *               For framework users it is uninteresting as there it is handled via CLI commands.
+     *
+     * @param iterable<ReindexProviderInterface> $reindexProviders
+     * @param string|null $index
+     * @param bool $dropIndex
+     * @param callable(string, int, int|null): void|null $progressCallback
+     */
+    public function reindex(
+        iterable $reindexProviders,
+        ?string $index = null,
+        bool $dropIndex = false,
+        callable $progressCallback = null,
+    ): void;
 }

--- a/packages/seal/src/EngineInterface.php
+++ b/packages/seal/src/EngineInterface.php
@@ -79,8 +79,6 @@ interface EngineInterface
      *               For framework users it is uninteresting as there it is handled via CLI commands.
      *
      * @param iterable<ReindexProviderInterface> $reindexProviders
-     * @param string|null $index
-     * @param bool $dropIndex
      * @param callable(string, int, int|null): void|null $progressCallback
      */
     public function reindex(

--- a/packages/seal/src/Reindex/ReindexProviderInterface.php
+++ b/packages/seal/src/Reindex/ReindexProviderInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Schranz Search package.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Schranz\Search\SEAL\Reindex;
+
+interface ReindexProviderInterface
+{
+    /**
+     * Returns how many documents this provider will provide. Returns `null` if the total is unknown.
+     */
+    public function total(): ?int;
+
+    /**
+     * The reindex provider returns a Generator which provides the documents to reindex.
+     *
+     * @return \Generator<array<string, mixed>>
+     */
+    public function provide(): \Generator;
+
+    /**
+     * The name of the index for which the documents are for.
+     */
+    public static function getIndex(): string;
+}


### PR DESCRIPTION
It happens in development a lot that we need to reindex all our documents again. This should be easy by creating ReindexProviders inside the project.

fixes #16

# Open Questions

- Does a Reindexprovider require to know the engine?

# TODO

 - [x] ReindexProviderInterface
 - [x] Engine Reindex
 - [x] Symfony ReindexCommand
 - [x] Laravel ReindexCommand
 - [x] Spiral ReindexCommand
 - [x] Mezzio ReindexCommand
 - [x] Yii ReindexCommand
 - [x] Documentation