### PR TITLE
Add missing \r\n line break to test suite

### DIFF
--- a/packages/seal/src/Testing/AbstractSearcherTestCase.php
+++ b/packages/seal/src/Testing/AbstractSearcherTestCase.php
@@ -325,7 +325,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         }
     }
 
-    public function testEqualConditionSpecialString(string $specialString = "^The 17\" O'Conner && O`Series \n OR a || 1%2 1~2 1*2 \n book? \r \twhat \\ text: }{ )( ][ - + // \n\r ok? end$"): void
+    public function testEqualConditionSpecialString(string $specialString = "^The 17\" O'Conner && O`Series \n OR a || 1%2 1~2 1*2 \r\n book? \r \twhat \\ text: }{ )( ][ - + // \n\r ok? end$"): void
     {
         $documents = TestingHelper::createComplexFixtures();
 


### PR DESCRIPTION
Bug was fixed in #302 / #303  but the test was not modified correctly.