### PR TITLE
Add option to control bulk size for reindex commands (BC Break)

### DIFF
--- a/integrations/laravel/src/Console/ReindexCommand.php
+++ b/integrations/laravel/src/Console/ReindexCommand.php
@@ -27,7 +27,7 @@ final class ReindexCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'schranz:search:reindex {--engine= : The name of the engine} {--index= : The name of the index} {--drop : Drop the index before reindexing}';
+    protected $signature = 'schranz:search:reindex {--engine= : The name of the engine} {--index= : The name of the index} {--drop : Drop the index before reindexing} {--bulk-size= : The bulk size for reindexing, defaults to 100.}';
 
     /**
      * The console command description.
@@ -57,6 +57,8 @@ final class ReindexCommand extends Command
         $indexName = $this->option('index');
         /** @var bool $drop */
         $drop = $this->option('drop');
+        /** @var int $bulkSize */
+        $bulkSize = $this->option('bulk-size') ?: 100;
 
         foreach ($engineRegistry->getEngines() as $name => $engine) {
             if ($engineName && $engineName !== $name) {
@@ -71,6 +73,7 @@ final class ReindexCommand extends Command
                 $this->reindexProviders,
                 $indexName,
                 $drop,
+                $bulkSize,
                 function (string $index, int $count, int|null $total) use ($progressBar) {
                     if (null !== $total) {
                         $progressBar->setMaxSteps($total);

--- a/integrations/laravel/src/Console/ReindexCommand.php
+++ b/integrations/laravel/src/Console/ReindexCommand.php
@@ -58,7 +58,7 @@ final class ReindexCommand extends Command
         /** @var bool $drop */
         $drop = $this->option('drop');
         /** @var int $bulkSize */
-        $bulkSize = $this->option('bulk-size') ?: 100;
+        $bulkSize = ((int) $this->option('bulk-size')) ?: 100;
 
         foreach ($engineRegistry->getEngines() as $name => $engine) {
             if ($engineName && $engineName !== $name) {

--- a/integrations/mezzio/src/Command/ReindexCommand.php
+++ b/integrations/mezzio/src/Command/ReindexCommand.php
@@ -42,6 +42,7 @@ final class ReindexCommand extends Command
         $this->addOption('engine', null, InputOption::VALUE_REQUIRED, 'The name of the engine to create the schema for.');
         $this->addOption('index', null, InputOption::VALUE_REQUIRED, 'The name of the index to create the schema for.');
         $this->addOption('drop', null, InputOption::VALUE_NONE, 'Drop the index before reindexing.');
+        $this->addOption('bulk-size', null, InputOption::VALUE_REQUIRED, 'The bulk size for reindexing, defaults to 100.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -53,6 +54,8 @@ final class ReindexCommand extends Command
         $indexName = $input->getOption('index');
         /** @var bool $drop */
         $drop = $input->getOption('drop');
+        /** @var int $bulkSize */
+        $bulkSize = ((int) $input->getOption('bulk-size')) ?: 100;
 
         foreach ($this->engineRegistry->getEngines() as $name => $engine) {
             if ($engineName && $engineName !== $name) {
@@ -67,6 +70,7 @@ final class ReindexCommand extends Command
                 $this->reindexProviders,
                 $indexName,
                 $drop,
+                $bulkSize,
                 function (string $index, int $count, int|null $total) use ($progressBar) {
                     if (null !== $total) {
                         $progressBar->setMaxSteps($total);

--- a/integrations/spiral/src/Console/ReindexCommand.php
+++ b/integrations/spiral/src/Console/ReindexCommand.php
@@ -32,8 +32,11 @@ final class ReindexCommand extends Command
     #[Option(name: 'index', mode: InputOption::VALUE_REQUIRED, description: 'The name of the index')]
     private string|null $indexName = null;
 
-    #[Option(shortcut: 'd', description: 'Drop the index before reindexing.')]
+    #[Option(name: 'drop', description: 'Drop the index before reindexing.')]
     private bool $drop = false;
+
+    #[Option(name: 'bulk-size', description: 'The bulk size for reindexing, defaults to 100.')]
+    private int $bulkSize = 100;
 
     /**
      * @param iterable<ReindexProviderInterface> $reindexProviders
@@ -60,6 +63,7 @@ final class ReindexCommand extends Command
                 $this->reindexProviders,
                 $this->indexName,
                 $this->drop,
+                $this->bulkSize,
                 function (string $index, int $count, int|null $total) use ($progressBar) {
                     if (null !== $total) {
                         $progressBar->setMaxSteps($total);

--- a/integrations/symfony/src/Command/ReindexCommand.php
+++ b/integrations/symfony/src/Command/ReindexCommand.php
@@ -43,6 +43,7 @@ final class ReindexCommand extends Command
         $this->addOption('engine', null, InputOption::VALUE_REQUIRED, 'The name of the engine to create the schema for.');
         $this->addOption('index', null, InputOption::VALUE_REQUIRED, 'The name of the index to create the schema for.');
         $this->addOption('drop', null, InputOption::VALUE_NONE, 'Drop the index before reindexing.');
+        $this->addOption('bulk-size', null, InputOption::VALUE_REQUIRED, 'The bulk size for reindexing, defaults to 100.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -54,6 +55,8 @@ final class ReindexCommand extends Command
         $indexName = $input->getOption('index');
         /** @var bool $drop */
         $drop = $input->getOption('drop');
+        /** @var int $bulkSize */
+        $bulkSize = ((int) $input->getOption('bulk-size')) ?: 100;
 
         foreach ($this->engineRegistry->getEngines() as $name => $engine) {
             if ($engineName && $engineName !== $name) {
@@ -68,6 +71,7 @@ final class ReindexCommand extends Command
                 $this->reindexProviders,
                 $indexName,
                 $drop,
+                $bulkSize,
                 function (string $index, int $count, int|null $total) use ($progressBar) {
                     if (null !== $total) {
                         $progressBar->setMaxSteps($total);

--- a/integrations/yii/src/Command/ReindexCommand.php
+++ b/integrations/yii/src/Command/ReindexCommand.php
@@ -42,6 +42,7 @@ final class ReindexCommand extends Command
         $this->addOption('engine', null, InputOption::VALUE_REQUIRED, 'The name of the engine to create the schema for.');
         $this->addOption('index', null, InputOption::VALUE_REQUIRED, 'The name of the index to create the schema for.');
         $this->addOption('drop', null, InputOption::VALUE_NONE, 'Drop the index before reindexing.');
+        $this->addOption('bulk-size', null, InputOption::VALUE_REQUIRED, 'The bulk size for reindexing, defaults to 100.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -53,6 +54,8 @@ final class ReindexCommand extends Command
         $indexName = $input->getOption('index');
         /** @var bool $drop */
         $drop = $input->getOption('drop');
+        /** @var int $bulkSize */
+        $bulkSize = ((int) $input->getOption('bulk-size')) ?: 100;
 
         foreach ($this->engineRegistry->getEngines() as $name => $engine) {
             if ($engineName && $engineName !== $name) {
@@ -67,6 +70,7 @@ final class ReindexCommand extends Command
                 $this->reindexProviders,
                 $indexName,
                 $drop,
+                $bulkSize,
                 function (string $index, int $count, int|null $total) use ($progressBar) {
                     if (null !== $total) {
                         $progressBar->setMaxSteps($total);

--- a/packages/seal/src/Engine.php
+++ b/packages/seal/src/Engine.php
@@ -158,6 +158,7 @@ final class Engine implements EngineInterface
         iterable $reindexProviders,
         string|null $index = null,
         bool $dropIndex = false,
+        int $bulkSize = 100,
         callable|null $progressCallback = null,
     ): void {
         /** @var array<string, ReindexProviderInterface[]> $reindexProvidersPerIndex */
@@ -184,8 +185,6 @@ final class Engine implements EngineInterface
             }
 
             foreach ($reindexProviders as $reindexProvider) {
-                $bulkSize = 100;
-
                 $this->bulk(
                     $index,
                     (function () use ($index, $reindexProvider, $bulkSize, $progressCallback) {

--- a/packages/seal/src/EngineInterface.php
+++ b/packages/seal/src/EngineInterface.php
@@ -94,6 +94,7 @@ interface EngineInterface
         iterable $reindexProviders,
         string|null $index = null,
         bool $dropIndex = false,
+        int $bulkSize = 100,
         callable|null $progressCallback = null,
     ): void;
 }


### PR DESCRIPTION
This will add possibility to define the bulk size for reindexing with `--bulk-size 100` the 100 value is default.

## BC Breaks

 - Additional parameter `$bulkSize` to `Engine` and `Engineinterface` to `reindex` command added
 - Rename `-d` parameter of Spiral to `--drop` for consistents to other integrations