### PR TITLE
Remove general pull_request action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,6 @@ name: Docs
 
 on:
     pull_request_target:
-    pull_request:
     push:
         branches:
             - '[0-9]+.[0-9]+'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,6 @@ name: Lint
 
 on:
     pull_request_target:
-    pull_request:
     push:
         branches:
             - '[0-9]+.[0-9]+'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,6 @@ name: Test
 
 on:
     pull_request_target:
-    pull_request:
     push:
         branches:
             - '[0-9]+.[0-9]+'


### PR DESCRIPTION
pull_request and pull_request_target seems to be produce duplicated actions so we need to remove pull_request.

First I thought I need both because when first adding `pull_request_target` no tests where run. But the `pull_request_target` just need to be get merged and after it it works like expected for fork and not forked PRs.

FYI @kbond 

Related: https://github.com/schranz-search/schranz-search/pull/208