### PR TITLE
Revert run pull request on pull_request_target

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 name: Docs
 
 on:
-    pull_request_target:
+    pull_request:
     push:
         branches:
             - '[0-9]+.[0-9]+'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 name: Lint
 
 on:
-    pull_request_target:
+    pull_request:
     push:
         branches:
             - '[0-9]+.[0-9]+'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test
 
 on:
-    pull_request_target:
+    pull_request:
     push:
         branches:
             - '[0-9]+.[0-9]+'


### PR DESCRIPTION
Run pull request on `pull_request` target does clone the false branch and does not run on the target pull request.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target