### PR TITLE
Add bulk operation for Engine and Indexers and use it for reindex operation

### DIFF
--- a/integrations/laravel/src/Console/ReindexCommand.php
+++ b/integrations/laravel/src/Console/ReindexCommand.php
@@ -72,12 +72,12 @@ final class ReindexCommand extends Command
                 $indexName,
                 $drop,
                 function (string $index, int $count, int|null $total) use ($progressBar) {
-                    $progressBar->setMessage($index);
-                    $progressBar->setProgress($count);
-
                     if (null !== $total) {
                         $progressBar->setMaxSteps($total);
                     }
+
+                    $progressBar->setMessage($index);
+                    $progressBar->setProgress($count);
                 },
             );
 

--- a/integrations/mezzio/src/Command/ReindexCommand.php
+++ b/integrations/mezzio/src/Command/ReindexCommand.php
@@ -68,12 +68,12 @@ final class ReindexCommand extends Command
                 $indexName,
                 $drop,
                 function (string $index, int $count, int|null $total) use ($progressBar) {
-                    $progressBar->setMessage($index);
-                    $progressBar->setProgress($count);
-
                     if (null !== $total) {
                         $progressBar->setMaxSteps($total);
                     }
+
+                    $progressBar->setMessage($index);
+                    $progressBar->setProgress($count);
                 },
             );
 

--- a/integrations/spiral/src/Console/ReindexCommand.php
+++ b/integrations/spiral/src/Console/ReindexCommand.php
@@ -61,12 +61,12 @@ final class ReindexCommand extends Command
                 $this->indexName,
                 $this->drop,
                 function (string $index, int $count, int|null $total) use ($progressBar) {
-                    $progressBar->setMessage($index);
-                    $progressBar->setProgress($count);
-
                     if (null !== $total) {
                         $progressBar->setMaxSteps($total);
                     }
+
+                    $progressBar->setMessage($index);
+                    $progressBar->setProgress($count);
                 },
             );
 

--- a/integrations/symfony/src/Command/ReindexCommand.php
+++ b/integrations/symfony/src/Command/ReindexCommand.php
@@ -69,16 +69,17 @@ final class ReindexCommand extends Command
                 $indexName,
                 $drop,
                 function (string $index, int $count, int|null $total) use ($progressBar) {
-                    $progressBar->setMessage($index);
-                    $progressBar->setProgress($count);
-
                     if (null !== $total) {
                         $progressBar->setMaxSteps($total);
                     }
+
+                    $progressBar->setMessage($index);
+                    $progressBar->setProgress($count);
                 },
             );
 
             $progressBar->finish();
+
             $ui->writeln('');
             $ui->writeln('');
         }

--- a/integrations/yii/src/Command/ReindexCommand.php
+++ b/integrations/yii/src/Command/ReindexCommand.php
@@ -68,12 +68,12 @@ final class ReindexCommand extends Command
                 $indexName,
                 $drop,
                 function (string $index, int $count, int|null $total) use ($progressBar) {
-                    $progressBar->setMessage($index);
-                    $progressBar->setProgress($count);
-
                     if (null !== $total) {
                         $progressBar->setMaxSteps($total);
                     }
+
+                    $progressBar->setMessage($index);
+                    $progressBar->setProgress($count);
                 },
             );
 

--- a/packages/seal-algolia-adapter/src/AlgoliaIndexer.php
+++ b/packages/seal-algolia-adapter/src/AlgoliaIndexer.php
@@ -14,13 +14,15 @@ declare(strict_types=1);
 namespace Schranz\Search\SEAL\Adapter\Algolia;
 
 use Algolia\AlgoliaSearch\Api\SearchClient;
+use Schranz\Search\SEAL\Adapter\BulkableIndexerInterface;
+use Schranz\Search\SEAL\Adapter\BulkHelper;
 use Schranz\Search\SEAL\Adapter\IndexerInterface;
 use Schranz\Search\SEAL\Marshaller\Marshaller;
 use Schranz\Search\SEAL\Schema\Index;
 use Schranz\Search\SEAL\Task\AsyncTask;
 use Schranz\Search\SEAL\Task\TaskInterface;
 
-final class AlgoliaIndexer implements IndexerInterface
+final class AlgoliaIndexer implements IndexerInterface, BulkableIndexerInterface
 {
     private readonly Marshaller $marshaller;
 
@@ -79,6 +81,45 @@ final class AlgoliaIndexer implements IndexerInterface
                 $index->name,
                 $batchIndexingResponse['taskID'],
             );
+        });
+    }
+
+    public function bulk(Index $index, iterable $saveDocuments, iterable $deleteDocumentIdentifiers, int $bulkSize = 100, array $options = []): TaskInterface|null
+    {
+        $identifierField = $index->getIdentifierField();
+
+        $batchIndexingResponses = [];
+        foreach (BulkHelper::splitBulk($saveDocuments, $bulkSize) as $bulkSaveDocuments) {
+            $marshalledBulkSaveDocuments = [];
+            foreach ($bulkSaveDocuments as $document) {
+                $document = $this->marshaller->marshall($index->fields, $document);
+                $document['objectID'] = $document[$identifierField->name]; // TODO check objectIDKey instead see: https://github.com/algolia/algoliasearch-client-php/issues/738
+
+                $marshalledBulkSaveDocuments[] = $document;
+            }
+
+            $batchIndexingResponses[] = $this->client->saveObjects($index->name, $marshalledBulkSaveDocuments);
+        }
+
+        foreach (BulkHelper::splitBulk($deleteDocumentIdentifiers, $bulkSize) as $bulkDeleteDocumentIdentifiers) {
+            $batchIndexingResponses[] = $this->client->deleteObjects($index->name, $bulkDeleteDocumentIdentifiers);
+        }
+
+        if (!($options['return_slow_promise_result'] ?? false)) {
+            return null;
+        }
+
+        return new AsyncTask(function () use ($batchIndexingResponses, $index) {
+            foreach ($batchIndexingResponses as $batchIndexingResponseList) {
+                foreach ($batchIndexingResponseList as $batchIndexingResponse) {
+                    \assert(isset($batchIndexingResponse['taskID']) && \is_int($batchIndexingResponse['taskID']), 'Task ID is expected to be returned by algolia client.');
+
+                    $this->client->waitForTask(
+                        $index->name,
+                        $batchIndexingResponse['taskID'],
+                    );
+                }
+            }
         });
     }
 }

--- a/packages/seal-meilisearch-adapter/composer.json
+++ b/packages/seal-meilisearch-adapter/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": "^8.1",
         "schranz-search/seal": "^0.6",
-        "meilisearch/meilisearch-php": "^1.0",
+        "meilisearch/meilisearch-php": "^1.2",
         "psr/container": "^1.0 || ^2.0"
     },
     "require-dev": {

--- a/packages/seal-meilisearch-adapter/composer.lock
+++ b/packages/seal-meilisearch-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c1fb02bfad2d5f499c51bba80fa971bc",
+    "content-hash": "1dd67acad1ac8ef1872fd60df61c1ab2",
     "packages": [
         {
             "name": "meilisearch/meilisearch-php",
@@ -2871,12 +2871,12 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.1"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/packages/seal-redisearch-adapter/src/RediSearchIndexer.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchIndexer.php
@@ -96,7 +96,6 @@ final class RediSearchIndexer implements IndexerInterface, BulkableIndexerInterf
     {
         $identifierField = $index->getIdentifierField();
 
-        $batchIndexingResponses = [];
         foreach (BulkHelper::splitBulk($saveDocuments, $bulkSize) as $bulkSaveDocuments) {
             $multiClient = $this->client->multi();
             foreach ($bulkSaveDocuments as $document) {

--- a/packages/seal-redisearch-adapter/src/RediSearchIndexer.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchIndexer.php
@@ -13,13 +13,15 @@ declare(strict_types=1);
 
 namespace Schranz\Search\SEAL\Adapter\RediSearch;
 
+use Schranz\Search\SEAL\Adapter\BulkableIndexerInterface;
+use Schranz\Search\SEAL\Adapter\BulkHelper;
 use Schranz\Search\SEAL\Adapter\IndexerInterface;
 use Schranz\Search\SEAL\Marshaller\Marshaller;
 use Schranz\Search\SEAL\Schema\Index;
 use Schranz\Search\SEAL\Task\SyncTask;
 use Schranz\Search\SEAL\Task\TaskInterface;
 
-final class RediSearchIndexer implements IndexerInterface
+final class RediSearchIndexer implements IndexerInterface, BulkableIndexerInterface
 {
     private readonly Marshaller $marshaller;
 
@@ -88,5 +90,56 @@ final class RediSearchIndexer implements IndexerInterface
         $this->client->clearLastError();
 
         return new \RuntimeException('Redis: ' . $lastError);
+    }
+
+    public function bulk(Index $index, iterable $saveDocuments, iterable $deleteDocumentIdentifiers, int $bulkSize = 100, array $options = []): TaskInterface|null
+    {
+        $identifierField = $index->getIdentifierField();
+
+        $batchIndexingResponses = [];
+        foreach (BulkHelper::splitBulk($saveDocuments, $bulkSize) as $bulkSaveDocuments) {
+            $multiClient = $this->client->multi();
+            foreach ($bulkSaveDocuments as $document) {
+                /** @var string|int|null $identifier */
+                $identifier = $document[$identifierField->name] ?? null;
+
+                $marshalledDocument = $this->marshaller->marshall($index->fields, $document);
+
+                $multiClient->rawCommand(
+                    'JSON.SET',
+                    $index->name . ':' . ((string) $identifier),
+                    '$',
+                    \json_encode($marshalledDocument, \JSON_THROW_ON_ERROR),
+                );
+            }
+
+            $multiExec = $multiClient->exec();
+
+            if (false === $multiExec) {
+                throw $this->createRedisLastErrorException();
+            }
+        }
+
+        foreach (BulkHelper::splitBulk($deleteDocumentIdentifiers, $bulkSize) as $bulkDeleteDocumentIdentifiers) {
+            $multiClient = $this->client->multi();
+            foreach ($bulkDeleteDocumentIdentifiers as $deleteDocumentIdentifier) {
+                $multiClient->rawCommand(
+                    'JSON.DEL',
+                    $index->name . ':' . $deleteDocumentIdentifier,
+                );
+            }
+
+            $multiExec = $multiClient->exec();
+
+            if (false === $multiExec) {
+                throw $this->createRedisLastErrorException();
+            }
+        }
+
+        if (!($options['return_slow_promise_result'] ?? false)) {
+            return null;
+        }
+
+        return new SyncTask(null);
     }
 }

--- a/packages/seal-typesense-adapter/src/TypesenseIndexer.php
+++ b/packages/seal-typesense-adapter/src/TypesenseIndexer.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Schranz\Search\SEAL\Adapter\Typesense;
 
+use Schranz\Search\SEAL\Adapter\BulkableIndexerInterface;
+use Schranz\Search\SEAL\Adapter\BulkHelper;
 use Schranz\Search\SEAL\Adapter\IndexerInterface;
 use Schranz\Search\SEAL\Marshaller\Marshaller;
 use Schranz\Search\SEAL\Schema\Index;
@@ -20,7 +22,7 @@ use Schranz\Search\SEAL\Task\SyncTask;
 use Schranz\Search\SEAL\Task\TaskInterface;
 use Typesense\Client;
 
-final class TypesenseIndexer implements IndexerInterface
+final class TypesenseIndexer implements IndexerInterface, BulkableIndexerInterface
 {
     private readonly Marshaller $marshaller;
 
@@ -58,6 +60,48 @@ final class TypesenseIndexer implements IndexerInterface
     public function delete(Index $index, string $identifier, array $options = []): TaskInterface|null
     {
         $this->client->collections[$index->name]->documents[$identifier]->delete();
+
+        if (!($options['return_slow_promise_result'] ?? false)) {
+            return null;
+        }
+
+        return new SyncTask(null);
+    }
+
+    public function bulk(Index $index, iterable $saveDocuments, iterable $deleteDocumentIdentifiers, int $bulkSize = 100, array $options = []): TaskInterface|null
+    {
+        $identifierField = $index->getIdentifierField();
+
+        $batchIndexingResponses = [];
+        foreach (BulkHelper::splitBulk($saveDocuments, $bulkSize) as $bulkSaveDocuments) {
+            $marshalledBulkSaveDocuments = [];
+            foreach ($bulkSaveDocuments as $document) {
+                /** @var string|null $identifier */
+                $identifier = ((string) $document[$identifierField->name]) ?? null; // @phpstan-ignore-line
+
+                $marshalledDocument = $this->marshaller->marshall($index->fields, $document);
+                $marshalledDocument['id'] = $identifier;
+
+                $marshalledBulkSaveDocuments[] = $marshalledDocument;
+            }
+
+            $indexResponse = $this->client->collections[$index->name]->documents->import($marshalledBulkSaveDocuments);
+
+            $batchIndexingResponses[] = $indexResponse;
+        }
+
+        foreach (BulkHelper::splitBulk($deleteDocumentIdentifiers, $bulkSize) as $bulkDeleteDocumentIdentifiers) {
+            $filters = [];
+            foreach ($bulkDeleteDocumentIdentifiers as $deleteDocumentIdentifier) {
+                $filters[] = 'id:=' . $deleteDocumentIdentifier . '';
+            }
+
+            $deleteResponse = $this->client->collections[$index->name]->documents->delete([
+                'filter_by' => \implode(' || ', $filters),
+            ]);
+
+            $batchIndexingResponses[] = $deleteResponse;
+        }
 
         if (!($options['return_slow_promise_result'] ?? false)) {
             return null;

--- a/packages/seal/src/Adapter/BulkHelper.php
+++ b/packages/seal/src/Adapter/BulkHelper.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Schranz Search package.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Schranz\Search\SEAL\Adapter;
+
+/**
+ * @internal
+ */
+final class BulkHelper
+{
+    /**
+     * @template T of mixed
+     *
+     * @param iterable<T> $iterables
+     *
+     * @return \Generator<T[]>
+     */
+    public static function splitBulk(iterable $iterables, int $bulkSize): \Generator
+    {
+        $bulk = [];
+        $count = 0;
+
+        foreach ($iterables as $iterable) {
+            $bulk[] = $iterable;
+            ++$count;
+
+            if (0 === ($count % $bulkSize)) {
+                yield $bulk;
+                $bulk = [];
+            }
+        }
+
+        if ([] !== $bulk) {
+            yield $bulk;
+        }
+    }
+}

--- a/packages/seal/src/Adapter/BulkableIndexerInterface.php
+++ b/packages/seal/src/Adapter/BulkableIndexerInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Schranz Search package.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Schranz\Search\SEAL\Adapter;
+
+use Schranz\Search\SEAL\Schema\Index;
+use Schranz\Search\SEAL\Task\TaskInterface;
+
+interface BulkableIndexerInterface
+{
+    /**
+     * @param iterable<array<string, mixed>> $saveDocuments
+     * @param iterable<string> $deleteDocumentIdentifiers
+     * @param array{return_slow_promise_result?: true} $options
+     *
+     * @return ($options is non-empty-array ? TaskInterface<void|null> : null)
+     */
+    public function bulk(
+        Index $index,
+        iterable $saveDocuments,
+        iterable $deleteDocumentIdentifiers,
+        int $bulkSize = 100,
+        array $options = [],
+    ): TaskInterface|null;
+}

--- a/packages/seal/src/Engine.php
+++ b/packages/seal/src/Engine.php
@@ -192,7 +192,7 @@ final class Engine implements EngineInterface
                         $count = 0;
                         $total = $reindexProvider->total();
 
-                        $lastCount = 0;
+                        $lastCount = -1;
                         foreach ($reindexProvider->provide() as $document) {
                             ++$count;
 

--- a/packages/seal/src/Engine.php
+++ b/packages/seal/src/Engine.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Schranz\Search\SEAL;
 
 use Schranz\Search\SEAL\Adapter\AdapterInterface;
+use Schranz\Search\SEAL\Adapter\BulkableIndexerInterface;
 use Schranz\Search\SEAL\Exception\DocumentNotFoundException;
 use Schranz\Search\SEAL\Reindex\ReindexProviderInterface;
 use Schranz\Search\SEAL\Schema\Schema;
@@ -46,6 +47,38 @@ final class Engine implements EngineInterface
             $identifier,
             $options,
         );
+    }
+
+    public function bulk(string $index, iterable $saveDocuments, iterable $deleteDocumentIdentifiers, int $bulkSize = 100, array $options = []): TaskInterface|null
+    {
+        $indexer = $this->adapter->getIndexer();
+
+        if ($indexer instanceof BulkableIndexerInterface) {
+            return $indexer->bulk(
+                $this->schema->indexes[$index],
+                $saveDocuments,
+                $deleteDocumentIdentifiers,
+                $bulkSize,
+                $options,
+            );
+        }
+
+        $tasks = [];
+        foreach ($saveDocuments as $document) {
+            $tasks[] = $this->saveDocument($index, $document, $options);
+        }
+
+        foreach ($deleteDocumentIdentifiers as $deleteDocumentIdentifier) {
+            $tasks[] = $this->deleteDocument($index, $deleteDocumentIdentifier, $options);
+        }
+
+        if (!($options['return_slow_promise_result'] ?? false)) {
+            return null;
+        }
+
+        $tasks = \array_filter($tasks);
+
+        return new MultiTask($tasks);
     }
 
     public function getDocument(string $index, string $identifier): array
@@ -151,16 +184,33 @@ final class Engine implements EngineInterface
             }
 
             foreach ($reindexProviders as $reindexProvider) {
-                $count = 0;
-                $total = $reindexProvider->total();
-                foreach ($reindexProvider->provide() as $document) {
-                    $this->saveDocument($index, $document);
-                    ++$count;
+                $bulkSize = 2;
 
-                    if (null !== $progressCallback) {
-                        $progressCallback($index, $count, $total);
-                    }
-                }
+                $this->bulk(
+                    $index,
+                    (function () use ($index, $reindexProvider, $bulkSize, $progressCallback) {
+                        $count = 0;
+                        $total = $reindexProvider->total();
+
+                        foreach ($reindexProvider->provide() as $document) {
+                            ++$count;
+
+                            yield $document;
+
+                            if (null !== $progressCallback
+                                && 0 === $count % $bulkSize
+                            ) {
+                                $progressCallback($index, $count, $total);
+                            }
+                        }
+
+                        if (null !== $progressCallback) {
+                            $progressCallback($index, $count, $total);
+                        }
+                    })(),
+                    [],
+                    $bulkSize,
+                );
             }
         }
     }

--- a/packages/seal/src/Engine.php
+++ b/packages/seal/src/Engine.php
@@ -184,7 +184,7 @@ final class Engine implements EngineInterface
             }
 
             foreach ($reindexProviders as $reindexProvider) {
-                $bulkSize = 2;
+                $bulkSize = 100;
 
                 $this->bulk(
                     $index,

--- a/packages/seal/src/Engine.php
+++ b/packages/seal/src/Engine.php
@@ -198,7 +198,7 @@ final class Engine implements EngineInterface
                             yield $document;
 
                             if (null !== $progressCallback
-                                && 0 === $count % $bulkSize
+                                && 0 === ($count % $bulkSize)
                             ) {
                                 $progressCallback($index, $count, $total);
                             }

--- a/packages/seal/src/Engine.php
+++ b/packages/seal/src/Engine.php
@@ -192,6 +192,7 @@ final class Engine implements EngineInterface
                         $count = 0;
                         $total = $reindexProvider->total();
 
+                        $lastCount = 0;
                         foreach ($reindexProvider->provide() as $document) {
                             ++$count;
 
@@ -200,11 +201,14 @@ final class Engine implements EngineInterface
                             if (null !== $progressCallback
                                 && 0 === ($count % $bulkSize)
                             ) {
+                                $lastCount = $count;
                                 $progressCallback($index, $count, $total);
                             }
                         }
 
-                        if (null !== $progressCallback) {
+                        if ($lastCount !== $count
+                            && null !== $progressCallback
+                        ) {
                             $progressCallback($index, $count, $total);
                         }
                     })(),

--- a/packages/seal/src/EngineInterface.php
+++ b/packages/seal/src/EngineInterface.php
@@ -36,6 +36,15 @@ interface EngineInterface
     public function deleteDocument(string $index, string $identifier, array $options = []): TaskInterface|null;
 
     /**
+     * @param iterable<array<string, mixed>> $saveDocuments
+     * @param iterable<string> $deleteDocumentIdentifiers
+     * @param array{return_slow_promise_result?: true} $options
+     *
+     * @return ($options is non-empty-array ? TaskInterface<void|null> : null)
+     */
+    public function bulk(string $index, iterable $saveDocuments, iterable $deleteDocumentIdentifiers, int $bulkSize = 100, array $options = []): TaskInterface|null;
+
+    /**
      * @throws DocumentNotFoundException
      *
      * @return array<string, mixed>


### PR DESCRIPTION
A new interface will support bulk operations. If the index does not support it we wall fallback to the normal save and delete functions:

```php
    /**
     * @param iterable<array<string, mixed>> $saveDocuments
     * @param iterable<string> $deleteDocumentIdentifiers
     * @param array{return_slow_promise_result?: true} $options
     *
     * @return ($options is non-empty-array ? TaskInterface<array<string, mixed>> : null)
     */
    public function bulk(
        Index $index,
        iterable $saveDocuments,
        iterable $deleteDocumentIdentifiers,
        int $bulkSize = 100,
        array $options = [],
    ): TaskInterface|null;
```

fix #24 

## Adapters

 - [x] Memory https://github.com/schranz-search/schranz-search/pull/430/commits/a79c79562af5f4c3951cb291ec5cea3794431637
 - [x] Elasticsearch https://github.com/schranz-search/schranz-search/pull/430/commits/da7ecf4c90ab7abc0699ad03379152ee4b61724c
 - [x] Opensearch https://github.com/schranz-search/schranz-search/pull/430/commits/c6ae34002cc92348c48f3ca0659beac6c8cec9fe
 - [x] Meilisearch https://github.com/schranz-search/schranz-search/pull/430/commits/f40e0051bd2cf0c6c1af3acad0576bf98fd7b64d
 - [x] Algolia https://github.com/schranz-search/schranz-search/pull/430/commits/6f709025116c138b8ab7657edd46fe49363618b8
 - [x] Loupe https://github.com/schranz-search/schranz-search/pull/430/commits/646fe1b0808d83a515fd77281b7c693acb657c53
 - [x] Redisearch https://github.com/schranz-search/schranz-search/pull/430/commits/3cdb192885a5fe5a56b682d8a25a6df98aba416d
 - [x] Solr https://github.com/schranz-search/schranz-search/pull/430/commits/1eba8dd147fea28c6f845e388e2216c9574ecd07
 - [x] Typesense https://github.com/schranz-search/schranz-search/pull/430/commits/90bd3f30f991ec22d39d9cb7adb0a46e779d39aa

## Todo

 - [x] Fix integration reindex tests
 - [x] Fix Meilisearch lowest https://github.com/schranz-search/schranz-search/pull/430/commits/784d08465d0584b2e339f5bed873e577b38a091b