### PR TITLE
Update Elasticsearch, Redisearch, Typesense docker compose files to latest versions

### DIFF
--- a/.examples/laravel/docker-compose.yml
+++ b/.examples/laravel/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.2
     environment:
       discovery.type: single-node
       xpack.security.enabled: 'false'
@@ -47,7 +47,7 @@ services:
       - opensearch-data:/usr/share/opensearch/data
 
   redis:
-    image: redis/redis-stack:7.4.0-v0
+    image: redis/redis-stack:7.4.0-v1
     ports:
       - 6379:6379 # redis server
       - 8001:8001 # redis insight
@@ -57,7 +57,7 @@ services:
         - redisearch-data:/data
 
   typesense:
-    image: typesense/typesense:26.0
+    image: typesense/typesense:27.1
     ports:
       - "8108:8108"
     environment:

--- a/.examples/mezzio/docker-compose.yml
+++ b/.examples/mezzio/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.2
     environment:
       discovery.type: single-node
       xpack.security.enabled: 'false'
@@ -47,7 +47,7 @@ services:
       - opensearch-data:/usr/share/opensearch/data
 
   redis:
-    image: redis/redis-stack:7.4.0-v0
+    image: redis/redis-stack:7.4.0-v1
     ports:
       - 6379:6379 # redis server
       - 8001:8001 # redis insight
@@ -57,7 +57,7 @@ services:
       - redisearch-data:/data
 
   typesense:
-    image: typesense/typesense:26.0
+    image: typesense/typesense:27.1
     ports:
       - "8108:8108"
     environment:

--- a/.examples/spiral/docker-compose.yml
+++ b/.examples/spiral/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.2
     environment:
       discovery.type: single-node
       xpack.security.enabled: 'false'
@@ -47,7 +47,7 @@ services:
       - opensearch-data:/usr/share/opensearch/data
 
   redis:
-    image: redis/redis-stack:7.4.0-v0
+    image: redis/redis-stack:7.4.0-v1
     ports:
       - 6379:6379 # redis server
       - 8001:8001 # redis insight
@@ -57,7 +57,7 @@ services:
       - redisearch-data:/data
 
   typesense:
-    image: typesense/typesense:26.0
+    image: typesense/typesense:27.1
     ports:
       - "8108:8108"
     environment:

--- a/.examples/symfony/docker-compose.yml
+++ b/.examples/symfony/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.2
     environment:
       discovery.type: single-node
       xpack.security.enabled: 'false'
@@ -47,7 +47,7 @@ services:
       - opensearch-data:/usr/share/opensearch/data
 
   redis:
-    image: redis/redis-stack:7.4.0-v0
+    image: redis/redis-stack:7.4.0-v1
     ports:
       - 6379:6379 # redis server
       - 8001:8001 # redis insight
@@ -57,7 +57,7 @@ services:
       - redisearch-data:/data
 
   typesense:
-    image: typesense/typesense:26.0
+    image: typesense/typesense:27.1
     ports:
       - "8108:8108"
     environment:
@@ -70,6 +70,7 @@ services:
       retries: 20
     volumes:
       - typesense-data:/data
+
   solr:
     image: "solr:9"
     ports:
@@ -85,7 +86,6 @@ services:
       SOLR_OPTS: '-Dsolr.disableConfigSetsCreateAuthChecks=true'
     volumes:
       - solr-data:/var/solr
-
   zookeeper:
     image: "solr:9"
     depends_on:

--- a/.examples/yii/docker-compose.yml
+++ b/.examples/yii/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.2
     environment:
       discovery.type: single-node
       xpack.security.enabled: 'false'
@@ -47,7 +47,7 @@ services:
       - opensearch-data:/usr/share/opensearch/data
 
   redis:
-    image: redis/redis-stack:7.4.0-v0
+    image: redis/redis-stack:7.4.0-v1
     ports:
       - 6379:6379 # redis server
       - 8001:8001 # redis insight
@@ -57,7 +57,7 @@ services:
       - redisearch-data:/data
 
   typesense:
-    image: typesense/typesense:26.0
+    image: typesense/typesense:27.1
     ports:
       - "8108:8108"
     environment:

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -1506,7 +1506,7 @@ search engine.
 
             services:
               elasticsearch:
-                image: docker.elastic.co/elasticsearch/elasticsearch:8.15.0
+                image: docker.elastic.co/elasticsearch/elasticsearch:8.15.2
                 environment:
                   discovery.type: single-node
                   xpack.security.enabled: 'false'
@@ -1582,7 +1582,7 @@ search engine.
 
             services:
               redis:
-                image: redis/redis-stack:7.4.0-v0
+                image: redis/redis-stack:7.4.0-v1
                 ports:
                   - 6379:6379 # redis server
                   - 8001:8001 # redis insight
@@ -1667,7 +1667,7 @@ search engine.
 
             services:
               typesense:
-                image: typesense/typesense:26.0
+                image: typesense/typesense:27.1
                 ports:
                   - "8108:8108"
                 environment:

--- a/packages/seal-elasticsearch-adapter/docker-compose.yml
+++ b/packages/seal-elasticsearch-adapter/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.2
     environment:
       discovery.type: single-node
       xpack.security.enabled: 'false'

--- a/packages/seal-redisearch-adapter/docker-compose.yml
+++ b/packages/seal-redisearch-adapter/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   redis:
-    image: redis/redis-stack:7.4.0-v0
+    image: redis/redis-stack:7.4.0-v1
     ports:
       - 6379:6379 # redis server
       - 8001:8001 # redis insight

--- a/packages/seal-typesense-adapter/docker-compose.yml
+++ b/packages/seal-typesense-adapter/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   typesense:
-    image: typesense/typesense:26.0
+    image: typesense/typesense:27.1
     ports:
       - "8108:8108"
     environment:


### PR DESCRIPTION
Sadly this engines do not have any major version tags so we need keep them uptodate manually.