### PR TITLE
Update meilisearch image to new v1 tag

### DIFF
--- a/.examples/laravel/docker-compose.yml
+++ b/.examples/laravel/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - elasticsearch-data:/usr/share/elasticsearch/data
 
   meilisearch:
-    image: getmeili/meilisearch:v1.9
+    image: getmeili/meilisearch:v1
     environment:
       MEILI_ENV: development
     ports:

--- a/.examples/mezzio/docker-compose.yml
+++ b/.examples/mezzio/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - elasticsearch-data:/usr/share/elasticsearch/data
 
   meilisearch:
-    image: getmeili/meilisearch:v1.9
+    image: getmeili/meilisearch:v1
     environment:
       MEILI_ENV: development
     ports:

--- a/.examples/spiral/docker-compose.yml
+++ b/.examples/spiral/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - elasticsearch-data:/usr/share/elasticsearch/data
 
   meilisearch:
-    image: getmeili/meilisearch:v1.9
+    image: getmeili/meilisearch:v1
     environment:
       MEILI_ENV: development
     ports:

--- a/.examples/symfony/docker-compose.yml
+++ b/.examples/symfony/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - elasticsearch-data:/usr/share/elasticsearch/data
 
   meilisearch:
-    image: getmeili/meilisearch:v1.9
+    image: getmeili/meilisearch:v1
     environment:
       MEILI_ENV: development
     ports:

--- a/.examples/yii/docker-compose.yml
+++ b/.examples/yii/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - elasticsearch-data:/usr/share/elasticsearch/data
 
   meilisearch:
-    image: getmeili/meilisearch:v1.9
+    image: getmeili/meilisearch:v1
     environment:
       MEILI_ENV: development
     ports:

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -1463,7 +1463,7 @@ search engine.
 
             services:
               meilisearch:
-                image: getmeili/meilisearch:v1.9
+                image: getmeili/meilisearch:v1
                 environment:
                   MEILI_ENV: development
                 ports:

--- a/packages/seal-meilisearch-adapter/docker-compose.yml
+++ b/packages/seal-meilisearch-adapter/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   meilisearch:
-    image: getmeili/meilisearch:v1.9
+    image: getmeili/meilisearch:v1
     environment:
       MEILI_ENV: development
     ports:


### PR DESCRIPTION
So we not longer need to update our docker images for every minor release.