### PR TITLE
Fix documentation build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,10 @@ jobs:
               run: |
                   pip install -r docs/requirements.txt
 
+            - name: List dependencies
+              run: |
+                  pip list
+
             - name: Sphinx build
               run: |
                   sphinx-build docs docs/_build

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 furo==2023.3.27
 sphinx-tabs==3.4.1
+setuptools==68.2.2


### PR DESCRIPTION
Fixes:

```

Run sphinx-build docs docs/_build
Running Sphinx v6.2.1

Extension error:
Could not import extension sphinx_tabs.tabs (exception: No module named 'pkg_resources')
```

Not sure if this fixes it but looks like setuptools are required.