### PR TITLE
Add aliases support to different Adapters (#381)

### DIFF
--- a/packages/seal-elasticsearch-adapter/src/ElasticsearchSearcher.php
+++ b/packages/seal-elasticsearch-adapter/src/ElasticsearchSearcher.php
@@ -147,13 +147,26 @@ final class ElasticsearchSearcher implements SearcherInterface
     private function hitsToDocuments(array $indexes, array $hits): \Generator
     {
         $indexesByInternalName = [];
-        foreach ($indexes as $index) {
-            $indexesByInternalName[$index->name] = $index;
-        }
 
         /** @var array{_index: string, _source: array<string, mixed>} $hit */
         foreach ($hits as $hit) {
             $index = $indexesByInternalName[$hit['_index']] ?? null;
+            if (!$index instanceof Index) {
+                $lastMaxLength = 0;
+
+                // find the correct index alias as we use %indexName%_%datetime% as index name
+                foreach ($indexes as $otherIndex) {
+                    if (
+                        \str_starts_with($hit['_index'], $otherIndex->name . '_')
+                        && $lastMaxLength < \strlen($otherIndex->name)
+                    ) {
+                        $index = $otherIndex;
+                        $lastMaxLength = \strlen($index->name);
+                    }
+                }
+                $indexesByInternalName[$hit['_index']] = $index;
+            }
+
             if (!$index instanceof Index) {
                 throw new \RuntimeException('SchemaMetadata for Index "' . $hit['_index'] . '" not found.');
             }

--- a/packages/seal-elasticsearch-adapter/tests/ElasticsearchSchemaManagerTest.php
+++ b/packages/seal-elasticsearch-adapter/tests/ElasticsearchSchemaManagerTest.php
@@ -47,7 +47,9 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
         $task = static::$schemaManager->dropIndex($index, ['return_slow_promise_result' => true]);
         $task->wait();
 
-        $this->assertTrue(isset($mapping[$index->name]['mappings']['properties']));
+        $targetIndexName = \array_key_first($mapping);
+
+        $this->assertTrue(isset($mapping[$targetIndexName]['mappings']['properties']));
 
         $this->assertSame([
             'id' => [
@@ -57,7 +59,7 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             'title' => [
                 'type' => 'text',
             ],
-        ], $mapping[$index->name]['mappings']['properties']);
+        ], $mapping[$targetIndexName]['mappings']['properties']);
     }
 
     public function testComplexElasticsearchMapping(): void
@@ -76,7 +78,9 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
         $task = static::$schemaManager->dropIndex($index, ['return_slow_promise_result' => true]);
         $task->wait();
 
-        $this->assertTrue(isset($mapping[$index->name]['mappings']['properties']));
+        $targetIndexName = \array_key_first($mapping);
+
+        $this->assertTrue(isset($mapping[$targetIndexName]['mappings']['properties']));
 
         $this->assertSame([
             'article' => [
@@ -194,6 +198,6 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
                 'type' => 'keyword',
                 'index' => false,
             ],
-        ], $mapping[$index->name]['mappings']['properties']);
+        ], $mapping[$targetIndexName]['mappings']['properties']);
     }
 }

--- a/packages/seal-opensearch-adapter/tests/OpensearchSchemaManagerTest.php
+++ b/packages/seal-opensearch-adapter/tests/OpensearchSchemaManagerTest.php
@@ -43,7 +43,9 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
         $task = static::$schemaManager->dropIndex($index, ['return_slow_promise_result' => true]);
         $task->wait();
 
-        $this->assertTrue(isset($mapping[$index->name]['mappings']['properties']));
+        $targetIndexName = \array_key_first($mapping);
+
+        $this->assertTrue(isset($mapping[$targetIndexName]['mappings']['properties']));
 
         $this->assertSame([
             'id' => [
@@ -52,7 +54,7 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             'title' => [
                 'type' => 'text',
             ],
-        ], $mapping[$index->name]['mappings']['properties']);
+        ], $mapping[$targetIndexName]['mappings']['properties']);
     }
 
     public function testComplexOpensearchMapping(): void
@@ -68,7 +70,9 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
         $task = static::$schemaManager->dropIndex($index, ['return_slow_promise_result' => true]);
         $task->wait();
 
-        $this->assertTrue(isset($mapping[$index->name]['mappings']['properties']));
+        $targetIndexName = \array_key_first($mapping);
+
+        $this->assertTrue(isset($mapping[$targetIndexName]['mappings']['properties']));
 
         $this->assertSame([
             'article' => [
@@ -180,6 +184,6 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             'uuid' => [
                 'type' => 'keyword',
             ],
-        ], $mapping[$index->name]['mappings']['properties']);
+        ], $mapping[$targetIndexName]['mappings']['properties']);
     }
 }


### PR DESCRIPTION
Implemented:

 - [x] ~~Memory~~: No support required
 - [x] #381
 - [x] #384
 - [x] ~~Meilisearch~~: Not supported we will use swap indexes for zero downtime reindex
 - [ ] ~~Algolia~~: Not supported we will require to use replaceAll for zero downtime reindex
 - [ ] Redisearch
 - [ ] Solr
 - [ ] Loupe
 - [ ] Typesense

Aliases are for some adapters required for zero downtime reindexing. See for this #212 