### PR TITLE
Add highlight implementation for memory adapter

### DIFF
--- a/packages/seal/src/Search/Search.php
+++ b/packages/seal/src/Search/Search.php
@@ -21,7 +21,7 @@ final class Search
      * @param array<string, Index> $indexes
      * @param object[] $filters
      * @param array<string, 'asc'|'desc'> $sortBys
-     * @param array<string> $higlightFields
+     * @param array<string> $highlightFields
      */
     public function __construct(
         public readonly array $indexes = [],
@@ -29,7 +29,7 @@ final class Search
         public readonly array $sortBys = [],
         public readonly ?int $limit = null,
         public readonly int $offset = 0,
-        public readonly array $higlightFields = [],
+        public readonly array $highlightFields = [],
         public readonly string $highlightPreTag = '<mark>',
         public readonly string $highlightPostTag = '</mark>',
     ) {


### PR DESCRIPTION
Add support for:

```php
$searchBuilder
    ->addIndex('blog')
    ->addFilter(new Condition\SearchCondition('Test'))
    ->highlight(
        fields: ['title', 'description'],
        preTag: '<mark>',
        postTag: '</mark>',
    );
```