### PR TITLE
Improve algolia cleanup script to retry deletion

### DIFF
--- a/packages/seal-algolia-adapter/bin/drop_all_indexes.php
+++ b/packages/seal-algolia-adapter/bin/drop_all_indexes.php
@@ -42,9 +42,8 @@ foreach ($client->listIndices()['items'] as $key => $value) {
     try {
         $client->deleteIndex($value['name']);
     } catch (\Exception) {
-        $retryIndexes[$key] =  $value;
+        $retryIndexes[$key] = $value;
         echo 'Retry later ... ' . $value['name'] . \PHP_EOL;
-        $return = 1;
     }
 }
 
@@ -54,7 +53,6 @@ foreach ($retryIndexes as $key => $value) {
     try {
         $client->deleteIndex($value['name']);
     } catch (\Exception) {
-        $retryIndexes[] =  $value['name'];
         echo 'Errored ... ' . $value['name'] . \PHP_EOL;
         $return = 1;
     }

--- a/packages/seal-algolia-adapter/bin/drop_all_indexes.php
+++ b/packages/seal-algolia-adapter/bin/drop_all_indexes.php
@@ -34,12 +34,27 @@ $_ENV['ALGOLIA_DSN'] = $algoliaDsn;
 $client = \Schranz\Search\SEAL\Adapter\Algolia\Tests\ClientHelper::getClient();
 
 $return = 0;
+
+$retryIndexes = [];
 foreach ($client->listIndices()['items'] as $key => $value) {
     echo 'Delete ... ' . $value['name'] . \PHP_EOL;
 
     try {
         $client->deleteIndex($value['name']);
     } catch (\Exception) {
+        $retryIndexes[$key] =  $value;
+        echo 'Retry later ... ' . $value['name'] . \PHP_EOL;
+        $return = 1;
+    }
+}
+
+foreach ($retryIndexes as $key => $value) {
+    echo 'Delete ... ' . $value['name'] . \PHP_EOL;
+
+    try {
+        $client->deleteIndex($value['name']);
+    } catch (\Exception) {
+        $retryIndexes[] =  $value['name'];
         echo 'Errored ... ' . $value['name'] . \PHP_EOL;
         $return = 1;
     }


### PR DESCRIPTION
This let me remove the indexes with a single run even the replicas fails sometimes we will retry to remove them once.