### PR TITLE
Fix Opensearch Docker compose container exited (1) appearing in Opensearch 2.12

### DIFF
--- a/.examples/laravel/docker-compose.yml
+++ b/.examples/laravel/docker-compose.yml
@@ -33,8 +33,8 @@ services:
     image: opensearchproject/opensearch:2
     environment:
       discovery.type: single-node
-      plugins.security.disabled: 'true'
       cluster.routing.allocation.disk.threshold_enabled: 'false'
+      DISABLE_SECURITY_PLUGIN: true
       http.port: 9201
     ports:
       - "9201:9201"

--- a/.examples/mezzio/docker-compose.yml
+++ b/.examples/mezzio/docker-compose.yml
@@ -33,8 +33,8 @@ services:
     image: opensearchproject/opensearch:2
     environment:
       discovery.type: single-node
-      plugins.security.disabled: 'true'
       cluster.routing.allocation.disk.threshold_enabled: 'false'
+      DISABLE_SECURITY_PLUGIN: true
       http.port: 9201
     ports:
       - "9201:9201"

--- a/.examples/spiral/docker-compose.yml
+++ b/.examples/spiral/docker-compose.yml
@@ -33,8 +33,8 @@ services:
     image: opensearchproject/opensearch:2
     environment:
       discovery.type: single-node
-      plugins.security.disabled: 'true'
       cluster.routing.allocation.disk.threshold_enabled: 'false'
+      DISABLE_SECURITY_PLUGIN: true
       http.port: 9201
     ports:
       - "9201:9201"

--- a/.examples/symfony/docker-compose.yml
+++ b/.examples/symfony/docker-compose.yml
@@ -33,8 +33,8 @@ services:
     image: opensearchproject/opensearch:2
     environment:
       discovery.type: single-node
-      plugins.security.disabled: 'true'
       cluster.routing.allocation.disk.threshold_enabled: 'false'
+      DISABLE_SECURITY_PLUGIN: true
       http.port: 9201
     ports:
       - "9201:9201"

--- a/.examples/yii/docker-compose.yml
+++ b/.examples/yii/docker-compose.yml
@@ -33,8 +33,8 @@ services:
     image: opensearchproject/opensearch:2
     environment:
       discovery.type: single-node
-      plugins.security.disabled: 'true'
       cluster.routing.allocation.disk.threshold_enabled: 'false'
+      DISABLE_SECURITY_PLUGIN: true
       http.port: 9201
     ports:
       - "9201:9201"

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -1546,8 +1546,8 @@ search engine.
                 image: opensearchproject/opensearch:2
                 environment:
                   discovery.type: single-node
-                  plugins.security.disabled: 'true'
                   cluster.routing.allocation.disk.threshold_enabled: 'false'
+                  DISABLE_SECURITY_PLUGIN: true
                 ports:
                   - "9200:9200"
                 healthcheck:

--- a/packages/seal-opensearch-adapter/docker-compose.yml
+++ b/packages/seal-opensearch-adapter/docker-compose.yml
@@ -3,8 +3,8 @@ services:
     image: opensearchproject/opensearch:2
     environment:
       discovery.type: single-node
-      plugins.security.disabled: 'true'
       cluster.routing.allocation.disk.threshold_enabled: 'false'
+      DISABLE_SECURITY_PLUGIN: true
     ports:
       - "9200:9200"
     healthcheck:


### PR DESCRIPTION
This should fix issues with Opensearch 2.12: https://github.com/opensearch-project/OpenSearch/issues/12489