### PR TITLE
Add InCondition Filter

### DIFF
--- a/packages/seal-algolia-adapter/src/AlgoliaSearcher.php
+++ b/packages/seal-algolia-adapter/src/AlgoliaSearcher.php
@@ -161,6 +161,10 @@ final class AlgoliaSearcher implements SearcherInterface
         $filters = [];
 
         foreach ($conditions as $filter) {
+            if ($filter instanceof Condition\InCondition) {
+                $filter = $filter->createOrCondition();
+            }
+
             match (true) {
                 $filter instanceof Condition\IdentifierCondition => $filters[] = $index->getIdentifierField()->name . ':' . $this->escapeFilterValue($filter->identifier),
                 $filter instanceof Condition\SearchCondition => $query = $filter->query,

--- a/packages/seal-elasticsearch-adapter/src/ElasticsearchSearcher.php
+++ b/packages/seal-elasticsearch-adapter/src/ElasticsearchSearcher.php
@@ -196,6 +196,7 @@ final class ElasticsearchSearcher implements SearcherInterface
                 $filter instanceof Condition\GreaterThanEqualCondition => $filterQueries[]['range'][$this->getFilterField($indexes, $filter->field)]['gte'] = $filter->value,
                 $filter instanceof Condition\LessThanCondition => $filterQueries[]['range'][$this->getFilterField($indexes, $filter->field)]['lt'] = $filter->value,
                 $filter instanceof Condition\LessThanEqualCondition => $filterQueries[]['range'][$this->getFilterField($indexes, $filter->field)]['lte'] = $filter->value,
+                $filter instanceof Condition\InCondition => $filterQueries[]['terms'][$this->getFilterField($indexes, $filter->field)] = $filter->values,
                 $filter instanceof Condition\GeoDistanceCondition => $filterQueries[]['geo_distance'] = [
                     'distance' => $filter->distance,
                     $this->getFilterField($indexes, $filter->field) => [

--- a/packages/seal-loupe-adapter/src/LoupeSearcher.php
+++ b/packages/seal-loupe-adapter/src/LoupeSearcher.php
@@ -150,6 +150,7 @@ final class LoupeSearcher implements SearcherInterface
                 $filter instanceof Condition\GreaterThanEqualCondition => $filters[] = $this->loupeHelper->formatField($filter->field) . ' >= ' . $this->escapeFilterValue($filter->value),
                 $filter instanceof Condition\LessThanCondition => $filters[] = $this->loupeHelper->formatField($filter->field) . ' < ' . $this->escapeFilterValue($filter->value),
                 $filter instanceof Condition\LessThanEqualCondition => $filters[] = $this->loupeHelper->formatField($filter->field) . ' <= ' . $this->escapeFilterValue($filter->value),
+                $filter instanceof Condition\InCondition => $filters[] = $this->loupeHelper->formatField($filter->field) . ' IN (' . \implode(', ', \array_map(fn ($value) => $this->escapeFilterValue($value), $filter->values)) . ')',
                 $filter instanceof Condition\GeoDistanceCondition => $filters[] = \sprintf(
                     '_geoRadius(%s, %s, %s, %s)',
                     $this->loupeHelper->formatField($filter->field),

--- a/packages/seal-meilisearch-adapter/src/MeilisearchSearcher.php
+++ b/packages/seal-meilisearch-adapter/src/MeilisearchSearcher.php
@@ -134,6 +134,10 @@ final class MeilisearchSearcher implements SearcherInterface
         $filters = [];
 
         foreach ($conditions as $filter) {
+            if ($filter instanceof Condition\InCondition) {
+                $filter = $filter->createOrCondition();
+            }
+
             match (true) {
                 $filter instanceof Condition\IdentifierCondition => $filters[] = $index->getIdentifierField()->name . ' = ' . $this->escapeFilterValue($filter->identifier),
                 $filter instanceof Condition\SearchCondition => $query = $filter->query,

--- a/packages/seal-memory-adapter/src/MemorySearcher.php
+++ b/packages/seal-memory-adapter/src/MemorySearcher.php
@@ -115,6 +115,16 @@ final class MemorySearcher implements SearcherInterface
                 if (!\in_array($filter->value, $values, true)) {
                     continue;
                 }
+            } elseif ($filter instanceof Condition\InCondition) {
+                if (\str_contains($filter->field, '.')) {
+                    throw new \RuntimeException('Nested fields are not supported yet.');
+                }
+
+                $values = (array) ($document[$filter->field] ?? []);
+
+                if ([] === \array_intersect($filter->values, $values)) {
+                    continue;
+                }
             } elseif ($filter instanceof Condition\NotEqualCondition) {
                 if (\str_contains($filter->field, '.')) {
                     throw new \RuntimeException('Nested fields are not supported yet.');

--- a/packages/seal-opensearch-adapter/src/OpensearchSearcher.php
+++ b/packages/seal-opensearch-adapter/src/OpensearchSearcher.php
@@ -173,6 +173,7 @@ final class OpensearchSearcher implements SearcherInterface
                 $filter instanceof Condition\GreaterThanEqualCondition => $filterQueries[]['range'][$this->getFilterField($indexes, $filter->field)]['gte'] = $filter->value,
                 $filter instanceof Condition\LessThanCondition => $filterQueries[]['range'][$this->getFilterField($indexes, $filter->field)]['lt'] = $filter->value,
                 $filter instanceof Condition\LessThanEqualCondition => $filterQueries[]['range'][$this->getFilterField($indexes, $filter->field)]['lte'] = $filter->value,
+                $filter instanceof Condition\InCondition => $filterQueries[]['terms'][$this->getFilterField($indexes, $filter->field)] = $filter->values,
                 $filter instanceof Condition\GeoDistanceCondition => $filterQueries[]['geo_distance'] = [
                     'distance' => $filter->distance,
                     $this->getFilterField($indexes, $filter->field) => [

--- a/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
@@ -214,6 +214,10 @@ final class RediSearchSearcher implements SearcherInterface
         $filters = [];
 
         foreach ($conditions as $filter) {
+            if ($filter instanceof Condition\InCondition) {
+                $filter = $filter->createOrCondition();
+            }
+
             match (true) {
                 $filter instanceof Condition\SearchCondition => $filters[] = '%%' . \implode('%% ', \explode(' ', $this->escapeFilterValue($filter->query))) . '%%', // levenshtein of 2 per word
                 $filter instanceof Condition\IdentifierCondition => $filters[] = '@' . $index->getIdentifierField()->name . ':{' . $this->escapeFilterValue($filter->identifier) . '}',

--- a/packages/seal-solr-adapter/src/SolrSearcher.php
+++ b/packages/seal-solr-adapter/src/SolrSearcher.php
@@ -180,6 +180,10 @@ final class SolrSearcher implements SearcherInterface
         $filters = [];
 
         foreach ($conditions as $filter) {
+            if ($filter instanceof Condition\InCondition) {
+                $filter = $filter->createOrCondition();
+            }
+
             match (true) {
                 $filter instanceof Condition\SearchCondition => $queryText = $filter->query,
                 $filter instanceof Condition\IdentifierCondition => $filters[] = $index->getIdentifierField()->name . ':' . $this->escapeFilterValue($filter->identifier),

--- a/packages/seal-typesense-adapter/src/TypesenseSearcher.php
+++ b/packages/seal-typesense-adapter/src/TypesenseSearcher.php
@@ -143,6 +143,10 @@ final class TypesenseSearcher implements SearcherInterface
         $filters = [];
 
         foreach ($conditions as $filter) {
+            if ($filter instanceof Condition\InCondition) {
+                $filter = $filter->createOrCondition();
+            }
+
             match (true) {
                 $filter instanceof Condition\IdentifierCondition => $filters[] = 'id:=' . $this->escapeFilterValue($filter->identifier),
                 $filter instanceof Condition\SearchCondition => $query = $filter->query,

--- a/packages/seal/src/Search/Condition/InCondition.php
+++ b/packages/seal/src/Search/Condition/InCondition.php
@@ -23,4 +23,18 @@ class InCondition
         public readonly array $values,
     ) {
     }
+
+    /**
+     * Some search engines do not support the `IN` operator, so we need to convert it to an `OR` condition.
+     */
+    public function createOrCondition(): OrCondition
+    {
+        /** @var array<EqualCondition|GreaterThanCondition|GreaterThanEqualCondition|IdentifierCondition|LessThanCondition|LessThanEqualCondition|NotEqualCondition|AndCondition|OrCondition> $conditions */
+        $conditions = [];
+        foreach ($this->values as $value) {
+            $conditions[] = new EqualCondition($this->field, $value);
+        }
+
+        return new OrCondition(...$conditions);
+    }
 }

--- a/packages/seal/src/Search/Condition/InCondition.php
+++ b/packages/seal/src/Search/Condition/InCondition.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Schranz Search package.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Schranz\Search\SEAL\Search\Condition;
+
+class InCondition
+{
+    /**
+     * @param list<string|int|float|bool> $values
+     */
+    public function __construct(
+        public readonly string $field,
+        public readonly array $values,
+    ) {
+    }
+}

--- a/packages/seal/src/Search/Condition/InCondition.php
+++ b/packages/seal/src/Search/Condition/InCondition.php
@@ -25,6 +25,8 @@ class InCondition
     }
 
     /**
+     * @internal This method is for internal use and should not be called from outside.
+     *
      * Some search engines do not support the `IN` operator, so we need to convert it to an `OR` condition.
      */
     public function createOrCondition(): OrCondition

--- a/packages/seal/src/Testing/AbstractSearcherTestCase.php
+++ b/packages/seal/src/Testing/AbstractSearcherTestCase.php
@@ -873,6 +873,52 @@ abstract class AbstractSearcherTestCase extends TestCase
         }
     }
 
+    public function testInCondition(): void
+    {
+        $documents = TestingHelper::createComplexFixtures();
+
+        $schema = self::getSchema();
+
+        foreach ($documents as $document) {
+            self::$taskHelper->tasks[] = self::$indexer->save(
+                $schema->indexes[TestingHelper::INDEX_COMPLEX],
+                $document,
+                ['return_slow_promise_result' => true],
+            );
+        }
+        self::$taskHelper->waitForAll();
+
+        $search = new SearchBuilder($schema, self::$searcher);
+        $search->addIndex(TestingHelper::INDEX_COMPLEX);
+        $search->addFilter(new Condition\InCondition('tags', ['UI']));
+
+        $expectedDocumentsVariantA = [
+            $documents[0],
+            $documents[1],
+        ];
+        $expectedDocumentsVariantB = [
+            $documents[1],
+            $documents[0],
+        ];
+
+        $loadedDocuments = [...$search->getResult()];
+        $this->assertCount(2, $loadedDocuments);
+
+        $this->assertTrue(
+            $expectedDocumentsVariantA === $loadedDocuments
+            || $expectedDocumentsVariantB === $loadedDocuments,
+            'Not correct documents where found.',
+        );
+
+        foreach ($documents as $document) {
+            self::$taskHelper->tasks[] = self::$indexer->delete(
+                $schema->indexes[TestingHelper::INDEX_COMPLEX],
+                $document['uuid'],
+                ['return_slow_promise_result' => true],
+            );
+        }
+    }
+
     public function testSortByAsc(): void
     {
         $documents = TestingHelper::createComplexFixtures();


### PR DESCRIPTION
This add supports for `InCondition` with the already support for `OrCondition` and `EqualConditon` it should be possible to implement a `InCondition` in all adapters as `IN` is just a shortcut for `EqualCondition` on the same field `Or` connected.

So instead of writing:

```php
new Condition\OrCondition(
    new Condition\EqualCondition('tags', 'UI'),
    new Condition\EqualCondition('tags', 'UX'),
    new Condition\EqualCondition('tags', 'Frontend'),
);
```

It should now be possible to write:

```php
new Condition\InCondition('tags', ['UI','UX','Frontend'])
```

fix https://github.com/schranz-search/schranz-search/issues/444

### Todo

 - [x] Core: Add InCondition 
 - [x] Memory 
 - [x] Elasticsearch 
 - [x] Opensearch
 - [x] Meilisearch
 - [x] Algolia
 - [x] Loupe
 - [x] Redisearch
 - [x] Solr
 - [x] Typesense 
