### PR TITLE
Add support for Loupe 0.4 version

### DIFF
--- a/packages/seal-loupe-adapter/composer.json
+++ b/packages/seal-loupe-adapter/composer.json
@@ -32,7 +32,7 @@
     "require": {
         "php": "^8.1",
         "schranz-search/seal": "^0.2",
-        "loupe/loupe": "^0.3",
+        "loupe/loupe": "^0.3 || ^0.4",
         "psr/container": "^1.0 || ^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
The result of the changed addDocument is currently not used by seal so we can safely support also 0.4.

/cc @Toflar 