### PR TITLE
Fix CI for Loupe Adapter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
         uses: ./.github/workflows/callable-test.yml
         with:
             directory: 'packages/seal-loupe-adapter'
-            docker: true
+            docker: false
 
     redisearch-adapter:
         name: RediSearch Adapter


### PR DESCRIPTION
Loupe does not has a service and so does not require to start docker.