### PR TITLE
Upgrade Elasticsearch docker images to 8.11.0

### DIFF
--- a/.examples/laravel/docker-compose.yml
+++ b/.examples/laravel/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.10.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.0
     environment:
       discovery.type: single-node
       xpack.security.enabled: 'false'

--- a/.examples/mezzio/docker-compose.yml
+++ b/.examples/mezzio/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.10.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.0
     environment:
       discovery.type: single-node
       xpack.security.enabled: 'false'

--- a/.examples/spiral/docker-compose.yml
+++ b/.examples/spiral/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.10.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.0
     environment:
       discovery.type: single-node
       xpack.security.enabled: 'false'

--- a/.examples/symfony/docker-compose.yml
+++ b/.examples/symfony/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.10.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.0
     environment:
       discovery.type: single-node
       xpack.security.enabled: 'false'

--- a/.examples/yii/docker-compose.yml
+++ b/.examples/yii/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.10.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.0
     environment:
       discovery.type: single-node
       xpack.security.enabled: 'false'

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -1506,7 +1506,7 @@ search engine.
 
             services:
               elasticsearch:
-                image: docker.elastic.co/elasticsearch/elasticsearch:8.8.0
+                image: docker.elastic.co/elasticsearch/elasticsearch:8.11.0
                 environment:
                   discovery.type: single-node
                   xpack.security.enabled: 'false'

--- a/packages/seal-elasticsearch-adapter/docker-compose.yml
+++ b/packages/seal-elasticsearch-adapter/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.10.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.0
     environment:
       discovery.type: single-node
       xpack.security.enabled: 'false'


### PR DESCRIPTION
A new version of Elasticsearch docker images where added. This will update our used images and the docs images to the latest 8.11.0 versin.