### PR TITLE
Update Research list with paradedb

### DIFF
--- a/docs/research/index.rst
+++ b/docs/research/index.rst
@@ -42,6 +42,7 @@ Here we collect different search engines which are around and could be interesti
 - `Qdrant <#qdrant>`__
 - `OpenAI <#openai>`__
 - `Jina <#jina>`__
+- `Paradedb <#paradedb>`__
 
 Some more research links:
 -------------------------
@@ -342,3 +343,10 @@ Jina
 Another vector based search engine:
 
 - Server: `Jina Server <https://github.com/jina-ai/jina/>`__
+
+Paradedb
+~~~~~~~~
+
+A search and analytics engine ontop of Postgres:
+
+- Server: `Paradedb Server <https://github.com/paradedb/paradedb>`__

--- a/docs/research/index.rst
+++ b/docs/research/index.rst
@@ -347,6 +347,6 @@ Another vector based search engine:
 Paradedb
 ~~~~~~~~
 
-A search and analytics engine ontop of Postgres:
+A search and analytics engine ontop of Postgres, with own Postgres extensions written in Rust:
 
 - Server: `Paradedb Server <https://github.com/paradedb/paradedb>`__


### PR DESCRIPTION
The @paradedb project seems to be a new alternative to elasticsearch. Which seems to be written in rust.

Not sure yet if it is more for analytics data or even can be used as full featured search for complex website and shop projects.

Main development seems to be done by @philippemnoel and @rebasedming.