### PR TITLE
Add highlight implementation for typesense  adapter

### DIFF
--- a/packages/seal-typesense-adapter/src/TypesenseSearcher.php
+++ b/packages/seal-typesense-adapter/src/TypesenseSearcher.php
@@ -104,10 +104,16 @@ final class TypesenseSearcher implements SearcherInterface
             $searchParams['sort_by'] = \implode(',', $sortBys);
         }
 
+        if ([] !== $search->highlightFields) {
+            $searchParams['highlight_fields'] = \implode(', ', $search->highlightFields);
+            $searchParams['highlight_start_tag'] = $search->highlightPreTag;
+            $searchParams['highlight_end_tag'] = $search->highlightPostTag;
+        }
+
         $data = $this->client->collections[$index->name]->documents->search($searchParams);
 
         return new Result(
-            $this->hitsToDocuments($search->indexes, $data['hits']),
+            $this->hitsToDocuments($search->indexes, $data['hits'], $search->highlightFields),
             $data['found'] ?? null,
         );
     }
@@ -115,16 +121,41 @@ final class TypesenseSearcher implements SearcherInterface
     /**
      * @param Index[] $indexes
      * @param iterable<array<string, mixed>> $hits
+     * @param array<string> $highlightFields
      *
      * @return \Generator<int, array<string, mixed>>
      */
-    private function hitsToDocuments(array $indexes, iterable $hits): \Generator
+    private function hitsToDocuments(array $indexes, iterable $hits, array $highlightFields = []): \Generator
     {
         $index = $indexes[\array_key_first($indexes)];
 
-        /** @var array{document: array<string, mixed>} $hit */
+        /** @var array{document: array<string, mixed>, highlight?: array<string, array{snippet: string}>} $hit */
         foreach ($hits as $hit) {
-            yield $this->marshaller->unmarshall($index->fields, $hit['document']);
+            $document = $this->marshaller->unmarshall($index->fields, $hit['document']);
+
+            if ([] === $highlightFields) {
+                yield $document;
+
+                continue;
+            }
+
+            $document['_formatted'] ??= [];
+
+            \assert(
+                \is_array($document['_formatted']),
+                'Document with key "_formatted" expected to be array.',
+            );
+
+            foreach ($highlightFields as $highlightField) {
+                \assert(
+                    isset($hit['highlight'][$highlightField]['snippet']),
+                    'Expected highlight field to be set.',
+                );
+
+                $document['_formatted'][$highlightField] = $hit['highlight'][$highlightField]['snippet'];
+            }
+
+            yield $document;
         }
     }
 


### PR DESCRIPTION
Add support for:

```php
$searchBuilder
    ->addIndex('blog')
    ->addFilter(new Condition\SearchCondition('Test'))
    ->highlight(
        fields: ['title', 'description'],
        preTag: '<mark>',
        postTag: '</mark>',
    );
```