### PR TITLE
Add highlight methods to search and search builder

### DIFF
--- a/docs/search-and-filters/index.rst
+++ b/docs/search-and-filters/index.rst
@@ -212,8 +212,8 @@ The field is required to be marked as ``filterable`` in the index configuration.
 
 .. note::
 
-    The ``GeoBoundingBoxCondition`` is currently not supported by ``Redisearch`` adapter.
-    See `this GitHub Issue <https://github.com/RediSearch/RediSearch/issues/680>`__ for more information.
+    The ``GeoBoundingBoxCondition`` is currently not supported by ``RediSearch`` adapter.
+    See `this GitHub Issue <https://github.com/PHP-CMSIG/search/issues/422>`__ for more information.
 
 OrCondition
 ~~~~~~~~~~~
@@ -393,6 +393,33 @@ your results but also ``sort`` them by a given field.
         ->getResult();
 
 The field is required to be marked as ``sortable`` in the index configuration.
+
+--------------
+
+Highlighting
+------------
+
+The abstraction can also be used to highlight the search term in the result.
+
+.. code-block:: php
+
+    <?php
+
+    use CmsIg\Seal\Search\Condition;
+
+    $result = $this->engine->createSearchBuilder('blog')
+        ->addFilter(new Condition\SearchCondition('Search Term'))
+        ->highlight(['title'], '<mark>', '</mark>');
+        ->getResult();
+
+    foreach ($result as $document) {
+        $titleWithHighlight = $document['_formatted']['title'] ?? '';
+    }
+
+.. note::
+
+    The ``Highlighting`` is currently not supported by ``RediSearch`` adapter.
+    See `this GitHub Issue <https://github.com/PHP-CMSIG/search/issues/491>`__ for more information.
 
 --------------
 

--- a/packages/seal-elasticsearch-adapter/src/ElasticsearchSearcher.php
+++ b/packages/seal-elasticsearch-adapter/src/ElasticsearchSearcher.php
@@ -64,13 +64,13 @@ final class ElasticsearchSearcher implements SearcherInterface
                 }
 
                 return new Result(
-                    $this->hitsToDocuments($search->index, []),
+                    $this->hitsToDocuments($search->index, [], []),
                     0,
                 );
             }
 
             return new Result(
-                $this->hitsToDocuments($search->index, [$searchResult]),
+                $this->hitsToDocuments($search->index, [$searchResult], []),
                 1,
             );
         }
@@ -99,6 +99,20 @@ final class ElasticsearchSearcher implements SearcherInterface
             $body['size'] = $search->limit;
         }
 
+        if ([] !== $search->highlightFields) {
+            $highlightFields = [];
+            foreach ($search->highlightFields as $highlightField) {
+                $highlightFields[$highlightField] = [
+                    'pre_tags' => [$search->highlightPreTag],
+                    'post_tags' => [$search->highlightPostTag],
+                ];
+            }
+
+            $body['highlight'] = [
+                'fields' => $highlightFields,
+            ];
+        }
+
         /** @var Elasticsearch $response */
         $response = $this->client->search([
             'index' => $search->index->name,
@@ -118,21 +132,49 @@ final class ElasticsearchSearcher implements SearcherInterface
         $searchResult = $response->asArray();
 
         return new Result(
-            $this->hitsToDocuments($search->index, $searchResult['hits']['hits']),
+            $this->hitsToDocuments($search->index, $searchResult['hits']['hits'], $search->highlightFields),
             $searchResult['hits']['total']['value'],
         );
     }
 
     /**
      * @param array<array<string, mixed>> $hits
+     * @param array<string> $highlightFields
      *
      * @return \Generator<int, array<string, mixed>>
      */
-    private function hitsToDocuments(Index $index, array $hits): \Generator
+    private function hitsToDocuments(Index $index, array $hits, array $highlightFields): \Generator
     {
-        /** @var array{_index: string, _source: array<string, mixed>} $hit */
+        /** @var array{_index: string, _source: array<string, mixed>, highlight?: mixed} $hit */
         foreach ($hits as $hit) {
-            yield $this->marshaller->unmarshall($index->fields, $hit['_source']);
+            $document = $this->marshaller->unmarshall($index->fields, $hit['_source']);
+
+            if ([] === $highlightFields) {
+                yield $document;
+
+                continue;
+            }
+
+            $document['_formatted'] ??= [];
+
+            \assert(
+                \is_array($document['_formatted']),
+                'Document with key "_formatted" expected to be array.',
+            );
+
+            foreach ($highlightFields as $highlightField) {
+                \assert(
+                    isset($hit['highlight'])
+                    && \is_array($hit['highlight'])
+                    && isset($hit['highlight'][$highlightField])
+                    && \is_array($hit['highlight'][$highlightField]),
+                    'Expected highlight field to be set.',
+                );
+
+                $document['_formatted'][$highlightField] = $hit['highlight'][$highlightField][0] ?? null;
+            }
+
+            yield $document;
         }
     }
 

--- a/packages/seal-opensearch-adapter/src/OpensearchSearcher.php
+++ b/packages/seal-opensearch-adapter/src/OpensearchSearcher.php
@@ -54,13 +54,13 @@ final class OpensearchSearcher implements SearcherInterface
                 ]);
             } catch (Missing404Exception) {
                 return new Result(
-                    $this->hitsToDocuments($search->index, []),
+                    $this->hitsToDocuments($search->index, [], []),
                     0,
                 );
             }
 
             return new Result(
-                $this->hitsToDocuments($search->index, [$searchResult]),
+                $this->hitsToDocuments($search->index, [$searchResult], []),
                 1,
             );
         }
@@ -89,27 +89,69 @@ final class OpensearchSearcher implements SearcherInterface
             $body['size'] = $search->limit;
         }
 
+        if ([] !== $search->highlightFields) {
+            $highlightFields = [];
+            foreach ($search->highlightFields as $highlightField) {
+                $highlightFields[$highlightField] = [
+                    'pre_tags' => [$search->highlightPreTag],
+                    'post_tags' => [$search->highlightPostTag],
+                ];
+            }
+
+            $body['highlight'] = [
+                'fields' => $highlightFields,
+            ];
+        }
+
         $searchResult = $this->client->search([
             'index' => $search->index->name,
             'body' => $body,
         ]);
 
         return new Result(
-            $this->hitsToDocuments($search->index, $searchResult['hits']['hits']),
+            $this->hitsToDocuments($search->index, $searchResult['hits']['hits'], $search->highlightFields),
             $searchResult['hits']['total']['value'],
         );
     }
 
     /**
      * @param array<array<string, mixed>> $hits
+     * @param array<string> $highlightFields
      *
      * @return \Generator<int, array<string, mixed>>
      */
-    private function hitsToDocuments(Index $index, array $hits): \Generator
+    private function hitsToDocuments(Index $index, array $hits, array $highlightFields): \Generator
     {
-        /** @var array{_index: string, _source: array<string, mixed>} $hit */
+        /** @var array{_index: string, _source: array<string, mixed>, highlight?: mixed} $hit */
         foreach ($hits as $hit) {
-            yield $this->marshaller->unmarshall($index->fields, $hit['_source']);
+            $document = $this->marshaller->unmarshall($index->fields, $hit['_source']);
+
+            if ([] === $highlightFields) {
+                yield $document;
+
+                continue;
+            }
+
+            $document['_formatted'] ??= [];
+
+            \assert(
+                \is_array($document['_formatted']),
+                'Document with key "_formatted" expected to be array.',
+            );
+
+            foreach ($highlightFields as $highlightField) {
+                \assert(
+                    isset($hit['highlight'])
+                    && \is_array($hit['highlight'])
+                    && isset($hit['highlight'][$highlightField])
+                    && \is_array($hit['highlight'][$highlightField]),
+                    'Expected highlight field to be set.',
+                );
+
+                $document['_formatted'][$highlightField] = $hit['highlight'][$highlightField][0] ?? null;
+            }
+
+            yield $document;
         }
     }
 

--- a/packages/seal-redisearch-adapter/README.md
+++ b/packages/seal-redisearch-adapter/README.md
@@ -61,6 +61,11 @@ redis://phpredis:phpredis@127.0.0.1:6379
 The `ext-redis` and `ext-json` PHP extension is required for this adapter.
 The `Redisearch` and `RedisJson` module is required for the Redis Server.
 
+## Limitation
+
+- [No GeoBoundingBox support](https://github.com/PHP-CMSIG/search/issues/422)
+- [No HIGHLIGHT support](https://github.com/PHP-CMSIG/search/issues/491)
+
 ## Authors
 
 - [Alexander Schranz](https://github.com/alexander-schranz/)

--- a/packages/seal-redisearch-adapter/tests/RediSearchSearcherTest.php
+++ b/packages/seal-redisearch-adapter/tests/RediSearchSearcherTest.php
@@ -33,4 +33,12 @@ class RediSearchSearcherTest extends AbstractSearcherTestCase
     {
         $this->markTestSkipped('Not supported by RediSearch: https://github.com/RediSearch/RediSearch/issues/680 or https://github.com/RediSearch/RediSearch/issues/5032');
     }
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testSearchConditionWithHighlight(): void
+    {
+        $this->markTestSkipped('Not supported by RediSearch: https://github.com/RediSearch/RediSearch/issues/4420 or https://redis.io/docs/latest/develop/interact/search-and-query/indexing/#limitations');
+    }
 }

--- a/packages/seal-solr-adapter/src/SolrSchemaManager.php
+++ b/packages/seal-solr-adapter/src/SolrSchemaManager.php
@@ -148,7 +148,7 @@ final class SolrSchemaManager implements SchemaManagerInterface
                     'type' => $field->searchable ? 'text_general' : 'string',
                     'indexed' => $field->searchable,
                     'docValues' => $field->filterable || $field->sortable,
-                    'stored' => false,
+                    'stored' => true, // required to be set to stored for highlighting
                     'useDocValuesAsStored' => false,
                     'multiValued' => $isMultiple,
                 ],

--- a/packages/seal-solr-adapter/src/SolrSearcher.php
+++ b/packages/seal-solr-adapter/src/SolrSearcher.php
@@ -21,6 +21,7 @@ use CmsIg\Seal\Search\Condition;
 use CmsIg\Seal\Search\Result;
 use CmsIg\Seal\Search\Search;
 use Solarium\Client;
+use Solarium\Component\Result\Highlighting\Highlighting;
 use Solarium\Core\Query\DocumentInterface;
 
 final class SolrSearcher implements SearcherInterface
@@ -101,10 +102,17 @@ final class SolrSearcher implements SearcherInterface
             $query->addSort($field, $direction);
         }
 
+        if ([] !== $search->highlightFields) {
+            $highlighting = $query->getHighlighting();
+            $highlighting->setFields(\implode(', ', $search->highlightFields));
+            $highlighting->setSimplePrefix($search->highlightPreTag);
+            $highlighting->setSimplePostfix($search->highlightPostTag);
+        }
+
         $result = $this->client->select($query);
 
         return new Result(
-            $this->hitsToDocuments($search->index, $result->getDocuments()),
+            $this->hitsToDocuments($search->index, $result->getDocuments(), $result->getHighlighting()),
             (int) $result->getNumFound(),
         );
     }
@@ -114,23 +122,51 @@ final class SolrSearcher implements SearcherInterface
      *
      * @return \Generator<int, array<string, mixed>>
      */
-    private function hitsToDocuments(Index $index, iterable $hits): \Generator
+    private function hitsToDocuments(Index $index, iterable $hits, Highlighting|null $highlighting = null): \Generator
     {
         foreach ($hits as $hit) {
             /** @var array<string, mixed> $hit */
             $hit = $hit->getFields();
 
             unset($hit['_version_']);
+            $identifierFieldName = $index->getIdentifierField()->name;
 
-            if ('id' !== $index->getIdentifierField()->name) {
-                // Solr currently does not support set another identifier then id: https://github.com/php-cmsig/search/issues/87
+            if ('id' !== $identifierFieldName) {
+                // Solr currently does not support set another identifier then id: https://github.com/schranz-search/schranz-search/issues/87
                 $id = $hit['id'];
                 unset($hit['id']);
 
-                $hit[$index->getIdentifierField()->name] = $id;
+                $hit[$identifierFieldName] = $id;
             }
 
-            yield $this->marshaller->unmarshall($index->fields, $hit);
+            $document = $this->marshaller->unmarshall($index->fields, $hit);
+
+            if ($highlighting instanceof \Solarium\Component\Result\Highlighting\Highlighting) {
+                $highlightResult = $highlighting->getResult($hit[$identifierFieldName]);
+                \assert(
+                    $highlightResult instanceof \Solarium\Component\Result\Highlighting\Result,
+                    'Expected the highlighting exists.',
+                );
+
+                $document['_formatted'] ??= [];
+
+                \assert(
+                    \is_array($document['_formatted']),
+                    'Document with key "_formatted" expected to be array.',
+                );
+
+                foreach ($highlightResult->getFields() as $key => $value) {
+                    $fieldConfig = $index->getFieldByPath($key);
+                    // even non-multiple fields are returned as array we need to convert them to string
+                    if (!$fieldConfig->multiple && \is_array($value)) {
+                        $value = \implode(' ', $value);
+                    }
+
+                    $document['_formatted'][$key] = $value;
+                }
+            }
+
+            yield $document;
         }
     }
 

--- a/packages/seal/src/Search/Search.php
+++ b/packages/seal/src/Search/Search.php
@@ -20,6 +20,7 @@ final class Search
     /**
      * @param object[] $filters
      * @param array<string, 'asc'|'desc'> $sortBys
+     * @param array<string> $highlightFields
      */
     public function __construct(
         public readonly Index $index,
@@ -27,6 +28,9 @@ final class Search
         public readonly array $sortBys = [],
         public readonly int|null $limit = null,
         public readonly int $offset = 0,
+        public readonly array $highlightFields = [],
+        public readonly string $highlightPreTag = '<mark>',
+        public readonly string $highlightPostTag = '</mark>',
     ) {
     }
 }

--- a/packages/seal/src/Search/SearchBuilder.php
+++ b/packages/seal/src/Search/SearchBuilder.php
@@ -35,6 +35,15 @@ final class SearchBuilder
 
     private int|null $limit = null;
 
+    /**
+     * @var array<string>
+     */
+    private array $highlightFields = [];
+
+    private string $highlightPreTag = '<mark>';
+
+    private string $highlightPostTag = '</mark>';
+
     public function __construct(
         readonly private Schema $schema,
         readonly private SearcherInterface $searcher,
@@ -79,6 +88,23 @@ final class SearchBuilder
         return $this;
     }
 
+    /**
+     * @param array<string> $fields
+     */
+    public function highlight(array $fields, string $preTag = '<mark>', string $postTag = '</mark>'): static
+    {
+        $this->highlightFields = $fields;
+        $this->highlightPreTag = $preTag;
+        $this->highlightPostTag = $postTag;
+
+        return $this;
+    }
+
+    public function getSearcher(): SearcherInterface
+    {
+        return $this->searcher;
+    }
+
     public function getSearch(): Search
     {
         return new Search(
@@ -87,6 +113,9 @@ final class SearchBuilder
             $this->sortBys,
             $this->limit,
             $this->offset,
+            $this->highlightFields,
+            $this->highlightPreTag,
+            $this->highlightPostTag,
         );
     }
 

--- a/packages/seal/src/Testing/AbstractSearcherTestCase.php
+++ b/packages/seal/src/Testing/AbstractSearcherTestCase.php
@@ -131,6 +131,72 @@ abstract class AbstractSearcherTestCase extends TestCase
         }
     }
 
+    public function testSearchConditionWithHighlight(): void
+    {
+        $documents = TestingHelper::createComplexFixtures();
+
+        $schema = self::getSchema();
+
+        foreach ($documents as $document) {
+            self::$taskHelper->tasks[] = self::$indexer->save(
+                $schema->indexes[TestingHelper::INDEX_COMPLEX],
+                $document,
+                ['return_slow_promise_result' => true],
+            );
+        }
+        self::$taskHelper->waitForAll();
+
+        $search = new SearchBuilder($schema, self::$searcher);
+        $search->index(TestingHelper::INDEX_COMPLEX);
+        $search->addFilter(new Condition\SearchCondition('Blog'));
+        $search->highlight(['title'], '<mark>', '</mark>');
+
+        $expectedDocumentA = $documents[0];
+        $expectedDocumentA['_formatted']['title'] = \str_replace(
+            'Blog',
+            '<mark>Blog</mark>',
+            $expectedDocumentA['title'] ?? '',
+        );
+        $expectedDocumentB = $documents[1];
+        $expectedDocumentB['_formatted']['title'] = \str_replace(
+            'Blog',
+            '<mark>Blog</mark>',
+            $expectedDocumentB['title'] ?? '',
+        );
+
+        $expectedDocumentsVariantA = [
+            $expectedDocumentA,
+            $expectedDocumentB,
+        ];
+        $expectedDocumentsVariantB = [
+            $expectedDocumentB,
+            $expectedDocumentA,
+        ];
+
+        $loadedDocuments = [...$search->getResult()];
+        $this->assertCount(2, $loadedDocuments);
+
+        $this->assertTrue(
+            $expectedDocumentsVariantA === $loadedDocuments
+            || $expectedDocumentsVariantB === $loadedDocuments,
+            'Not correct documents where found.',
+        );
+
+        $search = new SearchBuilder($schema, self::$searcher);
+        $search->index(TestingHelper::INDEX_COMPLEX);
+        $search->addFilter(new Condition\SearchCondition('Thing'));
+
+        $this->assertSame([$documents[2]], [...$search->getResult()]);
+
+        foreach ($documents as $document) {
+            self::$taskHelper->tasks[] = self::$indexer->delete(
+                $schema->indexes[TestingHelper::INDEX_COMPLEX],
+                $document['uuid'],
+                ['return_slow_promise_result' => true],
+            );
+        }
+    }
+
     public function testNoneSearchableFields(): void
     {
         $documents = TestingHelper::createComplexFixtures();


### PR DESCRIPTION
This will add the core highlight methods for the highlighting search results:

```php
$result = $this->engine->createSearchBuilder('blog')
    ->addFilter(new Condition\SearchCondition('Search Term'))
    ->highlight(
        fields: ['title', 'description'],
        preTag: '<mark>',
        postTag: '</mark>',
    )
```

See also #343 

# TODO implementation

 - [x] https://github.com/schranz-search/schranz-search/pull/348
 - [x] Add `testSearchConditionWithHighlight` to `AbstractSearcherTestCase`: https://github.com/schranz-search/schranz-search/pull/351
 - [x] Memory: https://github.com/schranz-search/schranz-search/pull/351
 - [x] Elasticsearch https://github.com/PHP-CMSIG/search/pull/490
 - [x] Opensearch https://github.com/PHP-CMSIG/search/pull/490
 - [x] Meilisearch #488
 - [x] Algolia #489
 - [ ] Redisearch: https://github.com/schranz-search/schranz-search/pull/355 ⚠️ not supported skipped in https://github.com/PHP-CMSIG/search/pull/492
 - [x] Typesense: https://github.com/schranz-search/schranz-search/pull/354
 - [x] Solr: https://github.com/schranz-search/schranz-search/pull/353
 - [x] Loupe https://github.com/PHP-CMSIG/search/pull/487
 
----

fixes #343 