### PR TITLE
Add highlight methods to search and search builder

### DIFF
--- a/packages/seal/src/Search/Search.php
+++ b/packages/seal/src/Search/Search.php
@@ -21,6 +21,7 @@ final class Search
      * @param array<string, Index> $indexes
      * @param object[] $filters
      * @param array<string, 'asc'|'desc'> $sortBys
+     * @param array<string> $higlightFields
      */
     public function __construct(
         public readonly array $indexes = [],
@@ -28,6 +29,9 @@ final class Search
         public readonly array $sortBys = [],
         public readonly ?int $limit = null,
         public readonly int $offset = 0,
+        public readonly array $higlightFields = [],
+        public readonly string $highlightPreTag = '<mark>',
+        public readonly string $highlightPostTag = '</mark>',
     ) {
     }
 }

--- a/packages/seal/src/Search/SearchBuilder.php
+++ b/packages/seal/src/Search/SearchBuilder.php
@@ -38,6 +38,15 @@ final class SearchBuilder
 
     private ?int $limit = null;
 
+    /**
+     * @var array<string>
+     */
+    private array $highlightFields = [];
+
+    private string $highlightPreTag = '<mark>';
+
+    private string $highlightPostTag = '</mark>';
+
     public function __construct(
         readonly private Schema $schema,
         readonly private SearcherInterface $searcher,
@@ -82,6 +91,23 @@ final class SearchBuilder
         return $this;
     }
 
+    /**
+     * @param array<string> $fields
+     */
+    public function highlight(array $fields, string $preTag = '<mark>', string $postTag = '</mark>'): static
+    {
+        $this->highlightFields = $fields;
+        $this->highlightPreTag = $preTag;
+        $this->highlightPostTag = $postTag;
+
+        return $this;
+    }
+
+    public function getSearcher(): SearcherInterface
+    {
+        return $this->searcher;
+    }
+
     public function getSearch(): Search
     {
         return new Search(
@@ -90,6 +116,9 @@ final class SearchBuilder
             $this->sortBys,
             $this->limit,
             $this->offset,
+            $this->highlightFields,
+            $this->highlightPreTag,
+            $this->highlightPostTag,
         );
     }
 


### PR DESCRIPTION
This will add the core highlight methods for the highlighting search results:

```php
$searchBuilder
    ->addIndex('blog')
    ->addFilter(new Condition\SearchCondition('Test'))
    ->highlight(
        fields: ['title', 'description'],
        preTag: '<mark>',
        postTag: '</mark>',
    )
```