### PR TITLE
Add Facade for Engine and EngineRegistry

### DIFF
--- a/.examples/laravel/app/Http/Controllers/SearchController.php
+++ b/.examples/laravel/app/Http/Controllers/SearchController.php
@@ -41,8 +41,10 @@ class SearchController extends Controller
     {
         $engineNames = \implode(', ', \array_keys([...EngineRegistryFacade::getEngines()]));
 
-        $engineFacadeClass = get_class(EngineFacade::getFacadeRoot());
-        $engineRegistryFacadeClass = get_class(EngineRegistryFacade::getFacadeRoot());
+        $engineFacadeClass = EngineFacade::class;
+        $engineRegistryFacadeClass = EngineRegistryFacade::class;
+        $engineFacadeTargetClass = get_class(EngineFacade::getFacadeRoot());
+        $engineRegistryFacadeTargetClass = get_class(EngineRegistryFacade::getFacadeRoot());
 
         return
             <<<HTML
@@ -72,7 +74,12 @@ class SearchController extends Controller
                     </div>
 
                     <div>
-                        <strong>Facade Engines</strong>: $engineFacadeClass, $engineRegistryFacadeClass
+                        <h2>Facade Engines</h2>
+
+                        <ul>
+                            <li><strong>$engineFacadeClass</strong>: $engineFacadeTargetClass</li>
+                            <li><strong>$engineRegistryFacadeClass</strong>: $engineRegistryFacadeTargetClass</li>
+                        </ul>
                     </div>
                 </body>
             </html>

--- a/.examples/laravel/app/Http/Controllers/SearchController.php
+++ b/.examples/laravel/app/Http/Controllers/SearchController.php
@@ -6,7 +6,8 @@ namespace App\Http\Controllers;
 
 use Schranz\Search\SEAL\Adapter\AdapterInterface;
 use Schranz\Search\SEAL\EngineInterface;
-use Schranz\Search\SEAL\EngineRegistry;
+use Schranz\Search\Integration\Laravel\Facade\EngineRegistry as EngineRegistryFacade;
+use Schranz\Search\Integration\Laravel\Facade\Engine as EngineFacade;
 use Symfony\Component\HttpFoundation\Response;
 
 class SearchController extends Controller
@@ -22,24 +23,26 @@ class SearchController extends Controller
     private readonly EngineInterface $multiEngine;
     private readonly EngineInterface $readWriteEngine;
 
-    public function __construct(
-        private readonly EngineRegistry $engineRegistry,
-    ) {
-        $this->algoliaEngine = $this->engineRegistry->getEngine('algolia');
-        $this->meilisearchEngine = $this->engineRegistry->getEngine('meilisearch');
-        $this->elasticsearchEngine = $this->engineRegistry->getEngine('elasticsearch');
-        $this->memoryEngine = $this->engineRegistry->getEngine('memory');
-        $this->opensearchEngine = $this->engineRegistry->getEngine('opensearch');
-        $this->solrEngine = $this->engineRegistry->getEngine('solr');
-        $this->redisearchEngine = $this->engineRegistry->getEngine('redisearch');
-        $this->typesenseEngine = $this->engineRegistry->getEngine('typesense');
-        $this->multiEngine = $this->engineRegistry->getEngine('multi');
-        $this->readWriteEngine = $this->engineRegistry->getEngine('read-write');
+    public function __construct()
+    {
+        $this->algoliaEngine = EngineRegistryFacade::getEngine('algolia');
+        $this->meilisearchEngine = EngineRegistryFacade::getEngine('meilisearch');
+        $this->elasticsearchEngine = EngineRegistryFacade::getEngine('elasticsearch');
+        $this->memoryEngine = EngineRegistryFacade::getEngine('memory');
+        $this->opensearchEngine = EngineRegistryFacade::getEngine('opensearch');
+        $this->solrEngine = EngineRegistryFacade::getEngine('solr');
+        $this->redisearchEngine = EngineRegistryFacade::getEngine('redisearch');
+        $this->typesenseEngine = EngineRegistryFacade::getEngine('typesense');
+        $this->multiEngine = EngineRegistryFacade::getEngine('multi');
+        $this->readWriteEngine = EngineRegistryFacade::getEngine('read-write');
     }
 
     public function home(): string
     {
-        $engineNames = \implode(', ', \array_keys([...$this->engineRegistry->getEngines()]));
+        $engineNames = \implode(', ', \array_keys([...EngineRegistryFacade::getEngines()]));
+
+        $engineFacadeClass = get_class(EngineFacade::getFacadeRoot());
+        $engineRegistryFacadeClass = get_class(EngineRegistryFacade::getFacadeRoot());
 
         return
             <<<HTML
@@ -66,6 +69,10 @@ class SearchController extends Controller
 
                     <div>
                         <strong>Registred Engines</strong>: $engineNames
+                    </div>
+
+                    <div>
+                        <strong>Facade Engines</strong>: $engineFacadeClass, $engineRegistryFacadeClass
                     </div>
                 </body>
             </html>

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -601,6 +601,12 @@ It requires an instance of the ``Adapter`` which we did install before to connec
                         ],
                     ];
 
+        .. note::
+
+            The ``Laravel`` integration provides also `Facades <https://laravel.com/docs/10.x/facades>`__ for the later used default ``Engine``
+            and ``EngineRegistry``. They are provided under the ``Schranz\Search\Integration\Laravel\Facade\``
+            namespace. See also the `Laravel Integration README <https://github.com/schranz-search/schranz-search/tree/0.1/integrations/laravel>`__.
+
     .. group-tab:: Symfony
 
         When we are using the Symfony Bundle we just need to configure our ``Engine``

--- a/integrations/laravel/README.md
+++ b/integrations/laravel/README.md
@@ -186,6 +186,12 @@ class Some {
 }
 ```
 
+Instead of constructor injection the `Laravel` integration provides also two `Facades`
+for the above services:
+
+- `Schranz\Search\Integration\Laravel\Facade\Engine`
+- `Schranz\Search\Integration\Laravel\Facade\EngineRegistry`
+
 How to create a `Schema` file and use your `Engine` can be found [SEAL Documentation](../../README.md#usage).
 
 ### Commands

--- a/integrations/laravel/src/Facade/Engine.php
+++ b/integrations/laravel/src/Facade/Engine.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Schranz Search package.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Schranz\Search\Integration\Laravel\Facade;
+
+use Illuminate\Support\Facades\Facade;
+use Schranz\Search\SEAL\EngineInterface;
+use Schranz\Search\SEAL\Search\SearchBuilder;
+
+/**
+ * @method static void saveDocument(string $index, array $document)
+ * @method static void deleteDocument(string $index, string $identifier)
+ * @method static array<string, mixed> getDocument(string $index, string $identifier)
+ * @method static SearchBuilder createSearchBuilder()
+ * @method static void createIndex(string $index)
+ * @method static void dropIndex(string $index)
+ * @method static bool existIndex(string $index)
+ * @method static void createSchema()
+ * @method static void dropSchema()
+ * @method static void reindex(iterable $reindexProviders, string|null $index = null, bool $dropIndex = false, callable $progressCallback = null)
+ *
+ * @see \Schranz\Search\SEAL\EngineInterface
+ */
+class Engine extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return EngineInterface::class;
+    }
+}

--- a/integrations/laravel/src/Facade/EngineRegistry.php
+++ b/integrations/laravel/src/Facade/EngineRegistry.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Schranz Search package.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Schranz\Search\Integration\Laravel\Facade;
+
+use Illuminate\Support\Facades\Facade;
+use Schranz\Search\SEAL\EngineInterface;
+use Schranz\Search\SEAL\EngineRegistry as SealEngineRegistry;
+
+/**
+ * @method static iterable<string, EngineInterface> getEngines()
+ * @method static EngineInterface getEngine(string $name)
+ *
+ * @see \Schranz\Search\SEAL\EngineRegistry
+ */
+class EngineRegistry extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return SealEngineRegistry::class;
+    }
+}


### PR DESCRIPTION
fixes #180. This add Facade for Engine and EngineRegistry class.

 - `\Schranz\Search\Integration\Laravel\Facade\Engine::...`
 - `\Schranz\Search\Integration\Laravel\Facade\EngineRegistry::...`