### PR TITLE
Add Blog post Scaling Elasticsearch for Fun and Profit by Jason Taylor to research docs

### DIFF
--- a/docs/research/index.rst
+++ b/docs/research/index.rst
@@ -73,6 +73,7 @@ Optimization links:
 - `https://sites.google.com/site/kevinbouge/stopwords-lists <https://sites.google.com/site/kevinbouge/stopwords-lists>`__
 - `https://github.com/uschindler/german-decompounder <https://github.com/uschindler/german-decompounder>`__
 - `https://symfony.com/blog/migrating-symfony-com-search-engine-to-meilisearch <https://symfony.com/blog/migrating-symfony-com-search-engine-to-meilisearch>`__
+- `https://thetizzo.com/2024/02/13/scaling-elasticsearch-for-fun-and-profit <https://thetizzo.com/2024/02/13/scaling-elasticsearch-for-fun-and-profit>`__
 
 Descriptions of Search Engines
 ------------------------------


### PR DESCRIPTION
This project should not be only about providing a library about PHP but also a summary where we find interesting and helpful information about different search engines. 

And @thetizzo blog post about [Scaling Elasticsearch for Fun and Profit](https://thetizzo.com/2024/02/13/scaling-elasticsearch-for-fun-and-profit) fits perfectly into that direction what I want to have in the research documentation.