### PR TITLE
Add Windows support for creating search adapters

### DIFF
--- a/packages/seal/src/Adapter/AdapterFactory.php
+++ b/packages/seal/src/Adapter/AdapterFactory.php
@@ -87,7 +87,17 @@ final class AdapterFactory
 
             if (\str_contains($dsn, ':///')) {
                 // make DSN like loupe:///full/path/project/var/indexes parseable
-                $dsn = \str_replace(':///', '://' . $adapterName . '/', $dsn . $query);
+                $dsn = \str_replace(':///', '://' . $adapterName . '/', $dsn. $query);
+            } elseif (\DIRECTORY_SEPARATOR === '\\') {
+                // might be Windows and contain an absolute path like loupe://C:\path\project\var\indexes which will fail when parse_url is used
+                $dsnParts = \explode('://', $dsn);
+
+                return [
+                    'scheme' => $dsnParts[0] ?? '',
+                    'host' => '',
+                    'path' => $dsnParts[1] ?? '',
+                    'query' => [],
+                ];
             } else {
                 $dsn = $dsn . '@' . $adapterName . $query;
             }

--- a/packages/seal/tests/Adapter/AdapterFactoryTest.php
+++ b/packages/seal/tests/Adapter/AdapterFactoryTest.php
@@ -155,6 +155,29 @@ class AdapterFactoryTest extends TestCase
                 'fragment' => 'fragment',
             ],
         ];
+
+        yield 'windows_path' => [
+            'scheme://C:\path\project\var',
+            [
+                'scheme' => 'scheme',
+                'host' => '',
+                'path' => 'C:\path\project\var',
+                'query' => [],
+            ],
+        ];
+
+        yield 'windows_path_with_query' => [
+            'scheme://C:\path\project\var?queryKey=queryValue#fragment',
+            [
+                'scheme' => 'scheme',
+                'host' => '',
+                'path' => 'C:\path\project\var',
+                'query' => [
+                    'queryKey' => 'queryValue',
+                ],
+                'fragment' => 'fragment',
+            ],
+        ];
     }
 
     private function createAdapterFactory(string $name): AdapterFactoryInterface


### PR DESCRIPTION
Another try but now in the right repo :)

### Description

Absolute paths on windows fail due to an undefined array key within the following line not having a scheme at all;
https://github.com/schranz-search/schranz-search/blob/d91446a972b7bcc894abfd803eff40fc7dd3c09c/packages/seal/src/Adapter/AdapterFactory.php#L140

This PR adds `Windows` support for the path resolution since `$dsn` would fail later due to the second `parse_url` attempt returning `false` again.

In my case, the following `$dsn` would fail because it won't detect any scheme at all:
```loupe://C:\path\project\var\indexes```
The early return is done before adding the fallback where it adds the adapter name with an `@´  :')

Unsure if we should go for the `PHP_OS_FAMILY` check and see if it's windows in this case 🤔?

