### PR TITLE
Add dependency injection alias for Schema class

### DIFF
--- a/integrations/laravel/src/SearchProvider.php
+++ b/integrations/laravel/src/SearchProvider.php
@@ -127,6 +127,7 @@ final class SearchProvider extends ServiceProvider
 
             if ('default' === $name || (!isset($engines['default']) && !$this->app->has(EngineInterface::class))) {
                 $this->app->alias($engineServiceId, EngineInterface::class);
+                $this->app->alias($schemaId, Schema::class);
             }
         }
 

--- a/integrations/mezzio/src/ConfigProvider.php
+++ b/integrations/mezzio/src/ConfigProvider.php
@@ -32,6 +32,7 @@ use Schranz\Search\SEAL\Adapter\Solr\SolrAdapterFactory;
 use Schranz\Search\SEAL\Adapter\Typesense\TypesenseAdapterFactory;
 use Schranz\Search\SEAL\EngineInterface;
 use Schranz\Search\SEAL\EngineRegistry;
+use Schranz\Search\SEAL\Schema\Schema;
 
 final class ConfigProvider
 {
@@ -86,6 +87,7 @@ final class ConfigProvider
             'factories' => [
                 EngineRegistry::class => SealContainerServiceAbstractFactory::class,
                 EngineInterface::class => SealContainerServiceAbstractFactory::class,
+                Schema::class => SealContainerServiceAbstractFactory::class,
                 AdapterFactory::class => SealContainerServiceAbstractFactory::class,
                 SealContainer::class => SealContainerFactory::class,
                 Command\IndexCreateCommand::class => CommandAbstractFactory::class,

--- a/integrations/mezzio/src/Service/SealContainerFactory.php
+++ b/integrations/mezzio/src/Service/SealContainerFactory.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Schranz\Search\Integration\Mezzio\Service;
 
+use Doctrine\DBAL\Schema\Schema;
 use Psr\Container\ContainerInterface;
 use Schranz\Search\SEAL\Adapter\AdapterFactory;
 use Schranz\Search\SEAL\Adapter\AdapterFactoryInterface;
@@ -101,6 +102,7 @@ final class SealContainerFactory
             if ('default' === $name || (!isset($engineServices['default']) && !isset($config['engines']['default']))) {
                 $engineServices['default'] = $engine;
                 $sealContainer->set(EngineInterface::class, $engine);
+                $sealContainer->set(Schema::class, $schema);
             }
 
             $sealContainer->set($adapterServiceId, $adapter);

--- a/integrations/spiral/src/Bootloader/SearchBootloader.php
+++ b/integrations/spiral/src/Bootloader/SearchBootloader.php
@@ -150,6 +150,7 @@ final class SearchBootloader extends Bootloader
 
             if ('default' === $name || (!isset($engines['default']) && !$container->has(EngineInterface::class))) {
                 $container->bind(EngineInterface::class, $engineServiceId);
+                $container->bind(Schema::class, $schemaId);
             }
         }
 

--- a/integrations/symfony/src/SearchBundle.php
+++ b/integrations/symfony/src/SearchBundle.php
@@ -111,12 +111,19 @@ final class SearchBundle extends AbstractBundle
 
             if ('default' === $name || (!isset($engines['default']) && !$builder->has(EngineInterface::class))) {
                 $builder->setAlias(EngineInterface::class, $engineServiceId);
+                $builder->setAlias(Schema::class, $schemaId);
             }
 
             $builder->registerAliasForArgument(
                 $engineServiceId,
                 EngineInterface::class,
                 $name . 'Engine',
+            );
+
+            $builder->registerAliasForArgument(
+                $schemaId,
+                Schema::class,
+                $name . 'Schema',
             );
         }
 

--- a/integrations/yii/config/di.php
+++ b/integrations/yii/config/di.php
@@ -165,8 +165,9 @@ foreach ($engines as $name => $engineConfig) {
         return new Engine($adapter, $schema);
     };
 
-    if ('default' === $name || (!isset($engines['default']) && !isset($diConfig[Engine::class]))) {
+    if ('default' === $name || (!isset($engines['default']) && !isset($diConfig[EngineInterface::class]))) {
         $diConfig[EngineInterface::class] = $engineServiceId;
+        $diConfig[Schema::class] = $schemaId;
     }
 }
 


### PR DESCRIPTION
Currently it was required for injecting via dependency injection the `Schema` class it was required manually bind the `schranz_search.schema.default` service.

This implementation helps to get the `Schema` via `Schema::class`. In this case when use Symfony or other frameworks which supports autowiring or similar features just need now use the `Schema` class in its constructor to get it directly.

This was done to make access to different metadata easier e.g.:

```php
namespace App;

use Schranz\Search\SEAL\Schema\Schema;

class SomeAny {
    public function __construct(
        private Schema $schema, // this is now by supported Frameworks autowired
    ) {}
  
    public function someMethod(): void {
        $this->schema->indexes['blog']->getIdentifierField()->name;
    }
}
```

fixes #352