### PR TITLE
Add `NotInCondition` Filter

### DIFF
--- a/packages/seal-algolia-adapter/src/AlgoliaSearcher.php
+++ b/packages/seal-algolia-adapter/src/AlgoliaSearcher.php
@@ -161,9 +161,11 @@ final class AlgoliaSearcher implements SearcherInterface
         $filters = [];
 
         foreach ($conditions as $filter) {
-            if ($filter instanceof Condition\InCondition) {
-                $filter = $filter->createOrCondition();
-            }
+            $filter = match (true) {
+                $filter instanceof Condition\InCondition => $filter->createOrCondition(),
+                $filter instanceof Condition\NotInCondition => $filter->createAndCondition(),
+                default => $filter,
+            };
 
             match (true) {
                 $filter instanceof Condition\IdentifierCondition => $filters[] = $index->getIdentifierField()->name . ':' . $this->escapeFilterValue($filter->identifier),

--- a/packages/seal-elasticsearch-adapter/src/ElasticsearchSearcher.php
+++ b/packages/seal-elasticsearch-adapter/src/ElasticsearchSearcher.php
@@ -196,7 +196,8 @@ final class ElasticsearchSearcher implements SearcherInterface
                 $filter instanceof Condition\GreaterThanEqualCondition => $filterQueries[]['range'][$this->getFilterField($indexes, $filter->field)]['gte'] = $filter->value,
                 $filter instanceof Condition\LessThanCondition => $filterQueries[]['range'][$this->getFilterField($indexes, $filter->field)]['lt'] = $filter->value,
                 $filter instanceof Condition\LessThanEqualCondition => $filterQueries[]['range'][$this->getFilterField($indexes, $filter->field)]['lte'] = $filter->value,
-                $filter instanceof Condition\InCondition => $filterQueries[]['terms'][$this->getFilterField($indexes, $filter->field)] = $filter->values,
+                $filter instanceof Condition\InCondition, => $filterQueries[]['terms'][$this->getFilterField($indexes, $filter->field)] = $filter->values,
+                $filter instanceof Condition\NotInCondition => $filterQueries[]['bool']['must_not']['terms'][$this->getFilterField($indexes, $filter->field)] = $filter->values,
                 $filter instanceof Condition\GeoDistanceCondition => $filterQueries[]['geo_distance'] = [
                     'distance' => $filter->distance,
                     $this->getFilterField($indexes, $filter->field) => [

--- a/packages/seal-loupe-adapter/src/LoupeSearcher.php
+++ b/packages/seal-loupe-adapter/src/LoupeSearcher.php
@@ -151,6 +151,7 @@ final class LoupeSearcher implements SearcherInterface
                 $filter instanceof Condition\LessThanCondition => $filters[] = $this->loupeHelper->formatField($filter->field) . ' < ' . $this->escapeFilterValue($filter->value),
                 $filter instanceof Condition\LessThanEqualCondition => $filters[] = $this->loupeHelper->formatField($filter->field) . ' <= ' . $this->escapeFilterValue($filter->value),
                 $filter instanceof Condition\InCondition => $filters[] = $this->loupeHelper->formatField($filter->field) . ' IN (' . \implode(', ', \array_map(fn ($value) => $this->escapeFilterValue($value), $filter->values)) . ')',
+                $filter instanceof Condition\NotInCondition => $filters[] = $this->loupeHelper->formatField($filter->field) . ' NOT IN (' . \implode(', ', \array_map(fn ($value) => $this->escapeFilterValue($value), $filter->values)) . ')',
                 $filter instanceof Condition\GeoDistanceCondition => $filters[] = \sprintf(
                     '_geoRadius(%s, %s, %s, %s)',
                     $this->loupeHelper->formatField($filter->field),

--- a/packages/seal-meilisearch-adapter/src/MeilisearchSearcher.php
+++ b/packages/seal-meilisearch-adapter/src/MeilisearchSearcher.php
@@ -126,6 +126,14 @@ final class MeilisearchSearcher implements SearcherInterface
         };
     }
 
+    private function escapeArrayFilterValues(array $value): string
+    {
+        return implode(
+            ', ',
+            array_map([$this, 'escapeFilterValue'], $value)
+        );
+    }
+
     /**
      * @param object[] $conditions
      */
@@ -143,6 +151,7 @@ final class MeilisearchSearcher implements SearcherInterface
                 $filter instanceof Condition\SearchCondition => $query = $filter->query,
                 $filter instanceof Condition\EqualCondition => $filters[] = $filter->field . ' = ' . $this->escapeFilterValue($filter->value),
                 $filter instanceof Condition\NotEqualCondition => $filters[] = $filter->field . ' != ' . $this->escapeFilterValue($filter->value),
+                $filter instanceof Condition\NotInCondition => $filters[] = $filter->field . ' NOT IN [' . $this->escapeArrayFilterValues($filter->values) . ']',
                 $filter instanceof Condition\GreaterThanCondition => $filters[] = $filter->field . ' > ' . $this->escapeFilterValue($filter->value),
                 $filter instanceof Condition\GreaterThanEqualCondition => $filters[] = $filter->field . ' >= ' . $this->escapeFilterValue($filter->value),
                 $filter instanceof Condition\LessThanCondition => $filters[] = $filter->field . ' < ' . $this->escapeFilterValue($filter->value),

--- a/packages/seal-memory-adapter/src/MemorySearcher.php
+++ b/packages/seal-memory-adapter/src/MemorySearcher.php
@@ -125,6 +125,16 @@ final class MemorySearcher implements SearcherInterface
                 if ([] === \array_intersect($filter->values, $values)) {
                     continue;
                 }
+            } elseif ($filter instanceof Condition\NotInCondition) {
+                if (\str_contains($filter->field, '.')) {
+                    throw new \RuntimeException('Nested fields are not supported yet.');
+                }
+
+                $values = (array) ($document[$filter->field] ?? []);
+
+                if ([] !== \array_intersect($filter->values, $values)) {
+                    continue;
+                }
             } elseif ($filter instanceof Condition\NotEqualCondition) {
                 if (\str_contains($filter->field, '.')) {
                     throw new \RuntimeException('Nested fields are not supported yet.');

--- a/packages/seal-opensearch-adapter/src/OpensearchSearcher.php
+++ b/packages/seal-opensearch-adapter/src/OpensearchSearcher.php
@@ -174,6 +174,7 @@ final class OpensearchSearcher implements SearcherInterface
                 $filter instanceof Condition\LessThanCondition => $filterQueries[]['range'][$this->getFilterField($indexes, $filter->field)]['lt'] = $filter->value,
                 $filter instanceof Condition\LessThanEqualCondition => $filterQueries[]['range'][$this->getFilterField($indexes, $filter->field)]['lte'] = $filter->value,
                 $filter instanceof Condition\InCondition => $filterQueries[]['terms'][$this->getFilterField($indexes, $filter->field)] = $filter->values,
+                $filter instanceof Condition\NotInCondition => $filterQueries[]['bool']['must_not']['terms'][$this->getFilterField($indexes, $filter->field)] = $filter->values,
                 $filter instanceof Condition\GeoDistanceCondition => $filterQueries[]['geo_distance'] = [
                     'distance' => $filter->distance,
                     $this->getFilterField($indexes, $filter->field) => [

--- a/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
@@ -214,9 +214,11 @@ final class RediSearchSearcher implements SearcherInterface
         $filters = [];
 
         foreach ($conditions as $filter) {
-            if ($filter instanceof Condition\InCondition) {
-                $filter = $filter->createOrCondition();
-            }
+            $filter = match (true) {
+                $filter instanceof Condition\InCondition => $filter->createOrCondition(),
+                $filter instanceof Condition\NotInCondition => $filter->createAndCondition(),
+                default => $filter,
+            };
 
             match (true) {
                 $filter instanceof Condition\SearchCondition => $filters[] = '%%' . \implode('%% ', \explode(' ', $this->escapeFilterValue($filter->query))) . '%%', // levenshtein of 2 per word

--- a/packages/seal-solr-adapter/src/SolrSearcher.php
+++ b/packages/seal-solr-adapter/src/SolrSearcher.php
@@ -180,9 +180,11 @@ final class SolrSearcher implements SearcherInterface
         $filters = [];
 
         foreach ($conditions as $filter) {
-            if ($filter instanceof Condition\InCondition) {
-                $filter = $filter->createOrCondition();
-            }
+            $filter = match (true) {
+                $filter instanceof Condition\InCondition => $filter->createOrCondition(),
+                $filter instanceof Condition\NotInCondition => $filter->createAndCondition(),
+                default => $filter,
+            };
 
             match (true) {
                 $filter instanceof Condition\SearchCondition => $queryText = $filter->query,

--- a/packages/seal-typesense-adapter/src/TypesenseSearcher.php
+++ b/packages/seal-typesense-adapter/src/TypesenseSearcher.php
@@ -143,9 +143,11 @@ final class TypesenseSearcher implements SearcherInterface
         $filters = [];
 
         foreach ($conditions as $filter) {
-            if ($filter instanceof Condition\InCondition) {
-                $filter = $filter->createOrCondition();
-            }
+            $filter = match (true) {
+                $filter instanceof Condition\InCondition => $filter->createOrCondition(),
+                $filter instanceof Condition\NotInCondition => $filter->createAndCondition(),
+                default => $filter,
+            };
 
             match (true) {
                 $filter instanceof Condition\IdentifierCondition => $filters[] = 'id:=' . $this->escapeFilterValue($filter->identifier),

--- a/packages/seal/src/Search/Condition/NotInCondition.php
+++ b/packages/seal/src/Search/Condition/NotInCondition.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Schranz Search package.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Schranz\Search\SEAL\Search\Condition;
+
+class NotInCondition
+{
+    /**
+     * @param list<string|int|float|bool> $values
+     */
+    public function __construct(
+        public readonly string $field,
+        public readonly array $values,
+    ) {
+    }
+
+    /**
+     * @internal This method is for internal use and should not be called from outside.
+     *
+     * Some search engines do not support the `NOT IN` operator, so we need to convert it to an `AND` condition.
+     */
+    public function createAndCondition(): AndCondition
+    {
+        /** @var array<EqualCondition|GreaterThanCondition|GreaterThanEqualCondition|IdentifierCondition|LessThanCondition|LessThanEqualCondition|NotEqualCondition|AndCondition|OrCondition> $conditions */
+        $conditions = [];
+        foreach ($this->values as $value) {
+            $conditions[] = new NotEqualCondition($this->field, $value);
+        }
+
+        return new AndCondition(...$conditions);
+    }
+}

--- a/packages/seal/src/Testing/AbstractSearcherTestCase.php
+++ b/packages/seal/src/Testing/AbstractSearcherTestCase.php
@@ -919,6 +919,47 @@ abstract class AbstractSearcherTestCase extends TestCase
         }
     }
 
+    public function testNotInCondition(): void
+    {
+        $documents = TestingHelper::createComplexFixtures();
+
+        $schema = self::getSchema();
+
+        foreach ($documents as $document) {
+            self::$taskHelper->tasks[] = self::$indexer->save(
+                $schema->indexes[TestingHelper::INDEX_COMPLEX],
+                $document,
+                ['return_slow_promise_result' => true],
+            );
+        }
+        self::$taskHelper->waitForAll();
+
+        $search = new SearchBuilder($schema, self::$searcher);
+        $search->addIndex(TestingHelper::INDEX_COMPLEX);
+        $search->addFilter(new Condition\NotInCondition('tags', ['UI']));
+
+        $expectedDocumentsVariant = [
+            $documents[2],
+            $documents[3],
+        ];
+
+        $loadedDocuments = [...$search->getResult()];
+        $this->assertCount(2, $loadedDocuments);
+
+        $this->assertTrue(
+            $expectedDocumentsVariant === $loadedDocuments,
+            'Not correct documents where found.',
+        );
+
+        foreach ($documents as $document) {
+            self::$taskHelper->tasks[] = self::$indexer->delete(
+                $schema->indexes[TestingHelper::INDEX_COMPLEX],
+                $document['uuid'],
+                ['return_slow_promise_result' => true],
+            );
+        }
+    }
+
     public function testSortByAsc(): void
     {
         $documents = TestingHelper::createComplexFixtures();

--- a/packages/seal/src/Testing/AbstractSearcherTestCase.php
+++ b/packages/seal/src/Testing/AbstractSearcherTestCase.php
@@ -938,16 +938,22 @@ abstract class AbstractSearcherTestCase extends TestCase
         $search->addIndex(TestingHelper::INDEX_COMPLEX);
         $search->addFilter(new Condition\NotInCondition('tags', ['UI']));
 
-        $expectedDocumentsVariant = [
+        $expectedDocumentsVariantA = [
             $documents[2],
             $documents[3],
+        ];
+
+        $expectedDocumentsVariantB = [
+            $documents[3],
+            $documents[2],
         ];
 
         $loadedDocuments = [...$search->getResult()];
         $this->assertCount(2, $loadedDocuments);
 
         $this->assertTrue(
-            $expectedDocumentsVariant === $loadedDocuments,
+            $expectedDocumentsVariantA === $loadedDocuments
+            || $expectedDocumentsVariantB === $loadedDocuments,
             'Not correct documents where found.',
         );
 


### PR DESCRIPTION
This add supports for `NotInCondition` with the already support for `AndCondition` and `NotEqualCondition` it should be possible to implement a `NotInCondition` in all adapters as `NOT IN` is just a shortcut for `NotEqualCondition` on the same field `AND` connected.

So instead of writing:

```php
new Condition\AndCondition(
    new Condition\NotEqualCondition('tags', 'UI'),
    new Condition\NotEqualCondition('tags', 'UX'),
    new Condition\NotEqualCondition('tags', 'Frontend'),
);
```

It should now be possible to write:

```php
new Condition\NotInCondition('tags', ['UI','UX','Frontend'])
```

Fixes #445 

### Todo

- [x]  Core: Add `NotInCondition`
- [x]  Memory
- [x]  Elasticsearch
- [x]  Opensearch
- [x]  Meilisearch
- [x]  Algolia
- [x]  Loupe
- [x]  Redisearch
- [x]  Solr
- [x]  Typesense