### PR TITLE
Add Support for Loupe 0.5

### DIFF
--- a/.examples/laravel/composer.lock
+++ b/.examples/laravel/composer.lock
@@ -7235,16 +7235,16 @@
         },
         {
             "name": "loupe/loupe",
-            "version": "0.4.0",
+            "version": "0.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/loupe-php/loupe.git",
-                "reference": "2fc7306899d89ed8e71a21c9636b9871d7951699"
+                "reference": "36bfaa32fb5acf1b33fbbce9f28e900ec02ca244"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/2fc7306899d89ed8e71a21c9636b9871d7951699",
-                "reference": "2fc7306899d89ed8e71a21c9636b9871d7951699",
+                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/36bfaa32fb5acf1b33fbbce9f28e900ec02ca244",
+                "reference": "36bfaa32fb5acf1b33fbbce9f28e900ec02ca244",
                 "shasum": ""
             },
             "require": {
@@ -7255,7 +7255,7 @@
                 "nitotm/efficient-language-detector": "^2.0",
                 "php": "^8.1",
                 "psr/log": "^3.0",
-                "toflar/state-set-index": "^1.0",
+                "toflar/state-set-index": "^2.0.1",
                 "voku/portable-utf8": "^6.0",
                 "wamania/php-stemmer": "^3.0"
             },
@@ -7286,7 +7286,7 @@
             "description": "A full text search engine with tokenization, stemming, typo tolerance, filters and geo support based on only PHP and SQLite",
             "support": {
                 "issues": "https://github.com/loupe-php/loupe/issues",
-                "source": "https://github.com/loupe-php/loupe/tree/0.4.0"
+                "source": "https://github.com/loupe-php/loupe/tree/0.5.3"
             },
             "funding": [
                 {
@@ -7294,7 +7294,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-01T12:04:21+00:00"
+            "time": "2023-12-19T16:49:00+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -10038,10 +10038,10 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "91074d444ab6182a1f55d419322421976b4165d5"
+                "reference": "a13ba2ba5ae643b7b37be86ef13872254f50ac9e"
             },
             "require": {
-                "loupe/loupe": "^0.3 || ^0.4",
+                "loupe/loupe": "^0.5",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "schranz-search/seal": "^0.2"
@@ -12708,16 +12708,16 @@
         },
         {
             "name": "toflar/state-set-index",
-            "version": "1.0.2",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Toflar/state-set-index.git",
-                "reference": "a4277c050b69d8d5fb61d27aee4eef2092b4fac3"
+                "reference": "27fe48fd7c231a7ec5b495ca7f6e433b0add0519"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Toflar/state-set-index/zipball/a4277c050b69d8d5fb61d27aee4eef2092b4fac3",
-                "reference": "a4277c050b69d8d5fb61d27aee4eef2092b4fac3",
+                "url": "https://api.github.com/repos/Toflar/state-set-index/zipball/27fe48fd7c231a7ec5b495ca7f6e433b0add0519",
+                "reference": "27fe48fd7c231a7ec5b495ca7f6e433b0add0519",
                 "shasum": ""
             },
             "require": {
@@ -12747,9 +12747,9 @@
             "description": "Implementation of the State Set Index Algorithm",
             "support": {
                 "issues": "https://github.com/Toflar/state-set-index/issues",
-                "source": "https://github.com/Toflar/state-set-index/tree/1.0.2"
+                "source": "https://github.com/Toflar/state-set-index/tree/2.0.1"
             },
-            "time": "2023-08-18T10:03:59+00:00"
+            "time": "2023-10-06T07:27:46+00:00"
         },
         {
             "name": "typesense/typesense-php",

--- a/.examples/mezzio/composer.lock
+++ b/.examples/mezzio/composer.lock
@@ -4279,16 +4279,16 @@
         },
         {
             "name": "loupe/loupe",
-            "version": "0.4.0",
+            "version": "0.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/loupe-php/loupe.git",
-                "reference": "2fc7306899d89ed8e71a21c9636b9871d7951699"
+                "reference": "36bfaa32fb5acf1b33fbbce9f28e900ec02ca244"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/2fc7306899d89ed8e71a21c9636b9871d7951699",
-                "reference": "2fc7306899d89ed8e71a21c9636b9871d7951699",
+                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/36bfaa32fb5acf1b33fbbce9f28e900ec02ca244",
+                "reference": "36bfaa32fb5acf1b33fbbce9f28e900ec02ca244",
                 "shasum": ""
             },
             "require": {
@@ -4299,7 +4299,7 @@
                 "nitotm/efficient-language-detector": "^2.0",
                 "php": "^8.1",
                 "psr/log": "^3.0",
-                "toflar/state-set-index": "^1.0",
+                "toflar/state-set-index": "^2.0.1",
                 "voku/portable-utf8": "^6.0",
                 "wamania/php-stemmer": "^3.0"
             },
@@ -4330,7 +4330,7 @@
             "description": "A full text search engine with tokenization, stemming, typo tolerance, filters and geo support based on only PHP and SQLite",
             "support": {
                 "issues": "https://github.com/loupe-php/loupe/issues",
-                "source": "https://github.com/loupe-php/loupe/tree/0.4.0"
+                "source": "https://github.com/loupe-php/loupe/tree/0.5.3"
             },
             "funding": [
                 {
@@ -4338,7 +4338,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-01T12:04:21+00:00"
+            "time": "2023-12-19T16:49:00+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -7350,10 +7350,10 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "91074d444ab6182a1f55d419322421976b4165d5"
+                "reference": "a13ba2ba5ae643b7b37be86ef13872254f50ac9e"
             },
             "require": {
-                "loupe/loupe": "^0.3 || ^0.4",
+                "loupe/loupe": "^0.5",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "schranz-search/seal": "^0.2"
@@ -9784,16 +9784,16 @@
         },
         {
             "name": "toflar/state-set-index",
-            "version": "1.0.2",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Toflar/state-set-index.git",
-                "reference": "a4277c050b69d8d5fb61d27aee4eef2092b4fac3"
+                "reference": "27fe48fd7c231a7ec5b495ca7f6e433b0add0519"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Toflar/state-set-index/zipball/a4277c050b69d8d5fb61d27aee4eef2092b4fac3",
-                "reference": "a4277c050b69d8d5fb61d27aee4eef2092b4fac3",
+                "url": "https://api.github.com/repos/Toflar/state-set-index/zipball/27fe48fd7c231a7ec5b495ca7f6e433b0add0519",
+                "reference": "27fe48fd7c231a7ec5b495ca7f6e433b0add0519",
                 "shasum": ""
             },
             "require": {
@@ -9823,9 +9823,9 @@
             "description": "Implementation of the State Set Index Algorithm",
             "support": {
                 "issues": "https://github.com/Toflar/state-set-index/issues",
-                "source": "https://github.com/Toflar/state-set-index/tree/1.0.2"
+                "source": "https://github.com/Toflar/state-set-index/tree/2.0.1"
             },
-            "time": "2023-08-18T10:03:59+00:00"
+            "time": "2023-10-06T07:27:46+00:00"
         },
         {
             "name": "typesense/typesense-php",

--- a/.examples/spiral/composer.lock
+++ b/.examples/spiral/composer.lock
@@ -8333,16 +8333,16 @@
         },
         {
             "name": "loupe/loupe",
-            "version": "0.4.0",
+            "version": "0.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/loupe-php/loupe.git",
-                "reference": "2fc7306899d89ed8e71a21c9636b9871d7951699"
+                "reference": "36bfaa32fb5acf1b33fbbce9f28e900ec02ca244"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/2fc7306899d89ed8e71a21c9636b9871d7951699",
-                "reference": "2fc7306899d89ed8e71a21c9636b9871d7951699",
+                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/36bfaa32fb5acf1b33fbbce9f28e900ec02ca244",
+                "reference": "36bfaa32fb5acf1b33fbbce9f28e900ec02ca244",
                 "shasum": ""
             },
             "require": {
@@ -8353,7 +8353,7 @@
                 "nitotm/efficient-language-detector": "^2.0",
                 "php": "^8.1",
                 "psr/log": "^3.0",
-                "toflar/state-set-index": "^1.0",
+                "toflar/state-set-index": "^2.0.1",
                 "voku/portable-utf8": "^6.0",
                 "wamania/php-stemmer": "^3.0"
             },
@@ -8384,7 +8384,7 @@
             "description": "A full text search engine with tokenization, stemming, typo tolerance, filters and geo support based on only PHP and SQLite",
             "support": {
                 "issues": "https://github.com/loupe-php/loupe/issues",
-                "source": "https://github.com/loupe-php/loupe/tree/0.4.0"
+                "source": "https://github.com/loupe-php/loupe/tree/0.5.3"
             },
             "funding": [
                 {
@@ -8392,7 +8392,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-01T12:04:21+00:00"
+            "time": "2023-12-19T16:49:00+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -10690,10 +10690,10 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "91074d444ab6182a1f55d419322421976b4165d5"
+                "reference": "a13ba2ba5ae643b7b37be86ef13872254f50ac9e"
             },
             "require": {
-                "loupe/loupe": "^0.3 || ^0.4",
+                "loupe/loupe": "^0.5",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "schranz-search/seal": "^0.2"
@@ -13129,16 +13129,16 @@
         },
         {
             "name": "toflar/state-set-index",
-            "version": "1.0.2",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Toflar/state-set-index.git",
-                "reference": "a4277c050b69d8d5fb61d27aee4eef2092b4fac3"
+                "reference": "27fe48fd7c231a7ec5b495ca7f6e433b0add0519"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Toflar/state-set-index/zipball/a4277c050b69d8d5fb61d27aee4eef2092b4fac3",
-                "reference": "a4277c050b69d8d5fb61d27aee4eef2092b4fac3",
+                "url": "https://api.github.com/repos/Toflar/state-set-index/zipball/27fe48fd7c231a7ec5b495ca7f6e433b0add0519",
+                "reference": "27fe48fd7c231a7ec5b495ca7f6e433b0add0519",
                 "shasum": ""
             },
             "require": {
@@ -13168,9 +13168,9 @@
             "description": "Implementation of the State Set Index Algorithm",
             "support": {
                 "issues": "https://github.com/Toflar/state-set-index/issues",
-                "source": "https://github.com/Toflar/state-set-index/tree/1.0.2"
+                "source": "https://github.com/Toflar/state-set-index/tree/2.0.1"
             },
-            "time": "2023-08-18T10:03:59+00:00"
+            "time": "2023-10-06T07:27:46+00:00"
         },
         {
             "name": "typesense/typesense-php",

--- a/.examples/symfony/composer.lock
+++ b/.examples/symfony/composer.lock
@@ -4282,16 +4282,16 @@
         },
         {
             "name": "loupe/loupe",
-            "version": "0.4.0",
+            "version": "0.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/loupe-php/loupe.git",
-                "reference": "2fc7306899d89ed8e71a21c9636b9871d7951699"
+                "reference": "36bfaa32fb5acf1b33fbbce9f28e900ec02ca244"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/2fc7306899d89ed8e71a21c9636b9871d7951699",
-                "reference": "2fc7306899d89ed8e71a21c9636b9871d7951699",
+                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/36bfaa32fb5acf1b33fbbce9f28e900ec02ca244",
+                "reference": "36bfaa32fb5acf1b33fbbce9f28e900ec02ca244",
                 "shasum": ""
             },
             "require": {
@@ -4302,7 +4302,7 @@
                 "nitotm/efficient-language-detector": "^2.0",
                 "php": "^8.1",
                 "psr/log": "^3.0",
-                "toflar/state-set-index": "^1.0",
+                "toflar/state-set-index": "^2.0.1",
                 "voku/portable-utf8": "^6.0",
                 "wamania/php-stemmer": "^3.0"
             },
@@ -4333,7 +4333,7 @@
             "description": "A full text search engine with tokenization, stemming, typo tolerance, filters and geo support based on only PHP and SQLite",
             "support": {
                 "issues": "https://github.com/loupe-php/loupe/issues",
-                "source": "https://github.com/loupe-php/loupe/tree/0.4.0"
+                "source": "https://github.com/loupe-php/loupe/tree/0.5.3"
             },
             "funding": [
                 {
@@ -4341,7 +4341,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-01T12:04:21+00:00"
+            "time": "2023-12-19T16:49:00+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -6560,10 +6560,10 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "91074d444ab6182a1f55d419322421976b4165d5"
+                "reference": "a13ba2ba5ae643b7b37be86ef13872254f50ac9e"
             },
             "require": {
-                "loupe/loupe": "^0.3 || ^0.4",
+                "loupe/loupe": "^0.5",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "schranz-search/seal": "^0.2"
@@ -8671,16 +8671,16 @@
         },
         {
             "name": "toflar/state-set-index",
-            "version": "1.0.2",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Toflar/state-set-index.git",
-                "reference": "a4277c050b69d8d5fb61d27aee4eef2092b4fac3"
+                "reference": "27fe48fd7c231a7ec5b495ca7f6e433b0add0519"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Toflar/state-set-index/zipball/a4277c050b69d8d5fb61d27aee4eef2092b4fac3",
-                "reference": "a4277c050b69d8d5fb61d27aee4eef2092b4fac3",
+                "url": "https://api.github.com/repos/Toflar/state-set-index/zipball/27fe48fd7c231a7ec5b495ca7f6e433b0add0519",
+                "reference": "27fe48fd7c231a7ec5b495ca7f6e433b0add0519",
                 "shasum": ""
             },
             "require": {
@@ -8710,9 +8710,9 @@
             "description": "Implementation of the State Set Index Algorithm",
             "support": {
                 "issues": "https://github.com/Toflar/state-set-index/issues",
-                "source": "https://github.com/Toflar/state-set-index/tree/1.0.2"
+                "source": "https://github.com/Toflar/state-set-index/tree/2.0.1"
             },
-            "time": "2023-08-18T10:03:59+00:00"
+            "time": "2023-10-06T07:27:46+00:00"
         },
         {
             "name": "typesense/typesense-php",

--- a/.examples/yii/composer.lock
+++ b/.examples/yii/composer.lock
@@ -8909,16 +8909,16 @@
         },
         {
             "name": "loupe/loupe",
-            "version": "0.4.0",
+            "version": "0.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/loupe-php/loupe.git",
-                "reference": "2fc7306899d89ed8e71a21c9636b9871d7951699"
+                "reference": "36bfaa32fb5acf1b33fbbce9f28e900ec02ca244"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/2fc7306899d89ed8e71a21c9636b9871d7951699",
-                "reference": "2fc7306899d89ed8e71a21c9636b9871d7951699",
+                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/36bfaa32fb5acf1b33fbbce9f28e900ec02ca244",
+                "reference": "36bfaa32fb5acf1b33fbbce9f28e900ec02ca244",
                 "shasum": ""
             },
             "require": {
@@ -8929,7 +8929,7 @@
                 "nitotm/efficient-language-detector": "^2.0",
                 "php": "^8.1",
                 "psr/log": "^3.0",
-                "toflar/state-set-index": "^1.0",
+                "toflar/state-set-index": "^2.0.1",
                 "voku/portable-utf8": "^6.0",
                 "wamania/php-stemmer": "^3.0"
             },
@@ -8960,7 +8960,7 @@
             "description": "A full text search engine with tokenization, stemming, typo tolerance, filters and geo support based on only PHP and SQLite",
             "support": {
                 "issues": "https://github.com/loupe-php/loupe/issues",
-                "source": "https://github.com/loupe-php/loupe/tree/0.4.0"
+                "source": "https://github.com/loupe-php/loupe/tree/0.5.3"
             },
             "funding": [
                 {
@@ -8968,7 +8968,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-01T12:04:21+00:00"
+            "time": "2023-12-19T16:49:00+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -12514,10 +12514,10 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "91074d444ab6182a1f55d419322421976b4165d5"
+                "reference": "a13ba2ba5ae643b7b37be86ef13872254f50ac9e"
             },
             "require": {
-                "loupe/loupe": "^0.3 || ^0.4",
+                "loupe/loupe": "^0.5",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "schranz-search/seal": "^0.2"
@@ -15609,16 +15609,16 @@
         },
         {
             "name": "toflar/state-set-index",
-            "version": "1.0.2",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Toflar/state-set-index.git",
-                "reference": "a4277c050b69d8d5fb61d27aee4eef2092b4fac3"
+                "reference": "27fe48fd7c231a7ec5b495ca7f6e433b0add0519"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Toflar/state-set-index/zipball/a4277c050b69d8d5fb61d27aee4eef2092b4fac3",
-                "reference": "a4277c050b69d8d5fb61d27aee4eef2092b4fac3",
+                "url": "https://api.github.com/repos/Toflar/state-set-index/zipball/27fe48fd7c231a7ec5b495ca7f6e433b0add0519",
+                "reference": "27fe48fd7c231a7ec5b495ca7f6e433b0add0519",
                 "shasum": ""
             },
             "require": {
@@ -15648,9 +15648,9 @@
             "description": "Implementation of the State Set Index Algorithm",
             "support": {
                 "issues": "https://github.com/Toflar/state-set-index/issues",
-                "source": "https://github.com/Toflar/state-set-index/tree/1.0.2"
+                "source": "https://github.com/Toflar/state-set-index/tree/2.0.1"
             },
-            "time": "2023-08-18T10:03:59+00:00"
+            "time": "2023-10-06T07:27:46+00:00"
         },
         {
             "name": "typesense/typesense-php",

--- a/integrations/laravel/composer.lock
+++ b/integrations/laravel/composer.lock
@@ -3616,16 +3616,16 @@
         },
         {
             "name": "loupe/loupe",
-            "version": "0.4.0",
+            "version": "0.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/loupe-php/loupe.git",
-                "reference": "2fc7306899d89ed8e71a21c9636b9871d7951699"
+                "reference": "36bfaa32fb5acf1b33fbbce9f28e900ec02ca244"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/2fc7306899d89ed8e71a21c9636b9871d7951699",
-                "reference": "2fc7306899d89ed8e71a21c9636b9871d7951699",
+                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/36bfaa32fb5acf1b33fbbce9f28e900ec02ca244",
+                "reference": "36bfaa32fb5acf1b33fbbce9f28e900ec02ca244",
                 "shasum": ""
             },
             "require": {
@@ -3636,7 +3636,7 @@
                 "nitotm/efficient-language-detector": "^2.0",
                 "php": "^8.1",
                 "psr/log": "^3.0",
-                "toflar/state-set-index": "^1.0",
+                "toflar/state-set-index": "^2.0.1",
                 "voku/portable-utf8": "^6.0",
                 "wamania/php-stemmer": "^3.0"
             },
@@ -3667,7 +3667,7 @@
             "description": "A full text search engine with tokenization, stemming, typo tolerance, filters and geo support based on only PHP and SQLite",
             "support": {
                 "issues": "https://github.com/loupe-php/loupe/issues",
-                "source": "https://github.com/loupe-php/loupe/tree/0.4.0"
+                "source": "https://github.com/loupe-php/loupe/tree/0.5.3"
             },
             "funding": [
                 {
@@ -3675,7 +3675,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-01T12:04:21+00:00"
+            "time": "2023-12-19T16:49:00+00:00"
         },
         {
             "name": "meilisearch/meilisearch-php",
@@ -6015,10 +6015,10 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "91074d444ab6182a1f55d419322421976b4165d5"
+                "reference": "a13ba2ba5ae643b7b37be86ef13872254f50ac9e"
             },
             "require": {
-                "loupe/loupe": "^0.3 || ^0.4",
+                "loupe/loupe": "^0.5",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "schranz-search/seal": "^0.2"
@@ -8344,16 +8344,16 @@
         },
         {
             "name": "toflar/state-set-index",
-            "version": "1.0.2",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Toflar/state-set-index.git",
-                "reference": "a4277c050b69d8d5fb61d27aee4eef2092b4fac3"
+                "reference": "27fe48fd7c231a7ec5b495ca7f6e433b0add0519"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Toflar/state-set-index/zipball/a4277c050b69d8d5fb61d27aee4eef2092b4fac3",
-                "reference": "a4277c050b69d8d5fb61d27aee4eef2092b4fac3",
+                "url": "https://api.github.com/repos/Toflar/state-set-index/zipball/27fe48fd7c231a7ec5b495ca7f6e433b0add0519",
+                "reference": "27fe48fd7c231a7ec5b495ca7f6e433b0add0519",
                 "shasum": ""
             },
             "require": {
@@ -8383,9 +8383,9 @@
             "description": "Implementation of the State Set Index Algorithm",
             "support": {
                 "issues": "https://github.com/Toflar/state-set-index/issues",
-                "source": "https://github.com/Toflar/state-set-index/tree/1.0.2"
+                "source": "https://github.com/Toflar/state-set-index/tree/2.0.1"
             },
-            "time": "2023-08-18T10:03:59+00:00"
+            "time": "2023-10-06T07:27:46+00:00"
         },
         {
             "name": "typesense/typesense-php",

--- a/integrations/mezzio/composer.lock
+++ b/integrations/mezzio/composer.lock
@@ -2408,16 +2408,16 @@
         },
         {
             "name": "loupe/loupe",
-            "version": "0.4.0",
+            "version": "0.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/loupe-php/loupe.git",
-                "reference": "2fc7306899d89ed8e71a21c9636b9871d7951699"
+                "reference": "36bfaa32fb5acf1b33fbbce9f28e900ec02ca244"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/2fc7306899d89ed8e71a21c9636b9871d7951699",
-                "reference": "2fc7306899d89ed8e71a21c9636b9871d7951699",
+                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/36bfaa32fb5acf1b33fbbce9f28e900ec02ca244",
+                "reference": "36bfaa32fb5acf1b33fbbce9f28e900ec02ca244",
                 "shasum": ""
             },
             "require": {
@@ -2428,7 +2428,7 @@
                 "nitotm/efficient-language-detector": "^2.0",
                 "php": "^8.1",
                 "psr/log": "^3.0",
-                "toflar/state-set-index": "^1.0",
+                "toflar/state-set-index": "^2.0.1",
                 "voku/portable-utf8": "^6.0",
                 "wamania/php-stemmer": "^3.0"
             },
@@ -2459,7 +2459,7 @@
             "description": "A full text search engine with tokenization, stemming, typo tolerance, filters and geo support based on only PHP and SQLite",
             "support": {
                 "issues": "https://github.com/loupe-php/loupe/issues",
-                "source": "https://github.com/loupe-php/loupe/tree/0.4.0"
+                "source": "https://github.com/loupe-php/loupe/tree/0.5.3"
             },
             "funding": [
                 {
@@ -2467,7 +2467,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-01T12:04:21+00:00"
+            "time": "2023-12-19T16:49:00+00:00"
         },
         {
             "name": "meilisearch/meilisearch-php",
@@ -4806,10 +4806,10 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "91074d444ab6182a1f55d419322421976b4165d5"
+                "reference": "a13ba2ba5ae643b7b37be86ef13872254f50ac9e"
             },
             "require": {
-                "loupe/loupe": "^0.3 || ^0.4",
+                "loupe/loupe": "^0.5",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "schranz-search/seal": "^0.2"
@@ -7058,16 +7058,16 @@
         },
         {
             "name": "toflar/state-set-index",
-            "version": "1.0.2",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Toflar/state-set-index.git",
-                "reference": "a4277c050b69d8d5fb61d27aee4eef2092b4fac3"
+                "reference": "27fe48fd7c231a7ec5b495ca7f6e433b0add0519"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Toflar/state-set-index/zipball/a4277c050b69d8d5fb61d27aee4eef2092b4fac3",
-                "reference": "a4277c050b69d8d5fb61d27aee4eef2092b4fac3",
+                "url": "https://api.github.com/repos/Toflar/state-set-index/zipball/27fe48fd7c231a7ec5b495ca7f6e433b0add0519",
+                "reference": "27fe48fd7c231a7ec5b495ca7f6e433b0add0519",
                 "shasum": ""
             },
             "require": {
@@ -7097,9 +7097,9 @@
             "description": "Implementation of the State Set Index Algorithm",
             "support": {
                 "issues": "https://github.com/Toflar/state-set-index/issues",
-                "source": "https://github.com/Toflar/state-set-index/tree/1.0.2"
+                "source": "https://github.com/Toflar/state-set-index/tree/2.0.1"
             },
-            "time": "2023-08-18T10:03:59+00:00"
+            "time": "2023-10-06T07:27:46+00:00"
         },
         {
             "name": "typesense/typesense-php",

--- a/integrations/spiral/composer.lock
+++ b/integrations/spiral/composer.lock
@@ -3135,16 +3135,16 @@
         },
         {
             "name": "loupe/loupe",
-            "version": "0.4.0",
+            "version": "0.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/loupe-php/loupe.git",
-                "reference": "2fc7306899d89ed8e71a21c9636b9871d7951699"
+                "reference": "36bfaa32fb5acf1b33fbbce9f28e900ec02ca244"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/2fc7306899d89ed8e71a21c9636b9871d7951699",
-                "reference": "2fc7306899d89ed8e71a21c9636b9871d7951699",
+                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/36bfaa32fb5acf1b33fbbce9f28e900ec02ca244",
+                "reference": "36bfaa32fb5acf1b33fbbce9f28e900ec02ca244",
                 "shasum": ""
             },
             "require": {
@@ -3155,7 +3155,7 @@
                 "nitotm/efficient-language-detector": "^2.0",
                 "php": "^8.1",
                 "psr/log": "^3.0",
-                "toflar/state-set-index": "^1.0",
+                "toflar/state-set-index": "^2.0.1",
                 "voku/portable-utf8": "^6.0",
                 "wamania/php-stemmer": "^3.0"
             },
@@ -3186,7 +3186,7 @@
             "description": "A full text search engine with tokenization, stemming, typo tolerance, filters and geo support based on only PHP and SQLite",
             "support": {
                 "issues": "https://github.com/loupe-php/loupe/issues",
-                "source": "https://github.com/loupe-php/loupe/tree/0.4.0"
+                "source": "https://github.com/loupe-php/loupe/tree/0.5.3"
             },
             "funding": [
                 {
@@ -3194,7 +3194,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-01T12:04:21+00:00"
+            "time": "2023-12-19T16:49:00+00:00"
         },
         {
             "name": "meilisearch/meilisearch-php",
@@ -5377,10 +5377,10 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "91074d444ab6182a1f55d419322421976b4165d5"
+                "reference": "a13ba2ba5ae643b7b37be86ef13872254f50ac9e"
             },
             "require": {
-                "loupe/loupe": "^0.3 || ^0.4",
+                "loupe/loupe": "^0.5",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "schranz-search/seal": "^0.2"
@@ -7790,16 +7790,16 @@
         },
         {
             "name": "toflar/state-set-index",
-            "version": "1.0.2",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Toflar/state-set-index.git",
-                "reference": "a4277c050b69d8d5fb61d27aee4eef2092b4fac3"
+                "reference": "27fe48fd7c231a7ec5b495ca7f6e433b0add0519"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Toflar/state-set-index/zipball/a4277c050b69d8d5fb61d27aee4eef2092b4fac3",
-                "reference": "a4277c050b69d8d5fb61d27aee4eef2092b4fac3",
+                "url": "https://api.github.com/repos/Toflar/state-set-index/zipball/27fe48fd7c231a7ec5b495ca7f6e433b0add0519",
+                "reference": "27fe48fd7c231a7ec5b495ca7f6e433b0add0519",
                 "shasum": ""
             },
             "require": {
@@ -7829,9 +7829,9 @@
             "description": "Implementation of the State Set Index Algorithm",
             "support": {
                 "issues": "https://github.com/Toflar/state-set-index/issues",
-                "source": "https://github.com/Toflar/state-set-index/tree/1.0.2"
+                "source": "https://github.com/Toflar/state-set-index/tree/2.0.1"
             },
-            "time": "2023-08-18T10:03:59+00:00"
+            "time": "2023-10-06T07:27:46+00:00"
         },
         {
             "name": "typesense/typesense-php",

--- a/integrations/symfony/composer.lock
+++ b/integrations/symfony/composer.lock
@@ -3057,16 +3057,16 @@
         },
         {
             "name": "loupe/loupe",
-            "version": "0.4.0",
+            "version": "0.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/loupe-php/loupe.git",
-                "reference": "2fc7306899d89ed8e71a21c9636b9871d7951699"
+                "reference": "36bfaa32fb5acf1b33fbbce9f28e900ec02ca244"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/2fc7306899d89ed8e71a21c9636b9871d7951699",
-                "reference": "2fc7306899d89ed8e71a21c9636b9871d7951699",
+                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/36bfaa32fb5acf1b33fbbce9f28e900ec02ca244",
+                "reference": "36bfaa32fb5acf1b33fbbce9f28e900ec02ca244",
                 "shasum": ""
             },
             "require": {
@@ -3077,7 +3077,7 @@
                 "nitotm/efficient-language-detector": "^2.0",
                 "php": "^8.1",
                 "psr/log": "^3.0",
-                "toflar/state-set-index": "^1.0",
+                "toflar/state-set-index": "^2.0.1",
                 "voku/portable-utf8": "^6.0",
                 "wamania/php-stemmer": "^3.0"
             },
@@ -3108,7 +3108,7 @@
             "description": "A full text search engine with tokenization, stemming, typo tolerance, filters and geo support based on only PHP and SQLite",
             "support": {
                 "issues": "https://github.com/loupe-php/loupe/issues",
-                "source": "https://github.com/loupe-php/loupe/tree/0.4.0"
+                "source": "https://github.com/loupe-php/loupe/tree/0.5.3"
             },
             "funding": [
                 {
@@ -3116,7 +3116,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-01T12:04:21+00:00"
+            "time": "2023-12-19T16:49:00+00:00"
         },
         {
             "name": "meilisearch/meilisearch-php",
@@ -5404,10 +5404,10 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "91074d444ab6182a1f55d419322421976b4165d5"
+                "reference": "a13ba2ba5ae643b7b37be86ef13872254f50ac9e"
             },
             "require": {
-                "loupe/loupe": "^0.3 || ^0.4",
+                "loupe/loupe": "^0.5",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "schranz-search/seal": "^0.2"
@@ -7656,16 +7656,16 @@
         },
         {
             "name": "toflar/state-set-index",
-            "version": "1.0.2",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Toflar/state-set-index.git",
-                "reference": "a4277c050b69d8d5fb61d27aee4eef2092b4fac3"
+                "reference": "27fe48fd7c231a7ec5b495ca7f6e433b0add0519"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Toflar/state-set-index/zipball/a4277c050b69d8d5fb61d27aee4eef2092b4fac3",
-                "reference": "a4277c050b69d8d5fb61d27aee4eef2092b4fac3",
+                "url": "https://api.github.com/repos/Toflar/state-set-index/zipball/27fe48fd7c231a7ec5b495ca7f6e433b0add0519",
+                "reference": "27fe48fd7c231a7ec5b495ca7f6e433b0add0519",
                 "shasum": ""
             },
             "require": {
@@ -7695,9 +7695,9 @@
             "description": "Implementation of the State Set Index Algorithm",
             "support": {
                 "issues": "https://github.com/Toflar/state-set-index/issues",
-                "source": "https://github.com/Toflar/state-set-index/tree/1.0.2"
+                "source": "https://github.com/Toflar/state-set-index/tree/2.0.1"
             },
-            "time": "2023-08-18T10:03:59+00:00"
+            "time": "2023-10-06T07:27:46+00:00"
         },
         {
             "name": "typesense/typesense-php",

--- a/integrations/yii/composer.lock
+++ b/integrations/yii/composer.lock
@@ -2450,16 +2450,16 @@
         },
         {
             "name": "loupe/loupe",
-            "version": "0.4.0",
+            "version": "0.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/loupe-php/loupe.git",
-                "reference": "2fc7306899d89ed8e71a21c9636b9871d7951699"
+                "reference": "36bfaa32fb5acf1b33fbbce9f28e900ec02ca244"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/2fc7306899d89ed8e71a21c9636b9871d7951699",
-                "reference": "2fc7306899d89ed8e71a21c9636b9871d7951699",
+                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/36bfaa32fb5acf1b33fbbce9f28e900ec02ca244",
+                "reference": "36bfaa32fb5acf1b33fbbce9f28e900ec02ca244",
                 "shasum": ""
             },
             "require": {
@@ -2470,7 +2470,7 @@
                 "nitotm/efficient-language-detector": "^2.0",
                 "php": "^8.1",
                 "psr/log": "^3.0",
-                "toflar/state-set-index": "^1.0",
+                "toflar/state-set-index": "^2.0.1",
                 "voku/portable-utf8": "^6.0",
                 "wamania/php-stemmer": "^3.0"
             },
@@ -2501,7 +2501,7 @@
             "description": "A full text search engine with tokenization, stemming, typo tolerance, filters and geo support based on only PHP and SQLite",
             "support": {
                 "issues": "https://github.com/loupe-php/loupe/issues",
-                "source": "https://github.com/loupe-php/loupe/tree/0.4.0"
+                "source": "https://github.com/loupe-php/loupe/tree/0.5.3"
             },
             "funding": [
                 {
@@ -2509,7 +2509,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-01T12:04:21+00:00"
+            "time": "2023-12-19T16:49:00+00:00"
         },
         {
             "name": "meilisearch/meilisearch-php",
@@ -4797,10 +4797,10 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "91074d444ab6182a1f55d419322421976b4165d5"
+                "reference": "a13ba2ba5ae643b7b37be86ef13872254f50ac9e"
             },
             "require": {
-                "loupe/loupe": "^0.3 || ^0.4",
+                "loupe/loupe": "^0.5",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "schranz-search/seal": "^0.2"
@@ -7133,16 +7133,16 @@
         },
         {
             "name": "toflar/state-set-index",
-            "version": "1.0.2",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Toflar/state-set-index.git",
-                "reference": "a4277c050b69d8d5fb61d27aee4eef2092b4fac3"
+                "reference": "27fe48fd7c231a7ec5b495ca7f6e433b0add0519"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Toflar/state-set-index/zipball/a4277c050b69d8d5fb61d27aee4eef2092b4fac3",
-                "reference": "a4277c050b69d8d5fb61d27aee4eef2092b4fac3",
+                "url": "https://api.github.com/repos/Toflar/state-set-index/zipball/27fe48fd7c231a7ec5b495ca7f6e433b0add0519",
+                "reference": "27fe48fd7c231a7ec5b495ca7f6e433b0add0519",
                 "shasum": ""
             },
             "require": {
@@ -7172,9 +7172,9 @@
             "description": "Implementation of the State Set Index Algorithm",
             "support": {
                 "issues": "https://github.com/Toflar/state-set-index/issues",
-                "source": "https://github.com/Toflar/state-set-index/tree/1.0.2"
+                "source": "https://github.com/Toflar/state-set-index/tree/2.0.1"
             },
-            "time": "2023-08-18T10:03:59+00:00"
+            "time": "2023-10-06T07:27:46+00:00"
         },
         {
             "name": "typesense/typesense-php",

--- a/packages/seal-loupe-adapter/composer.json
+++ b/packages/seal-loupe-adapter/composer.json
@@ -32,7 +32,7 @@
     "require": {
         "php": "^8.1",
         "schranz-search/seal": "^0.2",
-        "loupe/loupe": "^0.3 || ^0.4",
+        "loupe/loupe": "^0.5",
         "psr/container": "^1.0 || ^2.0"
     },
     "require-dev": {

--- a/packages/seal-loupe-adapter/composer.lock
+++ b/packages/seal-loupe-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "41282228286b99030a3a51d2799a3f51",
+    "content-hash": "b3b1e3166041b03d5020047942d4d0eb",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -432,16 +432,16 @@
         },
         {
             "name": "loupe/loupe",
-            "version": "0.4.0",
+            "version": "0.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/loupe-php/loupe.git",
-                "reference": "2fc7306899d89ed8e71a21c9636b9871d7951699"
+                "reference": "36bfaa32fb5acf1b33fbbce9f28e900ec02ca244"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/2fc7306899d89ed8e71a21c9636b9871d7951699",
-                "reference": "2fc7306899d89ed8e71a21c9636b9871d7951699",
+                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/36bfaa32fb5acf1b33fbbce9f28e900ec02ca244",
+                "reference": "36bfaa32fb5acf1b33fbbce9f28e900ec02ca244",
                 "shasum": ""
             },
             "require": {
@@ -452,7 +452,7 @@
                 "nitotm/efficient-language-detector": "^2.0",
                 "php": "^8.1",
                 "psr/log": "^3.0",
-                "toflar/state-set-index": "^1.0",
+                "toflar/state-set-index": "^2.0.1",
                 "voku/portable-utf8": "^6.0",
                 "wamania/php-stemmer": "^3.0"
             },
@@ -483,7 +483,7 @@
             "description": "A full text search engine with tokenization, stemming, typo tolerance, filters and geo support based on only PHP and SQLite",
             "support": {
                 "issues": "https://github.com/loupe-php/loupe/issues",
-                "source": "https://github.com/loupe-php/loupe/tree/0.4.0"
+                "source": "https://github.com/loupe-php/loupe/tree/0.5.3"
             },
             "funding": [
                 {
@@ -491,7 +491,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-01T12:04:21+00:00"
+            "time": "2023-12-19T16:49:00+00:00"
         },
         {
             "name": "mjaschen/phpgeo",
@@ -1297,16 +1297,16 @@
         },
         {
             "name": "toflar/state-set-index",
-            "version": "1.0.2",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Toflar/state-set-index.git",
-                "reference": "a4277c050b69d8d5fb61d27aee4eef2092b4fac3"
+                "reference": "27fe48fd7c231a7ec5b495ca7f6e433b0add0519"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Toflar/state-set-index/zipball/a4277c050b69d8d5fb61d27aee4eef2092b4fac3",
-                "reference": "a4277c050b69d8d5fb61d27aee4eef2092b4fac3",
+                "url": "https://api.github.com/repos/Toflar/state-set-index/zipball/27fe48fd7c231a7ec5b495ca7f6e433b0add0519",
+                "reference": "27fe48fd7c231a7ec5b495ca7f6e433b0add0519",
                 "shasum": ""
             },
             "require": {
@@ -1336,9 +1336,9 @@
             "description": "Implementation of the State Set Index Algorithm",
             "support": {
                 "issues": "https://github.com/Toflar/state-set-index/issues",
-                "source": "https://github.com/Toflar/state-set-index/tree/1.0.2"
+                "source": "https://github.com/Toflar/state-set-index/tree/2.0.1"
             },
-            "time": "2023-08-18T10:03:59+00:00"
+            "time": "2023-10-06T07:27:46+00:00"
         },
         {
             "name": "voku/portable-ascii",

--- a/packages/seal-loupe-adapter/src/LoupeHelper.php
+++ b/packages/seal-loupe-adapter/src/LoupeHelper.php
@@ -62,11 +62,15 @@ final class LoupeHelper
             $indexDirectory = $this->getIndexDirectory($index);
 
             // beside the .db and our own .loupe file there exists other files which we need to remove
-            $iterator = new \FilesystemIterator($indexDirectory);
+            $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($indexDirectory, \RecursiveDirectoryIterator::SKIP_DOTS), \RecursiveIteratorIterator::CHILD_FIRST);
             foreach ($iterator as $fileInfo) {
-                $filePath = (string) $fileInfo;
-                if (\is_file($filePath)) {
+                \assert($fileInfo instanceof \SplFileInfo);
+
+                $filePath = $fileInfo->getPathname();
+                if ($fileInfo->isFile()) {
                     \unlink($filePath);
+                } elseif ($fileInfo->isDir()) {
+                    \rmdir($filePath);
                 }
             }
 


### PR DESCRIPTION
As stated in the CHANGELOG of Loupe 0.5, Loupe requires now a directory instead of a DB: https://github.com/loupe-php/loupe/blob/main/CHANGELOG.md

So instead of `var/indexes/<index_name>.db`, we have now `var/indexes/<index_name>/loupe.db`.

Beside our own configuration which we store in the directory as `config.loupe`, Loupe itself stores other files like `loupe.db-shm`, `loupe.db-wal`, `state_set.php`, in that directory.

For dropping a index we need first remove all files inside the `var/indexes/<index_name>/` directory and then remove the empty dir via rmdir.

Support for previous versions of Loupe is dropped.

fixes #268 
 