### PR TITLE
Add stricter validation for field names

### DIFF
--- a/.github/workflows/callable-test.yml
+++ b/.github/workflows/callable-test.yml
@@ -44,7 +44,7 @@ jobs:
               with:
                   php-version: ${{ matrix.php-version }}
                   tools: 'composer:v2'
-                  ini-values: memory_limit=-1
+                  ini-values: memory_limit=-1, zend.assertions=1
                   coverage: none
 
             - name: Install composer dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
               with:
                   php-version: '8.2'
                   tools: 'composer:v2'
-                  ini-values: memory_limit=-1
+                  ini-values: memory_limit=-1, zend.assertions=1
                   coverage: none
 
             - name: Install composer dependencies

--- a/packages/seal/phpunit.xml.dist
+++ b/packages/seal/phpunit.xml.dist
@@ -8,6 +8,7 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
+        <ini name="zend.assertions" value="1" />
         <ini name="date.timezone" value="Europe/Berlin" />
         <server name="SHELL_VERBOSITY" value="-1" />
     </php>

--- a/packages/seal/src/Schema/Index.php
+++ b/packages/seal/src/Schema/Index.php
@@ -123,6 +123,25 @@ final class Index
         ];
 
         foreach ($fields as $name => $field) {
+            \assert(
+                $name === $field->name,
+                \sprintf(
+                    'A field named "%s" does not match key "%s" in index "%s", this is at current state required and may change in future.',
+                    $field->name,
+                    $name,
+                    $this->name,
+                ),
+            );
+
+            \assert(
+                \preg_match('/^[a-zA-Z0-9_]+$/', $field->name) === 1,
+                \sprintf(
+                    'A field named "%s" uses unsupported character in index "%s", supported characters are "a-z", "A-Z", "0-9" and "_".',
+                    $field->name,
+                    $this->name,
+                ),
+            );
+
             if ($field instanceof Field\ObjectField) {
                 foreach ($this->getAttributes($field->fields, true) as $attributeType => $fieldNames) {
                     foreach ($fieldNames as $fieldName) {

--- a/packages/seal/src/Schema/Index.php
+++ b/packages/seal/src/Schema/Index.php
@@ -124,7 +124,7 @@ final class Index
 
         foreach ($fields as $name => $field) {
             \assert(
-                $name === $field->name, // this may change in future, see https://github.com/schranz-search/schranz-search/issues/200
+                (string) $name === $field->name, // this may change in future, see https://github.com/schranz-search/schranz-search/issues/200
                 \sprintf(
                     'A field named "%s" does not match key "%s" in index "%s", this is at current state required and may change in future.',
                     $field->name,
@@ -134,7 +134,7 @@ final class Index
             );
 
             \assert(
-                1 === \preg_match('/^\w+$/', $field->name),
+                1 === \preg_match('/^([a-z]|[A-Z])\w+$/', $field->name),
                 \sprintf(
                     'A field named "%s" uses unsupported character in index "%s", supported characters are "a-z", "A-Z", "0-9" and "_".',
                     $field->name,

--- a/packages/seal/src/Schema/Index.php
+++ b/packages/seal/src/Schema/Index.php
@@ -134,7 +134,7 @@ final class Index
             );
 
             \assert(
-                \preg_match('/^[a-zA-Z0-9_]+$/', $field->name) === 1,
+                1 === \preg_match('/^\w+$/', $field->name),
                 \sprintf(
                     'A field named "%s" uses unsupported character in index "%s", supported characters are "a-z", "A-Z", "0-9" and "_".',
                     $field->name,

--- a/packages/seal/src/Schema/Index.php
+++ b/packages/seal/src/Schema/Index.php
@@ -124,7 +124,7 @@ final class Index
 
         foreach ($fields as $name => $field) {
             \assert(
-                $name === $field->name,
+                $name === $field->name, // this may change in future, see https://github.com/schranz-search/schranz-search/issues/200
                 \sprintf(
                     'A field named "%s" does not match key "%s" in index "%s", this is at current state required and may change in future.',
                     $field->name,

--- a/packages/seal/tests/Schema/IndexTest.php
+++ b/packages/seal/tests/Schema/IndexTest.php
@@ -1,11 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of the Schranz Search package.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Schranz\Search\SEAL\Tests\Schema;
 
-
 use PHPUnit\Framework\TestCase;
-use Schranz\Search\SEAL\Schema\Index;
 use Schranz\Search\SEAL\Schema\Field;
+use Schranz\Search\SEAL\Schema\Index;
 
 class IndexTest extends TestCase
 {
@@ -27,10 +37,10 @@ class IndexTest extends TestCase
         $this->expectException(\AssertionError::class);
         $this->expectExceptionMessage('A field named "title" does not match key "name" in index "test", this is at current state required and may change in future.');
 
-        (new Index('test', [
+        new Index('test', [
             'uuid' => new Field\IdentifierField('uuid'),
             'name' => new Field\TextField('title'),
-        ]));
+        ]);
     }
 
     public function testFalseIdentifiertFieldMapping(): void
@@ -38,9 +48,9 @@ class IndexTest extends TestCase
         $this->expectException(\AssertionError::class);
         $this->expectExceptionMessage('A field named "uuid" does not match key "id" in index "test", this is at current state required and may change in future.');
 
-        (new Index('test', [
+        new Index('test', [
             'id' => new Field\IdentifierField('uuid'),
-        ]));
+        ]);
     }
 
     public function testFalseObjectFieldMapping(): void
@@ -48,12 +58,12 @@ class IndexTest extends TestCase
         $this->expectException(\AssertionError::class);
         $this->expectExceptionMessage('A field named "title" does not match key "name" in index "test", this is at current state required and may change in future.');
 
-        (new Index('test', [
+        new Index('test', [
             'uuid' => new Field\IdentifierField('uuid'),
             'object' => new Field\ObjectField('object', [
                 'name' => new Field\TextField('title'),
             ]),
-        ]));
+        ]);
     }
 
     public function testFalseRootFieldCharacter(): void
@@ -61,10 +71,10 @@ class IndexTest extends TestCase
         $this->expectException(\AssertionError::class);
         $this->expectExceptionMessage('A field named "test.title" uses unsupported character in index "test", supported characters are "a-z", "A-Z", "0-9" and "_".');
 
-        (new Index('test', [
+        new Index('test', [
             'uuid' => new Field\IdentifierField('uuid'),
             'test.title' => new Field\TextField('test.title'),
-        ]));
+        ]);
     }
 
     public function testFalseObjectFieldCharacter(): void
@@ -72,11 +82,11 @@ class IndexTest extends TestCase
         $this->expectException(\AssertionError::class);
         $this->expectExceptionMessage('A field named "test.title" uses unsupported character in index "test", supported characters are "a-z", "A-Z", "0-9" and "_".');
 
-        (new Index('test', [
+        new Index('test', [
             'uuid' => new Field\IdentifierField('uuid'),
             'object' => new Field\ObjectField('object', [
                 'test.title' => new Field\TextField('test.title'),
             ]),
-        ]));
+        ]);
     }
 }

--- a/packages/seal/tests/Schema/IndexTest.php
+++ b/packages/seal/tests/Schema/IndexTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Schranz\Search\SEAL\Tests\Schema;
+
+
+use PHPUnit\Framework\TestCase;
+use Schranz\Search\SEAL\Schema\Index;
+use Schranz\Search\SEAL\Schema\Field;
+
+class IndexTest extends TestCase
+{
+    public function testIndex(): void
+    {
+        $index = new Index('test', [
+            'uuid' => new Field\IdentifierField('uuid'),
+            'object' => new Field\ObjectField('object', [
+                'name' => new Field\TextField('name'),
+            ]),
+        ]);
+
+        $this->assertSame('uuid', $index->getIdentifierField()->name);
+        $this->assertSame(['object.name'], $index->searchableFields);
+    }
+
+    public function testFalseRootFieldMapping(): void
+    {
+        $this->expectException(\AssertionError::class);
+        $this->expectExceptionMessage('A field named "title" does not match key "name" in index "test", this is at current state required and may change in future.');
+
+        (new Index('test', [
+            'uuid' => new Field\IdentifierField('uuid'),
+            'name' => new Field\TextField('title'),
+        ]));
+    }
+
+    public function testFalseIdentifiertFieldMapping(): void
+    {
+        $this->expectException(\AssertionError::class);
+        $this->expectExceptionMessage('A field named "uuid" does not match key "id" in index "test", this is at current state required and may change in future.');
+
+        (new Index('test', [
+            'id' => new Field\IdentifierField('uuid'),
+        ]));
+    }
+
+    public function testFalseObjectFieldMapping(): void
+    {
+        $this->expectException(\AssertionError::class);
+        $this->expectExceptionMessage('A field named "title" does not match key "name" in index "test", this is at current state required and may change in future.');
+
+        (new Index('test', [
+            'uuid' => new Field\IdentifierField('uuid'),
+            'object' => new Field\ObjectField('object', [
+                'name' => new Field\TextField('title'),
+            ]),
+        ]));
+    }
+
+    public function testFalseRootFieldCharacter(): void
+    {
+        $this->expectException(\AssertionError::class);
+        $this->expectExceptionMessage('A field named "test.title" uses unsupported character in index "test", supported characters are "a-z", "A-Z", "0-9" and "_".');
+
+        (new Index('test', [
+            'uuid' => new Field\IdentifierField('uuid'),
+            'test.title' => new Field\TextField('test.title'),
+        ]));
+    }
+
+    public function testFalseObjectFieldCharacter(): void
+    {
+        $this->expectException(\AssertionError::class);
+        $this->expectExceptionMessage('A field named "test.title" uses unsupported character in index "test", supported characters are "a-z", "A-Z", "0-9" and "_".');
+
+        (new Index('test', [
+            'uuid' => new Field\IdentifierField('uuid'),
+            'object' => new Field\ObjectField('object', [
+                'test.title' => new Field\TextField('test.title'),
+            ]),
+        ]));
+    }
+}

--- a/packages/seal/tests/Schema/Loader/fixtures/basic/news.php
+++ b/packages/seal/tests/Schema/Loader/fixtures/basic/news.php
@@ -45,7 +45,7 @@ return new Index('news', [
     'rating' => new Field\FloatField('rating'),
     'comments' => new Field\ObjectField('comments', [
         'email' => new Field\TextField('email'),
-        'text' => new Field\TextField('title'),
+        'text' => new Field\TextField('text'),
     ], multiple: true),
     'tags' => new Field\TextField('tags', multiple: true),
     'categoryIds' => new Field\IntegerField('categoryIds', multiple: true),


### PR DESCRIPTION
This outputs a error message for an unexpected input for the field name. We validate currently two things.

 - field Key === field name (this may be change in future)
 - field name only supports a-z, A-Z, 0-9 and _ (see #426)

fix #426 

FYI @Toflar 