### PR TITLE
Replace github action target from pull_request to pull_request_target

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,7 @@
 name: Docs
 
 on:
+    pull_request_target:
     pull_request:
     push:
         branches:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,7 @@
 name: Lint
 
 on:
+    pull_request_target:
     pull_request:
     push:
         branches:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Test
 
 on:
+    pull_request_target:
     pull_request:
     push:
         branches:


### PR DESCRIPTION
This was mention by @kbond to me: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks

This should allow that external PR can run Algolia tests which requires secrets: https://github.com/schranz-search/schranz-search/actions/runs/5192314158