### PR TITLE
Add conflict to doctrine/dbal < 3.6 for loupe adapter

### DIFF
--- a/.examples/laravel/composer.lock
+++ b/.examples/laravel/composer.lock
@@ -9972,13 +9972,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "f36f23e8a6c6dc86f4071705a8f640e177b9fae1"
+                "reference": "02974d0a9a0444a19fcb2c6f3b318f653205ae57"
             },
             "require": {
                 "loupe/loupe": "^0.3",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "schranz-search/seal": "^0.2"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.6.0"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.15",

--- a/.examples/mezzio/composer.lock
+++ b/.examples/mezzio/composer.lock
@@ -6491,12 +6491,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "9160fb2612003a99a28abbd588519d5ab3a77024"
+                "reference": "c16c8b67835bc384c40b9f282b3a49a6f4cb5124"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/9160fb2612003a99a28abbd588519d5ab3a77024",
-                "reference": "9160fb2612003a99a28abbd588519d5ab3a77024",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/c16c8b67835bc384c40b9f282b3a49a6f4cb5124",
+                "reference": "c16c8b67835bc384c40b9f282b3a49a6f4cb5124",
                 "shasum": ""
             },
             "conflict": {
@@ -6662,6 +6662,7 @@
                 "friendsofsymfony/rest-bundle": ">=1.2,<1.2.2",
                 "friendsofsymfony/user-bundle": ">=1.2,<1.3.5",
                 "friendsoftypo3/mediace": ">=7.6.2,<7.6.5",
+                "friendsoftypo3/openid": ">=4.5,<4.5.31|>=4.7,<4.7.16|>=6,<6.0.11|>=6.1,<6.1.6",
                 "froala/wysiwyg-editor": "<3.2.7",
                 "froxlor/froxlor": "<2.1",
                 "fuel/core": "<1.8.1",
@@ -7142,7 +7143,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-23T09:04:12+00:00"
+            "time": "2023-08-29T00:13:38+00:00"
         },
         {
             "name": "schranz-search/seal-algolia-adapter",
@@ -7331,13 +7332,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "f36f23e8a6c6dc86f4071705a8f640e177b9fae1"
+                "reference": "02974d0a9a0444a19fcb2c6f3b318f653205ae57"
             },
             "require": {
                 "loupe/loupe": "^0.3",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "schranz-search/seal": "^0.2"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.6.0"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.15",

--- a/.examples/spiral/composer.lock
+++ b/.examples/spiral/composer.lock
@@ -10590,13 +10590,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "f36f23e8a6c6dc86f4071705a8f640e177b9fae1"
+                "reference": "02974d0a9a0444a19fcb2c6f3b318f653205ae57"
             },
             "require": {
                 "loupe/loupe": "^0.3",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "schranz-search/seal": "^0.2"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.6.0"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.15",

--- a/.examples/symfony/composer.lock
+++ b/.examples/symfony/composer.lock
@@ -6599,13 +6599,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "f36f23e8a6c6dc86f4071705a8f640e177b9fae1"
+                "reference": "02974d0a9a0444a19fcb2c6f3b318f653205ae57"
             },
             "require": {
                 "loupe/loupe": "^0.3",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "schranz-search/seal": "^0.2"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.6.0"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.15",

--- a/.examples/yii/composer.lock
+++ b/.examples/yii/composer.lock
@@ -11603,12 +11603,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "9160fb2612003a99a28abbd588519d5ab3a77024"
+                "reference": "c16c8b67835bc384c40b9f282b3a49a6f4cb5124"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/9160fb2612003a99a28abbd588519d5ab3a77024",
-                "reference": "9160fb2612003a99a28abbd588519d5ab3a77024",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/c16c8b67835bc384c40b9f282b3a49a6f4cb5124",
+                "reference": "c16c8b67835bc384c40b9f282b3a49a6f4cb5124",
                 "shasum": ""
             },
             "conflict": {
@@ -11774,6 +11774,7 @@
                 "friendsofsymfony/rest-bundle": ">=1.2,<1.2.2",
                 "friendsofsymfony/user-bundle": ">=1.2,<1.3.5",
                 "friendsoftypo3/mediace": ">=7.6.2,<7.6.5",
+                "friendsoftypo3/openid": ">=4.5,<4.5.31|>=4.7,<4.7.16|>=6,<6.0.11|>=6.1,<6.1.6",
                 "froala/wysiwyg-editor": "<3.2.7",
                 "froxlor/froxlor": "<2.1",
                 "fuel/core": "<1.8.1",
@@ -12254,7 +12255,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-23T09:04:12+00:00"
+            "time": "2023-08-29T00:13:38+00:00"
         },
         {
             "name": "sanmai/later",
@@ -12566,13 +12567,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "f36f23e8a6c6dc86f4071705a8f640e177b9fae1"
+                "reference": "02974d0a9a0444a19fcb2c6f3b318f653205ae57"
             },
             "require": {
                 "loupe/loupe": "^0.3",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "schranz-search/seal": "^0.2"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.6.0"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.15",

--- a/.github/workflows/callable-test.yml
+++ b/.github/workflows/callable-test.yml
@@ -84,7 +84,7 @@ jobs:
               # so instead of using GitHub variables we require to generate a unique id
               run: |
                   echo "uuid=$(uuidgen)" >> $GITHUB_OUTPUT
-                  echo $GITHUB_OUTPUT
+                  cat $GITHUB_OUTPUT
 
             - name: Run tests
               run: composer test

--- a/integrations/laravel/composer.lock
+++ b/integrations/laravel/composer.lock
@@ -5926,13 +5926,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "f36f23e8a6c6dc86f4071705a8f640e177b9fae1"
+                "reference": "02974d0a9a0444a19fcb2c6f3b318f653205ae57"
             },
             "require": {
                 "loupe/loupe": "^0.3",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "schranz-search/seal": "^0.2"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.6.0"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.15",

--- a/integrations/mezzio/composer.lock
+++ b/integrations/mezzio/composer.lock
@@ -4801,13 +4801,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "f36f23e8a6c6dc86f4071705a8f640e177b9fae1"
+                "reference": "02974d0a9a0444a19fcb2c6f3b318f653205ae57"
             },
             "require": {
                 "loupe/loupe": "^0.3",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "schranz-search/seal": "^0.2"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.6.0"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.15",

--- a/integrations/spiral/composer.lock
+++ b/integrations/spiral/composer.lock
@@ -5352,13 +5352,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "f36f23e8a6c6dc86f4071705a8f640e177b9fae1"
+                "reference": "02974d0a9a0444a19fcb2c6f3b318f653205ae57"
             },
             "require": {
                 "loupe/loupe": "^0.3",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "schranz-search/seal": "^0.2"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.6.0"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.15",

--- a/integrations/symfony/composer.lock
+++ b/integrations/symfony/composer.lock
@@ -5398,13 +5398,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "f36f23e8a6c6dc86f4071705a8f640e177b9fae1"
+                "reference": "02974d0a9a0444a19fcb2c6f3b318f653205ae57"
             },
             "require": {
                 "loupe/loupe": "^0.3",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "schranz-search/seal": "^0.2"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.6.0"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.15",

--- a/integrations/yii/composer.lock
+++ b/integrations/yii/composer.lock
@@ -4793,13 +4793,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "f36f23e8a6c6dc86f4071705a8f640e177b9fae1"
+                "reference": "02974d0a9a0444a19fcb2c6f3b318f653205ae57"
             },
             "require": {
                 "loupe/loupe": "^0.3",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "schranz-search/seal": "^0.2"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.6.0"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.15",

--- a/packages/seal-loupe-adapter/composer.json
+++ b/packages/seal-loupe-adapter/composer.json
@@ -26,6 +26,9 @@
             "email": "alexander@sulu.io"
         }
     ],
+    "conflict": {
+        "doctrine/dbal": "<3.6.0"
+    },
     "require": {
         "php": "^8.1",
         "schranz-search/seal": "^0.2",

--- a/packages/seal-loupe-adapter/composer.lock
+++ b/packages/seal-loupe-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ed2ce695547960731968689dc187a356",
+    "content-hash": "551e70a1b118250bdf2d3f77179d7ccf",
     "packages": [
         {
             "name": "doctrine/cache",


### PR DESCRIPTION
When upgrading to Loupe 0.4 when is released this conflict can be resolved as already be handled by @loupe-php itself. /cc @Toflar 