### PR TITLE
Add highlight implementation for redisearch adapter

### DIFF
--- a/packages/seal-redisearch-adapter/src/RediSearchSchemaManager.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchSchemaManager.php
@@ -173,7 +173,7 @@ final class RediSearchSchemaManager implements SchemaManagerInterface
                     'sortable' => $field->sortable,
                     'filterable' => $field->filterable,
                 ],
-                $field instanceof Field\ObjectField => $indexFields = \array_replace($indexFields, $this->createJsonFields($field->fields, $name, $jsonPath)),
+                $field instanceof Field\ObjectField => $indexFields = \array_replace($indexFields, $this->createJsonFields($field->fields, $name . '.', $jsonPath)),
                 $field instanceof Field\TypedField => \array_map(function ($fields, $type) use ($name, &$indexFields, $jsonPath, $field) {
                     $newJsonPath = $jsonPath . '[\'' . $type . '\']';
                     if ($field->multiple) {

--- a/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
@@ -96,6 +96,20 @@ final class RediSearchSearcher implements SearcherInterface
             }
         }
 
+        if ($search->highlightFields !== []) {
+            $arguments[] = 'HIGHLIGHT';
+            $arguments[] = 'FIELDS';
+            $arguments[] = \count($search->highlightFields);
+
+            foreach ($search->highlightFields as $highlightField) {
+                $arguments[] = $highlightField;
+            }
+
+            $arguments[] = 'TAGS';
+            $arguments[] = $search->highlightPreTag;
+            $arguments[] = $search->highlightPostTag;
+        }
+
         $arguments[] = 'DIALECT';
         $arguments[] = '3';
 


### PR DESCRIPTION
Add support for:

```php
$searchBuilder
    ->addIndex('blog')
    ->addFilter(new Condition\SearchCondition('Test'))
    ->highlight(
        fields: ['title', 'description'],
        preTag: '<mark>',
        postTag: '</mark>',
    );
```

## TODO

- [ ] Find a way for following issue: https://github.com/RediSearch/RediSearch/issues/4420