### PR TITLE
Make And and OrConditions readonly

### DIFF
--- a/packages/seal-algolia-adapter/src/AlgoliaSearcher.php
+++ b/packages/seal-algolia-adapter/src/AlgoliaSearcher.php
@@ -181,8 +181,8 @@ final class AlgoliaSearcher implements SearcherInterface
                 $filter instanceof Condition\GeoBoundingBoxCondition => $geoFilters = [
                     'insideBoundingBox' => [[$filter->northLatitude, $filter->westLongitude, $filter->southLatitude, $filter->eastLongitude]],
                 ],
-                $filter instanceof Condition\AndCondition => $filters[] = '(' . $this->recursiveResolveFilterConditions($index, $filter->getConditions(), true, $query, $geoFilters) . ')',
-                $filter instanceof Condition\OrCondition => $filters[] = '(' . $this->recursiveResolveFilterConditions($index, $filter->getConditions(), false, $query, $geoFilters) . ')',
+                $filter instanceof Condition\AndCondition => $filters[] = '(' . $this->recursiveResolveFilterConditions($index, $filter->conditions, true, $query, $geoFilters) . ')',
+                $filter instanceof Condition\OrCondition => $filters[] = '(' . $this->recursiveResolveFilterConditions($index, $filter->conditions, false, $query, $geoFilters) . ')',
                 default => throw new \LogicException($filter::class . ' filter not implemented.'),
             };
         }

--- a/packages/seal-elasticsearch-adapter/src/ElasticsearchSearcher.php
+++ b/packages/seal-elasticsearch-adapter/src/ElasticsearchSearcher.php
@@ -213,8 +213,8 @@ final class ElasticsearchSearcher implements SearcherInterface
                         'lon' => $filter->eastLongitude,
                     ],
                 ],
-                $filter instanceof Condition\AndCondition => $filterQueries[] = $this->recursiveResolveFilterConditions($indexes, $filter->getConditions(), true),
-                $filter instanceof Condition\OrCondition => $filterQueries[] = $this->recursiveResolveFilterConditions($indexes, $filter->getConditions(), false),
+                $filter instanceof Condition\AndCondition => $filterQueries[] = $this->recursiveResolveFilterConditions($indexes, $filter->conditions, true),
+                $filter instanceof Condition\OrCondition => $filterQueries[] = $this->recursiveResolveFilterConditions($indexes, $filter->conditions, false),
                 default => throw new \LogicException($filter::class . ' filter not implemented.'),
             };
         }

--- a/packages/seal-loupe-adapter/src/LoupeSearcher.php
+++ b/packages/seal-loupe-adapter/src/LoupeSearcher.php
@@ -165,8 +165,8 @@ final class LoupeSearcher implements SearcherInterface
                     $filter->southLatitude,
                     $filter->westLongitude,
                 ),
-                $filter instanceof Condition\AndCondition => $filters[] = '(' . $this->recursiveResolveFilterConditions($index, $filter->getConditions(), true, $query) . ')',
-                $filter instanceof Condition\OrCondition => $filters[] = '(' . $this->recursiveResolveFilterConditions($index, $filter->getConditions(), false, $query) . ')',
+                $filter instanceof Condition\AndCondition => $filters[] = '(' . $this->recursiveResolveFilterConditions($index, $filter->conditions, true, $query) . ')',
+                $filter instanceof Condition\OrCondition => $filters[] = '(' . $this->recursiveResolveFilterConditions($index, $filter->conditions, false, $query) . ')',
                 default => throw new \LogicException($filter::class . ' filter not implemented.'),
             };
         }

--- a/packages/seal-meilisearch-adapter/src/MeilisearchSearcher.php
+++ b/packages/seal-meilisearch-adapter/src/MeilisearchSearcher.php
@@ -156,8 +156,8 @@ final class MeilisearchSearcher implements SearcherInterface
                     $filter->southLatitude,
                     $filter->westLongitude,
                 ),
-                $filter instanceof Condition\AndCondition => $filters[] = '(' . $this->recursiveResolveFilterConditions($index, $filter->getConditions(), true, $query) . ')',
-                $filter instanceof Condition\OrCondition => $filters[] = '(' . $this->recursiveResolveFilterConditions($index, $filter->getConditions(), false, $query) . ')',
+                $filter instanceof Condition\AndCondition => $filters[] = '(' . $this->recursiveResolveFilterConditions($index, $filter->conditions, true, $query) . ')',
+                $filter instanceof Condition\OrCondition => $filters[] = '(' . $this->recursiveResolveFilterConditions($index, $filter->conditions, false, $query) . ')',
                 default => throw new \LogicException($filter::class . ' filter not implemented.'),
             };
         }

--- a/packages/seal-memory-adapter/src/MemorySearcher.php
+++ b/packages/seal-memory-adapter/src/MemorySearcher.php
@@ -268,7 +268,7 @@ final class MemorySearcher implements SearcherInterface
                     $subDocuments = [...$subDocuments, ...$this->filterDocuments($index, [$document], $subFilter)];
                 }
 
-                if (\count($conditions) !== \count($subDocuments)) {
+                if (\count($filter->conditions) !== \count($subDocuments)) {
                     continue;
                 }
             } elseif ($filter instanceof Condition\OrCondition) {

--- a/packages/seal-memory-adapter/src/MemorySearcher.php
+++ b/packages/seal-memory-adapter/src/MemorySearcher.php
@@ -263,9 +263,8 @@ final class MemorySearcher implements SearcherInterface
                     continue;
                 }
             } elseif ($filter instanceof Condition\AndCondition) {
-                $conditions = $filter->getConditions();
                 $subDocuments = [];
-                foreach ($conditions as $subFilter) {
+                foreach ($filter->conditions as $subFilter) {
                     $subDocuments = [...$subDocuments, ...$this->filterDocuments($index, [$document], $subFilter)];
                 }
 
@@ -273,9 +272,8 @@ final class MemorySearcher implements SearcherInterface
                     continue;
                 }
             } elseif ($filter instanceof Condition\OrCondition) {
-                $conditions = $filter->getConditions();
                 $subDocuments = [];
-                foreach ($conditions as $subFilter) {
+                foreach ($filter->conditions as $subFilter) {
                     $subDocuments = [...$subDocuments, ...$this->filterDocuments($index, [$document], $subFilter)];
                 }
 

--- a/packages/seal-opensearch-adapter/src/OpensearchSearcher.php
+++ b/packages/seal-opensearch-adapter/src/OpensearchSearcher.php
@@ -190,8 +190,8 @@ final class OpensearchSearcher implements SearcherInterface
                         'lon' => $filter->eastLongitude,
                     ],
                 ],
-                $filter instanceof Condition\AndCondition => $filterQueries[] = $this->recursiveResolveFilterConditions($indexes, $filter->getConditions(), true),
-                $filter instanceof Condition\OrCondition => $filterQueries[] = $this->recursiveResolveFilterConditions($indexes, $filter->getConditions(), false),
+                $filter instanceof Condition\AndCondition => $filterQueries[] = $this->recursiveResolveFilterConditions($indexes, $filter->conditions, true),
+                $filter instanceof Condition\OrCondition => $filterQueries[] = $this->recursiveResolveFilterConditions($indexes, $filter->conditions, false),
                 default => throw new \LogicException($filter::class . ' filter not implemented.'),
             };
         }

--- a/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
@@ -250,8 +250,8 @@ final class RediSearchSearcher implements SearcherInterface
                     $filter->northLatitude,
                 )),
                 */
-                $filter instanceof Condition\AndCondition => $filters[] = '(' . $this->recursiveResolveFilterConditions($index, $filter->getConditions(), $indexes, true, $parameters) . ')',
-                $filter instanceof Condition\OrCondition => $filters[] = '(' . $this->recursiveResolveFilterConditions($index, $filter->getConditions(), $indexes, false, $parameters) . ')',
+                $filter instanceof Condition\AndCondition => $filters[] = '(' . $this->recursiveResolveFilterConditions($index, $filter->conditions, $indexes, true, $parameters) . ')',
+                $filter instanceof Condition\OrCondition => $filters[] = '(' . $this->recursiveResolveFilterConditions($index, $filter->conditions, $indexes, false, $parameters) . ')',
                 default => throw new \LogicException($filter::class . ' filter not implemented.'),
             };
         }

--- a/packages/seal-solr-adapter/src/SolrSearcher.php
+++ b/packages/seal-solr-adapter/src/SolrSearcher.php
@@ -204,8 +204,8 @@ final class SolrSearcher implements SearcherInterface
                     $filter->northLatitude,
                     $filter->eastLongitude,
                 ),
-                $filter instanceof Condition\AndCondition => $filters[] = '(' . $this->recursiveResolveFilterConditions($index, $filter->getConditions(), $indexes, true, $queryText) . ')',
-                $filter instanceof Condition\OrCondition => $filters[] = '(' . $this->recursiveResolveFilterConditions($index, $filter->getConditions(), $indexes, false, $queryText) . ')',
+                $filter instanceof Condition\AndCondition => $filters[] = '(' . $this->recursiveResolveFilterConditions($index, $filter->conditions, $indexes, true, $queryText) . ')',
+                $filter instanceof Condition\OrCondition => $filters[] = '(' . $this->recursiveResolveFilterConditions($index, $filter->conditions, $indexes, false, $queryText) . ')',
                 default => throw new \LogicException($filter::class . ' filter not implemented.'),
             };
         }

--- a/packages/seal-typesense-adapter/src/TypesenseSearcher.php
+++ b/packages/seal-typesense-adapter/src/TypesenseSearcher.php
@@ -172,8 +172,8 @@ final class TypesenseSearcher implements SearcherInterface
                     $filter->northLatitude,
                     $filter->westLongitude,
                 ),
-                $filter instanceof Condition\AndCondition => $filters[] = '(' . $this->recursiveResolveFilterConditions($index, $filter->getConditions(), true, $query) . ')',
-                $filter instanceof Condition\OrCondition => $filters[] = '(' . $this->recursiveResolveFilterConditions($index, $filter->getConditions(), false, $query) . ')',
+                $filter instanceof Condition\AndCondition => $filters[] = '(' . $this->recursiveResolveFilterConditions($index, $filter->conditions, true, $query) . ')',
+                $filter instanceof Condition\OrCondition => $filters[] = '(' . $this->recursiveResolveFilterConditions($index, $filter->conditions, false, $query) . ')',
                 default => throw new \LogicException($filter::class . ' filter not implemented.'),
             };
         }

--- a/packages/seal/src/Search/Condition/AbstractGroupCondition.php
+++ b/packages/seal/src/Search/Condition/AbstractGroupCondition.php
@@ -21,7 +21,7 @@ abstract class AbstractGroupCondition
     /**
      * @var array<EqualCondition|GreaterThanCondition|GreaterThanEqualCondition|IdentifierCondition|LessThanCondition|LessThanEqualCondition|NotEqualCondition|AndCondition|OrCondition>
      */
-    public array $conditions = [];
+    public readonly array $conditions;
 
     /**
      * @param EqualCondition|GreaterThanCondition|GreaterThanEqualCondition|IdentifierCondition|LessThanCondition|LessThanEqualCondition|NotEqualCondition|AndCondition|OrCondition $conditions

--- a/packages/seal/src/Search/Condition/AbstractGroupCondition.php
+++ b/packages/seal/src/Search/Condition/AbstractGroupCondition.php
@@ -13,35 +13,21 @@ declare(strict_types=1);
 
 namespace Schranz\Search\SEAL\Search\Condition;
 
+/**
+ * @internal this class is internal please use AndCondition or OrCondition directly
+ */
 abstract class AbstractGroupCondition
 {
     /**
      * @var array<EqualCondition|GreaterThanCondition|GreaterThanEqualCondition|IdentifierCondition|LessThanCondition|LessThanEqualCondition|NotEqualCondition|AndCondition|OrCondition>
      */
-    private array $conditions = [];
+    public array $conditions = [];
 
     /**
      * @param EqualCondition|GreaterThanCondition|GreaterThanEqualCondition|IdentifierCondition|LessThanCondition|LessThanEqualCondition|NotEqualCondition|AndCondition|OrCondition $conditions
      */
     public function __construct(...$conditions)
     {
-        foreach ($conditions as $condition) {
-            $this->addCondition($condition);
-        }
-    }
-
-    public function addCondition(EqualCondition|GreaterThanCondition|GreaterThanEqualCondition|IdentifierCondition|LessThanCondition|LessThanEqualCondition|NotEqualCondition|AndCondition|OrCondition $condition): static
-    {
-        $this->conditions[] = $condition;
-
-        return $this;
-    }
-
-    /**
-     * @return array<EqualCondition|GreaterThanCondition|GreaterThanEqualCondition|IdentifierCondition|LessThanCondition|LessThanEqualCondition|NotEqualCondition|AndCondition|OrCondition>
-     */
-    public function getConditions(): array
-    {
-        return $this->conditions;
+        $this->conditions = $conditions;
     }
 }


### PR DESCRIPTION
At current state I will keep the AndCondition and OrCondition like all existing conditions readonly to be consistent.