### PR TITLE
Remove support for search multi Indexes by once (BC Break)

### DIFF
--- a/packages/seal-algolia-adapter/src/AlgoliaSearcher.php
+++ b/packages/seal-algolia-adapter/src/AlgoliaSearcher.php
@@ -79,7 +79,7 @@ final class AlgoliaSearcher implements SearcherInterface
 
         $query = '';
         $geoFilters = [];
-        $filters = $this->recursiveResolveFilterConditions($index, $search->filters, true, $query, $geoFilters);
+        $filters = $this->recursiveResolveFilterConditions($search->index, $search->filters, true, $query, $geoFilters);
 
         $searchParams = [];
         if ('' !== $filters) {
@@ -111,7 +111,7 @@ final class AlgoliaSearcher implements SearcherInterface
         \assert(isset($data['nbHits']) && \is_int($data['nbHits']), 'The "nbHits" value is expected to be returned by algolia client.');
 
         return new Result(
-            $this->hitsToDocuments($search->indexes, $data['hits']),
+            $this->hitsToDocuments($search->index, $data['hits']),
             $data['nbHits'] ?? null, // @phpstan-ignore-line
         );
     }

--- a/packages/seal-algolia-adapter/tests/AlgoliaSearcherTest.php
+++ b/packages/seal-algolia-adapter/tests/AlgoliaSearcherTest.php
@@ -25,12 +25,4 @@ class AlgoliaSearcherTest extends AbstractSearcherTestCase
 
         parent::setUpBeforeClass();
     }
-
-    /**
-     * @doesNotPerformAssertions
-     */
-    public function testFindMultipleIndexes(): void
-    {
-        $this->markTestSkipped('Not supported by Algolia: https://github.com/schranz-search/schranz-search/issues/41');
-    }
 }

--- a/packages/seal-elasticsearch-adapter/src/ElasticsearchSearcher.php
+++ b/packages/seal-elasticsearch-adapter/src/ElasticsearchSearcher.php
@@ -18,7 +18,6 @@ use Elastic\Elasticsearch\Exception\ClientResponseException;
 use Elastic\Elasticsearch\Response\Elasticsearch;
 use Schranz\Search\SEAL\Adapter\SearcherInterface;
 use Schranz\Search\SEAL\Marshaller\Marshaller;
-use Schranz\Search\SEAL\Schema\Exception\FieldByPathNotFoundException;
 use Schranz\Search\SEAL\Schema\Field;
 use Schranz\Search\SEAL\Schema\Index;
 use Schranz\Search\SEAL\Search\Condition;
@@ -44,8 +43,7 @@ final class ElasticsearchSearcher implements SearcherInterface
     {
         // optimized single document query
         if (
-            1 === \count($search->indexes)
-            && 1 === \count($search->filters)
+            1 === \count($search->filters)
             && $search->filters[0] instanceof Condition\IdentifierCondition
             && 0 === $search->offset
             && 1 === $search->limit
@@ -53,7 +51,7 @@ final class ElasticsearchSearcher implements SearcherInterface
             try {
                 /** @var Elasticsearch $response */
                 $response = $this->client->get([
-                    'index' => $search->indexes[\array_key_first($search->indexes)]->name,
+                    'index' => $search->index->name,
                     'id' => $search->filters[0]->identifier,
                 ]);
 
@@ -66,23 +64,18 @@ final class ElasticsearchSearcher implements SearcherInterface
                 }
 
                 return new Result(
-                    $this->hitsToDocuments($search->indexes, []),
+                    $this->hitsToDocuments($search->index, []),
                     0,
                 );
             }
 
             return new Result(
-                $this->hitsToDocuments($search->indexes, [$searchResult]),
+                $this->hitsToDocuments($search->index, [$searchResult]),
                 1,
             );
         }
 
-        $indexesNames = [];
-        foreach ($search->indexes as $index) {
-            $indexesNames[] = $index->name;
-        }
-
-        $query = $this->recursiveResolveFilterConditions($search->indexes, $search->filters, true);
+        $query = $this->recursiveResolveFilterConditions($search->index, $search->filters, true);
 
         if ([] === $query) {
             $query['match_all'] = new \stdClass();
@@ -108,7 +101,7 @@ final class ElasticsearchSearcher implements SearcherInterface
 
         /** @var Elasticsearch $response */
         $response = $this->client->search([
-            'index' => \implode(',', $indexesNames),
+            'index' => $search->index->name,
             'body' => $body,
         ]);
 
@@ -125,64 +118,41 @@ final class ElasticsearchSearcher implements SearcherInterface
         $searchResult = $response->asArray();
 
         return new Result(
-            $this->hitsToDocuments($search->indexes, $searchResult['hits']['hits']),
+            $this->hitsToDocuments($search->index, $searchResult['hits']['hits']),
             $searchResult['hits']['total']['value'],
         );
     }
 
     /**
-     * @param Index[] $indexes
      * @param array<array<string, mixed>> $hits
      *
      * @return \Generator<int, array<string, mixed>>
      */
-    private function hitsToDocuments(array $indexes, array $hits): \Generator
+    private function hitsToDocuments(Index $index, array $hits): \Generator
     {
-        $indexesByInternalName = [];
-        foreach ($indexes as $index) {
-            $indexesByInternalName[$index->name] = $index;
-        }
-
         /** @var array{_index: string, _source: array<string, mixed>} $hit */
         foreach ($hits as $hit) {
-            $index = $indexesByInternalName[$hit['_index']] ?? null;
-            if (!$index instanceof Index) {
-                throw new \RuntimeException('SchemaMetadata for Index "' . $hit['_index'] . '" not found.');
-            }
-
             yield $this->marshaller->unmarshall($index->fields, $hit['_source']);
         }
     }
 
-    /**
-     * @param Index[] $indexes
-     */
-    private function getFilterField(array $indexes, string $name): string
+    private function getFilterField(Index $index, string $name): string
     {
-        foreach ($indexes as $index) {
-            try {
-                $field = $index->getFieldByPath($name);
+        $field = $index->getFieldByPath($name);
 
-                if ($field instanceof Field\TextField) {
-                    return $name . '.raw';
-                }
-
-                return $name;
-            } catch (FieldByPathNotFoundException) {
-                // ignore when field is not found and use go to next index instead
-            }
+        if ($field instanceof Field\TextField) {
+            return $name . '.raw';
         }
 
         return $name;
     }
 
     /**
-     * @param Index[] $indexes
      * @param object[] $filters
      *
      * @return array<string|int, mixed>
      */
-    private function recursiveResolveFilterConditions(array $indexes, array $filters, bool $conjunctive): array
+    private function recursiveResolveFilterConditions(Index $index, array $filters, bool $conjunctive): array
     {
         $filterQueries = [];
 
@@ -190,22 +160,22 @@ final class ElasticsearchSearcher implements SearcherInterface
             match (true) {
                 $filter instanceof Condition\IdentifierCondition => $filterQueries[]['ids']['values'][] = $filter->identifier,
                 $filter instanceof Condition\SearchCondition => $filterQueries[]['bool']['must']['query_string']['query'] = $filter->query,
-                $filter instanceof Condition\EqualCondition => $filterQueries[]['term'][$this->getFilterField($indexes, $filter->field)]['value'] = $filter->value,
-                $filter instanceof Condition\NotEqualCondition => $filterQueries[]['bool']['must_not']['term'][$this->getFilterField($indexes, $filter->field)]['value'] = $filter->value,
-                $filter instanceof Condition\GreaterThanCondition => $filterQueries[]['range'][$this->getFilterField($indexes, $filter->field)]['gt'] = $filter->value,
-                $filter instanceof Condition\GreaterThanEqualCondition => $filterQueries[]['range'][$this->getFilterField($indexes, $filter->field)]['gte'] = $filter->value,
-                $filter instanceof Condition\LessThanCondition => $filterQueries[]['range'][$this->getFilterField($indexes, $filter->field)]['lt'] = $filter->value,
-                $filter instanceof Condition\LessThanEqualCondition => $filterQueries[]['range'][$this->getFilterField($indexes, $filter->field)]['lte'] = $filter->value,
-                $filter instanceof Condition\InCondition, => $filterQueries[]['terms'][$this->getFilterField($indexes, $filter->field)] = $filter->values,
-                $filter instanceof Condition\NotInCondition => $filterQueries[]['bool']['must_not']['terms'][$this->getFilterField($indexes, $filter->field)] = $filter->values,
+                $filter instanceof Condition\EqualCondition => $filterQueries[]['term'][$this->getFilterField($index, $filter->field)]['value'] = $filter->value,
+                $filter instanceof Condition\NotEqualCondition => $filterQueries[]['bool']['must_not']['term'][$this->getFilterField($index, $filter->field)]['value'] = $filter->value,
+                $filter instanceof Condition\GreaterThanCondition => $filterQueries[]['range'][$this->getFilterField($index, $filter->field)]['gt'] = $filter->value,
+                $filter instanceof Condition\GreaterThanEqualCondition => $filterQueries[]['range'][$this->getFilterField($index, $filter->field)]['gte'] = $filter->value,
+                $filter instanceof Condition\LessThanCondition => $filterQueries[]['range'][$this->getFilterField($index, $filter->field)]['lt'] = $filter->value,
+                $filter instanceof Condition\LessThanEqualCondition => $filterQueries[]['range'][$this->getFilterField($index, $filter->field)]['lte'] = $filter->value,
+                $filter instanceof Condition\InCondition, => $filterQueries[]['terms'][$this->getFilterField($index, $filter->field)] = $filter->values,
+                $filter instanceof Condition\NotInCondition => $filterQueries[]['bool']['must_not']['terms'][$this->getFilterField($index, $filter->field)] = $filter->values,
                 $filter instanceof Condition\GeoDistanceCondition => $filterQueries[]['geo_distance'] = [
                     'distance' => $filter->distance,
-                    $this->getFilterField($indexes, $filter->field) => [
+                    $this->getFilterField($index, $filter->field) => [
                         'lat' => $filter->latitude,
                         'lon' => $filter->longitude,
                     ],
                 ],
-                $filter instanceof Condition\GeoBoundingBoxCondition => $filterQueries[]['geo_bounding_box'][$this->getFilterField($indexes, $filter->field)] = [
+                $filter instanceof Condition\GeoBoundingBoxCondition => $filterQueries[]['geo_bounding_box'][$this->getFilterField($index, $filter->field)] = [
                     'top_left' => [
                         'lat' => $filter->northLatitude,
                         'lon' => $filter->westLongitude,
@@ -215,8 +185,8 @@ final class ElasticsearchSearcher implements SearcherInterface
                         'lon' => $filter->eastLongitude,
                     ],
                 ],
-                $filter instanceof Condition\AndCondition => $filterQueries[] = $this->recursiveResolveFilterConditions($indexes, $filter->conditions, true),
-                $filter instanceof Condition\OrCondition => $filterQueries[] = $this->recursiveResolveFilterConditions($indexes, $filter->conditions, false),
+                $filter instanceof Condition\AndCondition => $filterQueries[] = $this->recursiveResolveFilterConditions($index, $filter->conditions, true),
+                $filter instanceof Condition\OrCondition => $filterQueries[] = $this->recursiveResolveFilterConditions($index, $filter->conditions, false),
                 default => throw new \LogicException($filter::class . ' filter not implemented.'),
             };
         }

--- a/packages/seal-loupe-adapter/tests/LoupeSearcherTest.php
+++ b/packages/seal-loupe-adapter/tests/LoupeSearcherTest.php
@@ -25,12 +25,4 @@ class LoupeSearcherTest extends AbstractSearcherTestCase
 
         parent::setUpBeforeClass();
     }
-
-    /**
-     * @doesNotPerformAssertions
-     */
-    public function testFindMultipleIndexes(): void
-    {
-        $this->markTestSkipped('Not supported by Loupe: https://github.com/schranz-search/schranz-search/issues/28');
-    }
 }

--- a/packages/seal-meilisearch-adapter/src/MeilisearchSearcher.php
+++ b/packages/seal-meilisearch-adapter/src/MeilisearchSearcher.php
@@ -117,6 +117,10 @@ final class MeilisearchSearcher implements SearcherInterface
         };
     }
 
+    /**
+     * @param list<string|int|float|bool> $value
+     * @return string
+     */
     private function escapeArrayFilterValues(array $value): string
     {
         return \implode(

--- a/packages/seal-meilisearch-adapter/src/MeilisearchSearcher.php
+++ b/packages/seal-meilisearch-adapter/src/MeilisearchSearcher.php
@@ -42,40 +42,34 @@ final class MeilisearchSearcher implements SearcherInterface
     {
         // optimized single document query
         if (
-            1 === \count($search->indexes)
-            && 1 === \count($search->filters)
+            1 === \count($search->filters)
             && $search->filters[0] instanceof Condition\IdentifierCondition
             && 0 === $search->offset
             && 1 === $search->limit
         ) {
             try {
-                $data = $this->client->index($search->indexes[\array_key_first($search->indexes)]->name)->getDocument($search->filters[0]->identifier);
+                $data = $this->client->index($search->index->name)->getDocument($search->filters[0]->identifier);
             } catch (ApiException $e) {
                 if (404 !== $e->httpStatus) {
                     throw $e;
                 }
 
                 return new Result(
-                    $this->hitsToDocuments($search->indexes, []),
+                    $this->hitsToDocuments($search->index, []),
                     0,
                 );
             }
 
             return new Result(
-                $this->hitsToDocuments($search->indexes, [$data]),
+                $this->hitsToDocuments($search->index, [$data]),
                 1,
             );
         }
 
-        if (1 !== \count($search->indexes)) {
-            throw new \RuntimeException('Meilisearch does not yet support search across multiple indexes: https://github.com/schranz-search/schranz-search/issues/28');
-        }
-
-        $index = $search->indexes[\array_key_first($search->indexes)];
-        $searchIndex = $this->client->index($index->name);
+        $searchIndex = $this->client->index($search->index->name);
 
         $query = null;
-        $filters = $this->recursiveResolveFilterConditions($index, $search->filters, true, $query);
+        $filters = $this->recursiveResolveFilterConditions($search->index, $search->filters, true, $query);
 
         $searchParams = [];
         if ('' !== $filters) {
@@ -97,21 +91,18 @@ final class MeilisearchSearcher implements SearcherInterface
         $data = $searchIndex->search($query, $searchParams)->toArray();
 
         return new Result(
-            $this->hitsToDocuments($search->indexes, $data['hits']),
+            $this->hitsToDocuments($search->index, $data['hits']),
             $data['totalHits'] ?? $data['estimatedTotalHits'] ?? null,
         );
     }
 
     /**
-     * @param Index[] $indexes
      * @param iterable<array<string, mixed>> $hits
      *
      * @return \Generator<int, array<string, mixed>>
      */
-    private function hitsToDocuments(array $indexes, iterable $hits): \Generator
+    private function hitsToDocuments(Index $index, iterable $hits): \Generator
     {
-        $index = $indexes[\array_key_first($indexes)];
-
         foreach ($hits as $hit) {
             yield $this->marshaller->unmarshall($index->fields, $hit);
         }
@@ -128,9 +119,9 @@ final class MeilisearchSearcher implements SearcherInterface
 
     private function escapeArrayFilterValues(array $value): string
     {
-        return implode(
+        return \implode(
             ', ',
-            array_map([$this, 'escapeFilterValue'], $value)
+            \array_map([$this, 'escapeFilterValue'], $value),
         );
     }
 

--- a/packages/seal-meilisearch-adapter/src/MeilisearchSearcher.php
+++ b/packages/seal-meilisearch-adapter/src/MeilisearchSearcher.php
@@ -119,7 +119,6 @@ final class MeilisearchSearcher implements SearcherInterface
 
     /**
      * @param list<string|int|float|bool> $value
-     * @return string
      */
     private function escapeArrayFilterValues(array $value): string
     {

--- a/packages/seal-meilisearch-adapter/tests/MeilisearchSearcherTest.php
+++ b/packages/seal-meilisearch-adapter/tests/MeilisearchSearcherTest.php
@@ -25,12 +25,4 @@ class MeilisearchSearcherTest extends AbstractSearcherTestCase
 
         parent::setUpBeforeClass();
     }
-
-    /**
-     * @doesNotPerformAssertions
-     */
-    public function testFindMultipleIndexes(): void
-    {
-        $this->markTestSkipped('Not supported by Meilisearch: https://github.com/schranz-search/schranz-search/issues/28');
-    }
 }

--- a/packages/seal-memory-adapter/src/MemorySearcher.php
+++ b/packages/seal-memory-adapter/src/MemorySearcher.php
@@ -35,7 +35,7 @@ final class MemorySearcher implements SearcherInterface
         $documents = [];
 
         /** @var Index $index */
-        foreach ($search->indexes as $index) {
+        foreach ([$search->index] as $index) {
             $indexDocuments = MemoryStorage::getDocuments($index);
 
             if ([] === $search->filters) {

--- a/packages/seal-opensearch-adapter/phpunit.xml.dist
+++ b/packages/seal-opensearch-adapter/phpunit.xml.dist
@@ -5,6 +5,7 @@
          colors="true"
          bootstrap="vendor/autoload.php"
          cacheDirectory=".phpunit.cache"
+         displayDetailsOnTestsThatTriggerWarnings="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/packages/seal-redisearch-adapter/tests/RediSearchSearcherTest.php
+++ b/packages/seal-redisearch-adapter/tests/RediSearchSearcherTest.php
@@ -29,14 +29,6 @@ class RediSearchSearcherTest extends AbstractSearcherTestCase
     /**
      * @doesNotPerformAssertions
      */
-    public function testFindMultipleIndexes(): void
-    {
-        $this->markTestSkipped('Not supported by RediSearch: https://github.com/schranz-search/schranz-search/issues/93');
-    }
-
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testGeoBoundingBoxCondition(): void
     {
         $this->markTestSkipped('Not supported by RediSearch: https://github.com/RediSearch/RediSearch/issues/680 or https://github.com/RediSearch/RediSearch/issues/5032');

--- a/packages/seal-solr-adapter/tests/SolrSearcherTest.php
+++ b/packages/seal-solr-adapter/tests/SolrSearcherTest.php
@@ -25,12 +25,4 @@ class SolrSearcherTest extends AbstractSearcherTestCase
 
         parent::setUpBeforeClass();
     }
-
-    /**
-     * @doesNotPerformAssertions
-     */
-    public function testFindMultipleIndexes(): void
-    {
-        $this->markTestSkipped('Not supported by Solr: TODO create issue');
-    }
 }

--- a/packages/seal-typesense-adapter/tests/TypesenseSearcherTest.php
+++ b/packages/seal-typesense-adapter/tests/TypesenseSearcherTest.php
@@ -25,12 +25,4 @@ class TypesenseSearcherTest extends AbstractSearcherTestCase
 
         parent::setUpBeforeClass();
     }
-
-    /**
-     * @doesNotPerformAssertions
-     */
-    public function testFindMultipleIndexes(): void
-    {
-        $this->markTestSkipped('Not supported by Typesense: https://github.com/schranz-search/schranz-search/issues/98');
-    }
 }

--- a/packages/seal/src/Engine.php
+++ b/packages/seal/src/Engine.php
@@ -61,8 +61,7 @@ final class Engine implements EngineInterface
 
     public function getDocument(string $index, string $identifier): array
     {
-        $documents = [...$this->createSearchBuilder()
-            ->addIndex($index)
+        $documents = [...$this->createSearchBuilder($index)
             ->addFilter(new IdentifierCondition($identifier))
             ->limit(1)
             ->getResult()];
@@ -81,12 +80,13 @@ final class Engine implements EngineInterface
         return $document;
     }
 
-    public function createSearchBuilder(): SearchBuilder
+    public function createSearchBuilder(string $index): SearchBuilder
     {
-        return new SearchBuilder(
+        return (new SearchBuilder(
             $this->schema,
             $this->adapter->getSearcher(),
-        );
+        ))
+            ->index($index);
     }
 
     public function createIndex(string $index, array $options = []): TaskInterface|null

--- a/packages/seal/src/EngineInterface.php
+++ b/packages/seal/src/EngineInterface.php
@@ -51,7 +51,7 @@ interface EngineInterface
      */
     public function getDocument(string $index, string $identifier): array;
 
-    public function createSearchBuilder(): SearchBuilder;
+    public function createSearchBuilder(string $index): SearchBuilder;
 
     /**
      * @param array{return_slow_promise_result?: true} $options

--- a/packages/seal/src/Search/Search.php
+++ b/packages/seal/src/Search/Search.php
@@ -18,12 +18,11 @@ use Schranz\Search\SEAL\Schema\Index;
 final class Search
 {
     /**
-     * @param array<string, Index> $indexes
      * @param object[] $filters
      * @param array<string, 'asc'|'desc'> $sortBys
      */
     public function __construct(
-        public readonly array $indexes = [],
+        public readonly Index $index,
         public readonly array $filters = [],
         public readonly array $sortBys = [],
         public readonly int|null $limit = null,

--- a/packages/seal/src/Search/SearchBuilder.php
+++ b/packages/seal/src/Search/SearchBuilder.php
@@ -19,10 +19,7 @@ use Schranz\Search\SEAL\Schema\Schema;
 
 final class SearchBuilder
 {
-    /**
-     * @var array<string, Index>
-     */
-    private array $indexes = [];
+    private Index $index;
 
     /**
      * @var object[]
@@ -44,9 +41,9 @@ final class SearchBuilder
     ) {
     }
 
-    public function addIndex(string $name): static
+    public function index(string $name): static
     {
-        $this->indexes[$name] = $this->schema->indexes[$name];
+        $this->index = $this->schema->indexes[$name];
 
         return $this;
     }
@@ -85,7 +82,7 @@ final class SearchBuilder
     public function getSearch(): Search
     {
         return new Search(
-            $this->indexes,
+            $this->index,
             $this->filters,
             $this->sortBys,
             $this->limit,

--- a/packages/seal/src/Testing/AbstractIndexerTestCase.php
+++ b/packages/seal/src/Testing/AbstractIndexerTestCase.php
@@ -97,7 +97,7 @@ abstract class AbstractIndexerTestCase extends TestCase
         $loadedDocuments = [];
         foreach ($documents as $document) {
             $search = new SearchBuilder($schema, self::$searcher);
-            $search->addIndex(TestingHelper::INDEX_COMPLEX);
+            $search->index(TestingHelper::INDEX_COMPLEX);
             $search->addFilter(new Condition\IdentifierCondition($document['uuid']));
             $search->limit(1);
 
@@ -131,7 +131,7 @@ abstract class AbstractIndexerTestCase extends TestCase
 
         foreach ($documents as $document) {
             $search = new SearchBuilder($schema, self::$searcher);
-            $search->addIndex(TestingHelper::INDEX_COMPLEX);
+            $search->index(TestingHelper::INDEX_COMPLEX);
             $search->addFilter(new Condition\IdentifierCondition($document['uuid']));
             $search->limit(1);
 
@@ -162,7 +162,7 @@ abstract class AbstractIndexerTestCase extends TestCase
         $loadedDocuments = [];
         foreach ($documents as $document) {
             $search = new SearchBuilder($schema, self::$searcher);
-            $search->addIndex(TestingHelper::INDEX_COMPLEX);
+            $search->index(TestingHelper::INDEX_COMPLEX);
             $search->addFilter(new Condition\IdentifierCondition($document['uuid']));
             $search->limit(1);
 
@@ -199,7 +199,7 @@ abstract class AbstractIndexerTestCase extends TestCase
 
         foreach ($documents as $document) {
             $search = new SearchBuilder($schema, self::$searcher);
-            $search->addIndex(TestingHelper::INDEX_COMPLEX);
+            $search->index(TestingHelper::INDEX_COMPLEX);
             $search->addFilter(new Condition\IdentifierCondition($document['uuid']));
             $search->limit(1);
 

--- a/packages/seal/src/Testing/AbstractSearcherTestCase.php
+++ b/packages/seal/src/Testing/AbstractSearcherTestCase.php
@@ -79,35 +79,6 @@ abstract class AbstractSearcherTestCase extends TestCase
         return self::$schema;
     }
 
-    public function testFindMultipleIndexes(): void
-    {
-        $document = TestingHelper::createSimpleFixtures()[0];
-
-        $schema = self::getSchema();
-
-        self::$indexer->save(
-            $schema->indexes[TestingHelper::INDEX_SIMPLE],
-            $document,
-            ['return_slow_promise_result' => true],
-        )->wait();
-
-        $search = new SearchBuilder($schema, self::$searcher);
-        $search->addIndex(TestingHelper::INDEX_COMPLEX);
-        $search->addIndex(TestingHelper::INDEX_SIMPLE);
-        $search->addFilter(new Condition\IdentifierCondition($document['id']));
-
-        $expectedDocument = $document;
-        $loadedDocument = \iterator_to_array($search->getResult(), false)[0] ?? null;
-
-        $this->assertSame($expectedDocument, $loadedDocument);
-
-        self::$indexer->delete(
-            $schema->indexes[TestingHelper::INDEX_SIMPLE],
-            $document['id'],
-            ['return_slow_promise_result' => true],
-        )->wait();
-    }
-
     public function testSearchCondition(): void
     {
         $documents = TestingHelper::createComplexFixtures();
@@ -124,7 +95,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         self::$taskHelper->waitForAll();
 
         $search = new SearchBuilder($schema, self::$searcher);
-        $search->addIndex(TestingHelper::INDEX_COMPLEX);
+        $search->index(TestingHelper::INDEX_COMPLEX);
         $search->addFilter(new Condition\SearchCondition('Blog'));
 
         $expectedDocumentsVariantA = [
@@ -146,7 +117,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         );
 
         $search = new SearchBuilder($schema, self::$searcher);
-        $search->addIndex(TestingHelper::INDEX_COMPLEX);
+        $search->index(TestingHelper::INDEX_COMPLEX);
         $search->addFilter(new Condition\SearchCondition('Thing'));
 
         $this->assertSame([$documents[2]], [...$search->getResult()]);
@@ -176,7 +147,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         self::$taskHelper->waitForAll();
 
         $search = new SearchBuilder($schema, self::$searcher);
-        $search->addIndex(TestingHelper::INDEX_COMPLEX);
+        $search->index(TestingHelper::INDEX_COMPLEX);
         $search->addFilter(new Condition\SearchCondition('admin.nonesearchablefield@localhost'));
 
         $this->assertCount(0, [...$search->getResult()]);
@@ -198,7 +169,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         self::$taskHelper->waitForAll();
 
         $search = (new SearchBuilder($schema, self::$searcher))
-            ->addIndex(TestingHelper::INDEX_COMPLEX)
+            ->index(TestingHelper::INDEX_COMPLEX)
             ->addFilter(new Condition\SearchCondition('Blog'))
             ->limit(1);
 
@@ -214,7 +185,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         $isFirstDocumentOnPage1 = [$documents[0]] === $loadedDocuments;
 
         $search = (new SearchBuilder($schema, self::$searcher))
-            ->addIndex(TestingHelper::INDEX_COMPLEX)
+            ->index(TestingHelper::INDEX_COMPLEX)
             ->addFilter(new Condition\SearchCondition('Blog'))
             ->offset(1)
             ->limit(1);
@@ -251,7 +222,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         self::$taskHelper->waitForAll();
 
         $search = new SearchBuilder($schema, self::$searcher);
-        $search->addIndex(TestingHelper::INDEX_COMPLEX);
+        $search->index(TestingHelper::INDEX_COMPLEX);
         $search->addFilter(new Condition\EqualCondition('tags', 'UI'));
 
         $expectedDocumentsVariantA = [
@@ -297,7 +268,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         self::$taskHelper->waitForAll();
 
         $search = new SearchBuilder($schema, self::$searcher);
-        $search->addIndex(TestingHelper::INDEX_COMPLEX);
+        $search->index(TestingHelper::INDEX_COMPLEX);
         $search->addFilter(new Condition\EqualCondition('isSpecial', true));
 
         $expectedDocumentsVariantA = [
@@ -347,7 +318,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         self::$taskHelper->waitForAll();
 
         $search = new SearchBuilder($schema, self::$searcher);
-        $search->addIndex(TestingHelper::INDEX_COMPLEX);
+        $search->index(TestingHelper::INDEX_COMPLEX);
         $search->addFilter(new Condition\EqualCondition('tags', $specialString));
 
         $expectedDocumentsVariantA = [
@@ -391,7 +362,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         self::$taskHelper->waitForAll();
 
         $search = new SearchBuilder($schema, self::$searcher);
-        $search->addIndex(TestingHelper::INDEX_COMPLEX);
+        $search->index(TestingHelper::INDEX_COMPLEX);
         $search->addFilter(new Condition\EqualCondition('tags', 'UI'));
         $search->addFilter(new Condition\EqualCondition('tags', 'UX'));
 
@@ -428,7 +399,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         self::$taskHelper->waitForAll();
 
         $search = new SearchBuilder($schema, self::$searcher);
-        $search->addIndex(TestingHelper::INDEX_COMPLEX);
+        $search->index(TestingHelper::INDEX_COMPLEX);
         $search->addFilter(new Condition\EqualCondition('tags', 'Tech'));
         $search->addFilter(new Condition\SearchCondition('Blog'));
 
@@ -462,7 +433,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         self::$taskHelper->waitForAll();
 
         $search = new SearchBuilder($schema, self::$searcher);
-        $search->addIndex(TestingHelper::INDEX_COMPLEX);
+        $search->index(TestingHelper::INDEX_COMPLEX);
         $search->addFilter(new Condition\NotEqualCondition('tags', 'UI'));
 
         $expectedDocumentsVariantA = [
@@ -508,7 +479,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         self::$taskHelper->waitForAll();
 
         $search = new SearchBuilder($schema, self::$searcher);
-        $search->addIndex(TestingHelper::INDEX_COMPLEX);
+        $search->index(TestingHelper::INDEX_COMPLEX);
         $search->addFilter(new Condition\GreaterThanCondition('rating', 2.5));
 
         $loadedDocuments = [...$search->getResult()];
@@ -543,7 +514,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         self::$taskHelper->waitForAll();
 
         $search = new SearchBuilder($schema, self::$searcher);
-        $search->addIndex(TestingHelper::INDEX_COMPLEX);
+        $search->index(TestingHelper::INDEX_COMPLEX);
         $search->addFilter(new Condition\GreaterThanEqualCondition('rating', 2.5));
 
         $loadedDocuments = [...$search->getResult()];
@@ -583,7 +554,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         self::$taskHelper->waitForAll();
 
         $search = new SearchBuilder($schema, self::$searcher);
-        $search->addIndex(TestingHelper::INDEX_COMPLEX);
+        $search->index(TestingHelper::INDEX_COMPLEX);
         $search->addFilter(new Condition\GreaterThanEqualCondition('categoryIds', 3.0));
 
         $loadedDocuments = [...$search->getResult()];
@@ -623,7 +594,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         self::$taskHelper->waitForAll();
 
         $search = new SearchBuilder($schema, self::$searcher);
-        $search->addIndex(TestingHelper::INDEX_COMPLEX);
+        $search->index(TestingHelper::INDEX_COMPLEX);
         $search->addFilter(new Condition\LessThanCondition('rating', 3.5));
 
         $loadedDocuments = [...$search->getResult()];
@@ -663,7 +634,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         self::$taskHelper->waitForAll();
 
         $search = new SearchBuilder($schema, self::$searcher);
-        $search->addIndex(TestingHelper::INDEX_COMPLEX);
+        $search->index(TestingHelper::INDEX_COMPLEX);
         $search->addFilter(new Condition\LessThanEqualCondition('rating', 3.5));
 
         $loadedDocuments = [...$search->getResult()];
@@ -703,7 +674,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         self::$taskHelper->waitForAll();
 
         $search = new SearchBuilder($schema, self::$searcher);
-        $search->addIndex(TestingHelper::INDEX_COMPLEX);
+        $search->index(TestingHelper::INDEX_COMPLEX);
         $search->addFilter(new Condition\GeoDistanceCondition(
             'location',
             // Berlin
@@ -768,7 +739,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         self::$taskHelper->waitForAll();
 
         $search = new SearchBuilder($schema, self::$searcher);
-        $search->addIndex(TestingHelper::INDEX_COMPLEX);
+        $search->index(TestingHelper::INDEX_COMPLEX);
         $search->addFilter(new Condition\GeoBoundingBoxCondition(
             'location',
             // Dublin - Athen
@@ -849,7 +820,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         self::$taskHelper->waitForAll();
 
         $search = new SearchBuilder($schema, self::$searcher);
-        $search->addIndex(TestingHelper::INDEX_COMPLEX);
+        $search->index(TestingHelper::INDEX_COMPLEX);
         $search->addFilter(new Condition\LessThanEqualCondition('categoryIds', 2.0));
 
         $loadedDocuments = [...$search->getResult()];
@@ -889,7 +860,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         self::$taskHelper->waitForAll();
 
         $search = new SearchBuilder($schema, self::$searcher);
-        $search->addIndex(TestingHelper::INDEX_COMPLEX);
+        $search->index(TestingHelper::INDEX_COMPLEX);
         $search->addFilter(new Condition\InCondition('tags', ['UI']));
 
         $expectedDocumentsVariantA = [
@@ -935,7 +906,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         self::$taskHelper->waitForAll();
 
         $search = new SearchBuilder($schema, self::$searcher);
-        $search->addIndex(TestingHelper::INDEX_COMPLEX);
+        $search->index(TestingHelper::INDEX_COMPLEX);
         $search->addFilter(new Condition\NotInCondition('tags', ['UI']));
 
         $expectedDocumentsVariantA = [
@@ -982,7 +953,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         self::$taskHelper->waitForAll();
 
         $search = new SearchBuilder($schema, self::$searcher);
-        $search->addIndex(TestingHelper::INDEX_COMPLEX);
+        $search->index(TestingHelper::INDEX_COMPLEX);
         $search->addFilter(new Condition\GreaterThanCondition('rating', 0));
         $search->addSortBy('rating', 'asc');
 
@@ -1021,7 +992,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         self::$taskHelper->waitForAll();
 
         $search = new SearchBuilder($schema, self::$searcher);
-        $search->addIndex(TestingHelper::INDEX_COMPLEX);
+        $search->index(TestingHelper::INDEX_COMPLEX);
         $search->addFilter(new Condition\GreaterThanCondition('rating', 0));
         $search->addSortBy('rating', 'desc');
 
@@ -1071,7 +1042,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         self::$taskHelper->waitForAll();
 
         $search = new SearchBuilder($schema, self::$searcher);
-        $search->addIndex(TestingHelper::INDEX_COMPLEX);
+        $search->index(TestingHelper::INDEX_COMPLEX);
 
         $condition = new Condition\AndCondition(
             new Condition\EqualCondition('tags', 'Tech'),


### PR DESCRIPTION
As discuss result of the current state in #99 we will not longer support search on multi indexes as most engine do not support that. See #99.

# BC Breaks

 - The `Engine::createSearchBuilder` requires a parameter `string $index`
 - The `Search` returns not longer `indexes` instead of single `index` parameter
 - Elasticsearch and Opensearch can not longer search on multiple indexes in aggregated result
 
closes #99 