### PR TITLE
Add cmsig/seal packages replaces schranz-search packages

### DIFF
--- a/.examples/laravel/composer.lock
+++ b/.examples/laravel/composer.lock
@@ -141,10 +141,13 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal",
-                "reference": "65e8ff1785e5c47d02a13c068ff45d31c05935d3"
+                "reference": "16c36c2aeb74a061fd60b0eabd37411121b51bc8"
             },
             "require": {
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -235,7 +238,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../integrations/laravel",
-                "reference": "c0a8dc051505a1bb34a8e326910cfab18e4a6246"
+                "reference": "481d96f49ca667454bca060b5e34d3accbccb42a"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -256,6 +259,9 @@
                 "cmsig/seal-redisearch-adapter": "<0.6 || >=0.7",
                 "cmsig/seal-solr-adapter": "<0.6 || >=0.7",
                 "cmsig/seal-typesense-adapter": "<0.6 || >=0.7"
+            },
+            "replace": {
+                "schranz-search/laravel-package": "self.version"
             },
             "require-dev": {
                 "cmsig/seal-algolia-adapter": "^0.6",
@@ -6079,13 +6085,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-algolia-adapter",
-                "reference": "ba35c75e21bd11b75955a9fa4e768e12fc1630bf"
+                "reference": "f278cb1f3b39f9714b62700d97682eada26f2eda"
             },
             "require": {
                 "algolia/algoliasearch-client-php": "^4.4",
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-algolia-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -6168,13 +6177,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-elasticsearch-adapter",
-                "reference": "a6ffe8da480ce2a935489c7bf7df11a78b522e0c"
+                "reference": "27c9d6edce3e024e7a3d5edf37e81a883f95311a"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "elasticsearch/elasticsearch": "^8.5.3",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-elasticsearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/psr7": "^2.0",
@@ -6260,7 +6272,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "d783be53a6a41e5d6f587be48127bab61121b3b6"
+                "reference": "3b9b6ad4bbbfbb534f2e590da5f2bddc35ae2350"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -6270,6 +6282,9 @@
             },
             "conflict": {
                 "doctrine/dbal": "<3.6.0"
+            },
+            "replace": {
+                "schranz-search/seal-loupe-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -6352,13 +6367,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-meilisearch-adapter",
-                "reference": "8b2e2b44065a24ef850efec3e2be5829248ae4e6"
+                "reference": "b482ac1c2d277c3c374244cd38e0094a5e38fbcb"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "meilisearch/meilisearch-php": "^1.2",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-meilisearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/guzzle": "^7.5",
@@ -6443,11 +6461,14 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-memory-adapter",
-                "reference": "f60e4a6c42a98640034789db9ee09347f9cc6580"
+                "reference": "264676dad6f706a8482992b02f6bf513554cef2b"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal-memory-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -6529,12 +6550,15 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-multi-adapter",
-                "reference": "5461452681fece1b89cc7ab9662699d2570a8df1"
+                "reference": "1f75abafbff4938c97bdae4907b97d3c3970e821"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-multi-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -6616,13 +6640,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-opensearch-adapter",
-                "reference": "d680d39cf873f0d82a99d7d67ad979222a17beb7"
+                "reference": "ee5d4c6a701e5af30a6e39b469d1fc1990091422"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "opensearch-project/opensearch-php": "^2.0",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-opensearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/psr7": "^2.0",
@@ -6708,12 +6735,15 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-read-write-adapter",
-                "reference": "e9a18f15f5877a34b4ca476ac414a4bb11e41463"
+                "reference": "2964f33b44fdc5a1434f77c4175b640b67cc2e55"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-read-write-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -6795,7 +6825,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-redisearch-adapter",
-                "reference": "39cb0f3ef6f534ed4e2071b6f16cc646ddeec839"
+                "reference": "4143bdf3a0984cbcefc1f887cfda4cda3026588a"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -6803,6 +6833,9 @@
                 "ext-redis": "^5 || ^6.0",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-redisearch-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -6886,7 +6919,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-solr-adapter",
-                "reference": "81fc94ee50b546952483c239649f660814e5a6c2"
+                "reference": "ed78726f0d617a81dc822a1b40e59aa4736601cb"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -6896,6 +6929,9 @@
             },
             "conflict": {
                 "solarium/solarium": "6.x-dev"
+            },
+            "replace": {
+                "schranz-search/seal-solr-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -6980,7 +7016,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-typesense-adapter",
-                "reference": "e2cc1062554955ae940f2b2d9ec059dd682aaece"
+                "reference": "1c9eec69e2eaf68bd0a268a525ba8bc040669194"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -6991,6 +7027,9 @@
             },
             "conflict": {
                 "monolog/monolog": "<2.0"
+            },
+            "replace": {
+                "schranz-search/seal-typesense-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",

--- a/.examples/mezzio/composer.lock
+++ b/.examples/mezzio/composer.lock
@@ -61,10 +61,13 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal",
-                "reference": "65e8ff1785e5c47d02a13c068ff45d31c05935d3"
+                "reference": "16c36c2aeb74a061fd60b0eabd37411121b51bc8"
             },
             "require": {
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -155,7 +158,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../integrations/mezzio",
-                "reference": "c1ad3c60e9d5f367276fe2f62334f6c89e751ae3"
+                "reference": "57bbf30707b9f9586198652106d38a64c7c0d479"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -176,6 +179,9 @@
                 "cmsig/seal-redisearch-adapter": "<0.6 || >=0.7",
                 "cmsig/seal-solr-adapter": "<0.6 || >=0.7",
                 "cmsig/seal-typesense-adapter": "<0.6 || >=0.7"
+            },
+            "replace": {
+                "schranz-search/mezzio-module": "self.version"
             },
             "require-dev": {
                 "cmsig/seal-algolia-adapter": "^0.6",
@@ -3047,13 +3053,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-algolia-adapter",
-                "reference": "ba35c75e21bd11b75955a9fa4e768e12fc1630bf"
+                "reference": "f278cb1f3b39f9714b62700d97682eada26f2eda"
             },
             "require": {
                 "algolia/algoliasearch-client-php": "^4.4",
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-algolia-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -3136,13 +3145,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-elasticsearch-adapter",
-                "reference": "a6ffe8da480ce2a935489c7bf7df11a78b522e0c"
+                "reference": "27c9d6edce3e024e7a3d5edf37e81a883f95311a"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "elasticsearch/elasticsearch": "^8.5.3",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-elasticsearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/psr7": "^2.0",
@@ -3228,7 +3240,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "d783be53a6a41e5d6f587be48127bab61121b3b6"
+                "reference": "3b9b6ad4bbbfbb534f2e590da5f2bddc35ae2350"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -3238,6 +3250,9 @@
             },
             "conflict": {
                 "doctrine/dbal": "<3.6.0"
+            },
+            "replace": {
+                "schranz-search/seal-loupe-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -3320,13 +3335,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-meilisearch-adapter",
-                "reference": "8b2e2b44065a24ef850efec3e2be5829248ae4e6"
+                "reference": "b482ac1c2d277c3c374244cd38e0094a5e38fbcb"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "meilisearch/meilisearch-php": "^1.2",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-meilisearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/guzzle": "^7.5",
@@ -3411,11 +3429,14 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-memory-adapter",
-                "reference": "f60e4a6c42a98640034789db9ee09347f9cc6580"
+                "reference": "264676dad6f706a8482992b02f6bf513554cef2b"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal-memory-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -3497,12 +3518,15 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-multi-adapter",
-                "reference": "5461452681fece1b89cc7ab9662699d2570a8df1"
+                "reference": "1f75abafbff4938c97bdae4907b97d3c3970e821"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-multi-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -3584,13 +3608,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-opensearch-adapter",
-                "reference": "d680d39cf873f0d82a99d7d67ad979222a17beb7"
+                "reference": "ee5d4c6a701e5af30a6e39b469d1fc1990091422"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "opensearch-project/opensearch-php": "^2.0",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-opensearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/psr7": "^2.0",
@@ -3676,12 +3703,15 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-read-write-adapter",
-                "reference": "e9a18f15f5877a34b4ca476ac414a4bb11e41463"
+                "reference": "2964f33b44fdc5a1434f77c4175b640b67cc2e55"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-read-write-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -3763,7 +3793,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-redisearch-adapter",
-                "reference": "39cb0f3ef6f534ed4e2071b6f16cc646ddeec839"
+                "reference": "4143bdf3a0984cbcefc1f887cfda4cda3026588a"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -3771,6 +3801,9 @@
                 "ext-redis": "^5 || ^6.0",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-redisearch-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -3854,7 +3887,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-solr-adapter",
-                "reference": "81fc94ee50b546952483c239649f660814e5a6c2"
+                "reference": "ed78726f0d617a81dc822a1b40e59aa4736601cb"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -3864,6 +3897,9 @@
             },
             "conflict": {
                 "solarium/solarium": "6.x-dev"
+            },
+            "replace": {
+                "schranz-search/seal-solr-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -3948,7 +3984,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-typesense-adapter",
-                "reference": "e2cc1062554955ae940f2b2d9ec059dd682aaece"
+                "reference": "1c9eec69e2eaf68bd0a268a525ba8bc040669194"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -3959,6 +3995,9 @@
             },
             "conflict": {
                 "monolog/monolog": "<2.0"
+            },
+            "replace": {
+                "schranz-search/seal-typesense-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",

--- a/.examples/spiral/composer.lock
+++ b/.examples/spiral/composer.lock
@@ -183,10 +183,13 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal",
-                "reference": "65e8ff1785e5c47d02a13c068ff45d31c05935d3"
+                "reference": "16c36c2aeb74a061fd60b0eabd37411121b51bc8"
             },
             "require": {
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -277,7 +280,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../integrations/spiral",
-                "reference": "8abd1cb6fab67703dc9242a184f058d149cb148d"
+                "reference": "ce8c9196e36e70fd08751409e08fc789397f04ae"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -299,6 +302,9 @@
                 "cmsig/seal-redisearch-adapter": "<0.6 || >=0.7",
                 "cmsig/seal-solr-adapter": "<0.6 || >=0.7",
                 "cmsig/seal-typesense-adapter": "<0.6 || >=0.7"
+            },
+            "replace": {
+                "schranz-search/spiral-bridge": "self.version"
             },
             "require-dev": {
                 "cmsig/seal-algolia-adapter": "^0.6",
@@ -6945,13 +6951,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-algolia-adapter",
-                "reference": "ba35c75e21bd11b75955a9fa4e768e12fc1630bf"
+                "reference": "f278cb1f3b39f9714b62700d97682eada26f2eda"
             },
             "require": {
                 "algolia/algoliasearch-client-php": "^4.4",
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-algolia-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -7034,13 +7043,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-elasticsearch-adapter",
-                "reference": "a6ffe8da480ce2a935489c7bf7df11a78b522e0c"
+                "reference": "27c9d6edce3e024e7a3d5edf37e81a883f95311a"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "elasticsearch/elasticsearch": "^8.5.3",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-elasticsearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/psr7": "^2.0",
@@ -7126,7 +7138,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "d783be53a6a41e5d6f587be48127bab61121b3b6"
+                "reference": "3b9b6ad4bbbfbb534f2e590da5f2bddc35ae2350"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -7136,6 +7148,9 @@
             },
             "conflict": {
                 "doctrine/dbal": "<3.6.0"
+            },
+            "replace": {
+                "schranz-search/seal-loupe-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -7218,13 +7233,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-meilisearch-adapter",
-                "reference": "8b2e2b44065a24ef850efec3e2be5829248ae4e6"
+                "reference": "b482ac1c2d277c3c374244cd38e0094a5e38fbcb"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "meilisearch/meilisearch-php": "^1.2",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-meilisearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/guzzle": "^7.5",
@@ -7309,11 +7327,14 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-memory-adapter",
-                "reference": "f60e4a6c42a98640034789db9ee09347f9cc6580"
+                "reference": "264676dad6f706a8482992b02f6bf513554cef2b"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal-memory-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -7395,12 +7416,15 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-multi-adapter",
-                "reference": "5461452681fece1b89cc7ab9662699d2570a8df1"
+                "reference": "1f75abafbff4938c97bdae4907b97d3c3970e821"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-multi-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -7482,13 +7506,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-opensearch-adapter",
-                "reference": "d680d39cf873f0d82a99d7d67ad979222a17beb7"
+                "reference": "ee5d4c6a701e5af30a6e39b469d1fc1990091422"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "opensearch-project/opensearch-php": "^2.0",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-opensearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/psr7": "^2.0",
@@ -7574,12 +7601,15 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-read-write-adapter",
-                "reference": "e9a18f15f5877a34b4ca476ac414a4bb11e41463"
+                "reference": "2964f33b44fdc5a1434f77c4175b640b67cc2e55"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-read-write-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -7661,7 +7691,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-redisearch-adapter",
-                "reference": "39cb0f3ef6f534ed4e2071b6f16cc646ddeec839"
+                "reference": "4143bdf3a0984cbcefc1f887cfda4cda3026588a"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -7669,6 +7699,9 @@
                 "ext-redis": "^5 || ^6.0",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-redisearch-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -7752,7 +7785,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-solr-adapter",
-                "reference": "81fc94ee50b546952483c239649f660814e5a6c2"
+                "reference": "ed78726f0d617a81dc822a1b40e59aa4736601cb"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -7762,6 +7795,9 @@
             },
             "conflict": {
                 "solarium/solarium": "6.x-dev"
+            },
+            "replace": {
+                "schranz-search/seal-solr-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -7846,7 +7882,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-typesense-adapter",
-                "reference": "e2cc1062554955ae940f2b2d9ec059dd682aaece"
+                "reference": "1c9eec69e2eaf68bd0a268a525ba8bc040669194"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -7857,6 +7893,9 @@
             },
             "conflict": {
                 "monolog/monolog": "<2.0"
+            },
+            "replace": {
+                "schranz-search/seal-typesense-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",

--- a/.examples/symfony/composer.lock
+++ b/.examples/symfony/composer.lock
@@ -12,10 +12,13 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal",
-                "reference": "65e8ff1785e5c47d02a13c068ff45d31c05935d3"
+                "reference": "16c36c2aeb74a061fd60b0eabd37411121b51bc8"
             },
             "require": {
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -106,7 +109,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../integrations/symfony",
-                "reference": "4cc5d1769e51ca11af27fbab975f7c6a2652ed37"
+                "reference": "f68f9e6afdfc24c4afcc691edf5bd2841ca051d9"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -128,6 +131,9 @@
                 "cmsig/seal-redisearch-adapter": "<0.6 || >=0.7",
                 "cmsig/seal-solr-adapter": "<0.6 || >=0.7",
                 "cmsig/seal-typesense-adapter": "<0.6 || >=0.7"
+            },
+            "replace": {
+                "schranz-search/symfony-bundle": "self.version"
             },
             "require-dev": {
                 "cmsig/seal-algolia-adapter": "^0.6",
@@ -3253,13 +3259,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-algolia-adapter",
-                "reference": "ba35c75e21bd11b75955a9fa4e768e12fc1630bf"
+                "reference": "f278cb1f3b39f9714b62700d97682eada26f2eda"
             },
             "require": {
                 "algolia/algoliasearch-client-php": "^4.4",
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-algolia-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -3342,13 +3351,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-elasticsearch-adapter",
-                "reference": "a6ffe8da480ce2a935489c7bf7df11a78b522e0c"
+                "reference": "27c9d6edce3e024e7a3d5edf37e81a883f95311a"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "elasticsearch/elasticsearch": "^8.5.3",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-elasticsearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/psr7": "^2.0",
@@ -3434,7 +3446,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "d783be53a6a41e5d6f587be48127bab61121b3b6"
+                "reference": "3b9b6ad4bbbfbb534f2e590da5f2bddc35ae2350"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -3444,6 +3456,9 @@
             },
             "conflict": {
                 "doctrine/dbal": "<3.6.0"
+            },
+            "replace": {
+                "schranz-search/seal-loupe-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -3526,13 +3541,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-meilisearch-adapter",
-                "reference": "8b2e2b44065a24ef850efec3e2be5829248ae4e6"
+                "reference": "b482ac1c2d277c3c374244cd38e0094a5e38fbcb"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "meilisearch/meilisearch-php": "^1.2",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-meilisearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/guzzle": "^7.5",
@@ -3617,11 +3635,14 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-memory-adapter",
-                "reference": "f60e4a6c42a98640034789db9ee09347f9cc6580"
+                "reference": "264676dad6f706a8482992b02f6bf513554cef2b"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal-memory-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -3703,12 +3724,15 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-multi-adapter",
-                "reference": "5461452681fece1b89cc7ab9662699d2570a8df1"
+                "reference": "1f75abafbff4938c97bdae4907b97d3c3970e821"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-multi-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -3790,13 +3814,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-opensearch-adapter",
-                "reference": "d680d39cf873f0d82a99d7d67ad979222a17beb7"
+                "reference": "ee5d4c6a701e5af30a6e39b469d1fc1990091422"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "opensearch-project/opensearch-php": "^2.0",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-opensearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/psr7": "^2.0",
@@ -3882,12 +3909,15 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-read-write-adapter",
-                "reference": "e9a18f15f5877a34b4ca476ac414a4bb11e41463"
+                "reference": "2964f33b44fdc5a1434f77c4175b640b67cc2e55"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-read-write-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -3969,7 +3999,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-redisearch-adapter",
-                "reference": "39cb0f3ef6f534ed4e2071b6f16cc646ddeec839"
+                "reference": "4143bdf3a0984cbcefc1f887cfda4cda3026588a"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -3977,6 +4007,9 @@
                 "ext-redis": "^5 || ^6.0",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-redisearch-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -4060,7 +4093,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-solr-adapter",
-                "reference": "81fc94ee50b546952483c239649f660814e5a6c2"
+                "reference": "ed78726f0d617a81dc822a1b40e59aa4736601cb"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -4070,6 +4103,9 @@
             },
             "conflict": {
                 "solarium/solarium": "6.x-dev"
+            },
+            "replace": {
+                "schranz-search/seal-solr-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -4154,7 +4190,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-typesense-adapter",
-                "reference": "e2cc1062554955ae940f2b2d9ec059dd682aaece"
+                "reference": "1c9eec69e2eaf68bd0a268a525ba8bc040669194"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -4165,6 +4201,9 @@
             },
             "conflict": {
                 "monolog/monolog": "<2.0"
+            },
+            "replace": {
+                "schranz-search/seal-typesense-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",

--- a/.examples/yii/composer.lock
+++ b/.examples/yii/composer.lock
@@ -122,10 +122,13 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal",
-                "reference": "65e8ff1785e5c47d02a13c068ff45d31c05935d3"
+                "reference": "16c36c2aeb74a061fd60b0eabd37411121b51bc8"
             },
             "require": {
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -216,7 +219,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../integrations/yii",
-                "reference": "4db0066f02cb2362fcaea2ee1e78c9709ef771a8"
+                "reference": "d5e8cdd6d318dca2fc8d967d7986208129febb59"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -237,6 +240,9 @@
                 "cmsig/seal-redisearch-adapter": "<0.6 || >=0.7",
                 "cmsig/seal-solr-adapter": "<0.6 || >=0.7",
                 "cmsig/seal-typesense-adapter": "<0.6 || >=0.7"
+            },
+            "replace": {
+                "schranz-search/yii-module": "self.version"
             },
             "require-dev": {
                 "cmsig/seal-algolia-adapter": "^0.6",
@@ -6275,13 +6281,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-algolia-adapter",
-                "reference": "ba35c75e21bd11b75955a9fa4e768e12fc1630bf"
+                "reference": "f278cb1f3b39f9714b62700d97682eada26f2eda"
             },
             "require": {
                 "algolia/algoliasearch-client-php": "^4.4",
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-algolia-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -6364,13 +6373,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-elasticsearch-adapter",
-                "reference": "a6ffe8da480ce2a935489c7bf7df11a78b522e0c"
+                "reference": "27c9d6edce3e024e7a3d5edf37e81a883f95311a"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "elasticsearch/elasticsearch": "^8.5.3",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-elasticsearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/psr7": "^2.0",
@@ -6456,7 +6468,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "d783be53a6a41e5d6f587be48127bab61121b3b6"
+                "reference": "3b9b6ad4bbbfbb534f2e590da5f2bddc35ae2350"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -6466,6 +6478,9 @@
             },
             "conflict": {
                 "doctrine/dbal": "<3.6.0"
+            },
+            "replace": {
+                "schranz-search/seal-loupe-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -6548,13 +6563,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-meilisearch-adapter",
-                "reference": "8b2e2b44065a24ef850efec3e2be5829248ae4e6"
+                "reference": "b482ac1c2d277c3c374244cd38e0094a5e38fbcb"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "meilisearch/meilisearch-php": "^1.2",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-meilisearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/guzzle": "^7.5",
@@ -6639,11 +6657,14 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-memory-adapter",
-                "reference": "f60e4a6c42a98640034789db9ee09347f9cc6580"
+                "reference": "264676dad6f706a8482992b02f6bf513554cef2b"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal-memory-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -6725,12 +6746,15 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-multi-adapter",
-                "reference": "5461452681fece1b89cc7ab9662699d2570a8df1"
+                "reference": "1f75abafbff4938c97bdae4907b97d3c3970e821"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-multi-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -6812,13 +6836,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-opensearch-adapter",
-                "reference": "d680d39cf873f0d82a99d7d67ad979222a17beb7"
+                "reference": "ee5d4c6a701e5af30a6e39b469d1fc1990091422"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "opensearch-project/opensearch-php": "^2.0",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-opensearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/psr7": "^2.0",
@@ -6904,12 +6931,15 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-read-write-adapter",
-                "reference": "e9a18f15f5877a34b4ca476ac414a4bb11e41463"
+                "reference": "2964f33b44fdc5a1434f77c4175b640b67cc2e55"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-read-write-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -6991,7 +7021,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-redisearch-adapter",
-                "reference": "39cb0f3ef6f534ed4e2071b6f16cc646ddeec839"
+                "reference": "4143bdf3a0984cbcefc1f887cfda4cda3026588a"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -6999,6 +7029,9 @@
                 "ext-redis": "^5 || ^6.0",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-redisearch-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -7082,7 +7115,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-solr-adapter",
-                "reference": "81fc94ee50b546952483c239649f660814e5a6c2"
+                "reference": "ed78726f0d617a81dc822a1b40e59aa4736601cb"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -7092,6 +7125,9 @@
             },
             "conflict": {
                 "solarium/solarium": "6.x-dev"
+            },
+            "replace": {
+                "schranz-search/seal-solr-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -7176,7 +7212,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-typesense-adapter",
-                "reference": "e2cc1062554955ae940f2b2d9ec059dd682aaece"
+                "reference": "1c9eec69e2eaf68bd0a268a525ba8bc040669194"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -7187,6 +7223,9 @@
             },
             "conflict": {
                 "monolog/monolog": "<2.0"
+            },
+            "replace": {
+                "schranz-search/seal-typesense-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",

--- a/integrations/laravel/composer.json
+++ b/integrations/laravel/composer.json
@@ -69,6 +69,9 @@
         "cmsig/seal-solr-adapter": "^0.6",
         "cmsig/seal-typesense-adapter": "^0.6"
     },
+    "replace": {
+        "schranz-search/laravel-package": "self.version"
+    },
     "conflict": {
         "cmsig/seal-algolia-adapter": "<0.6 || >=0.7",
         "cmsig/seal-elasticsearch-adapter": "<0.6 || >=0.7",

--- a/integrations/laravel/composer.lock
+++ b/integrations/laravel/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4a51e5de9986823f2f8ea04d2d8d2acf",
+    "content-hash": "291ebfd0d3772e28267072ccfe16d287",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -81,10 +81,13 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal",
-                "reference": "65e8ff1785e5c47d02a13c068ff45d31c05935d3"
+                "reference": "16c36c2aeb74a061fd60b0eabd37411121b51bc8"
             },
             "require": {
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -2654,13 +2657,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-algolia-adapter",
-                "reference": "ba35c75e21bd11b75955a9fa4e768e12fc1630bf"
+                "reference": "f278cb1f3b39f9714b62700d97682eada26f2eda"
             },
             "require": {
                 "algolia/algoliasearch-client-php": "^4.4",
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-algolia-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -2743,13 +2749,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-elasticsearch-adapter",
-                "reference": "a6ffe8da480ce2a935489c7bf7df11a78b522e0c"
+                "reference": "27c9d6edce3e024e7a3d5edf37e81a883f95311a"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "elasticsearch/elasticsearch": "^8.5.3",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-elasticsearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/psr7": "^2.0",
@@ -2835,7 +2844,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "d783be53a6a41e5d6f587be48127bab61121b3b6"
+                "reference": "3b9b6ad4bbbfbb534f2e590da5f2bddc35ae2350"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -2845,6 +2854,9 @@
             },
             "conflict": {
                 "doctrine/dbal": "<3.6.0"
+            },
+            "replace": {
+                "schranz-search/seal-loupe-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -2927,13 +2939,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-meilisearch-adapter",
-                "reference": "8b2e2b44065a24ef850efec3e2be5829248ae4e6"
+                "reference": "b482ac1c2d277c3c374244cd38e0094a5e38fbcb"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "meilisearch/meilisearch-php": "^1.2",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-meilisearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/guzzle": "^7.5",
@@ -3018,11 +3033,14 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-memory-adapter",
-                "reference": "f60e4a6c42a98640034789db9ee09347f9cc6580"
+                "reference": "264676dad6f706a8482992b02f6bf513554cef2b"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal-memory-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -3104,12 +3122,15 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-multi-adapter",
-                "reference": "5461452681fece1b89cc7ab9662699d2570a8df1"
+                "reference": "1f75abafbff4938c97bdae4907b97d3c3970e821"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-multi-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -3191,13 +3212,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-opensearch-adapter",
-                "reference": "d680d39cf873f0d82a99d7d67ad979222a17beb7"
+                "reference": "ee5d4c6a701e5af30a6e39b469d1fc1990091422"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "opensearch-project/opensearch-php": "^2.0",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-opensearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/psr7": "^2.0",
@@ -3283,12 +3307,15 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-read-write-adapter",
-                "reference": "e9a18f15f5877a34b4ca476ac414a4bb11e41463"
+                "reference": "2964f33b44fdc5a1434f77c4175b640b67cc2e55"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-read-write-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -3370,7 +3397,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-redisearch-adapter",
-                "reference": "39cb0f3ef6f534ed4e2071b6f16cc646ddeec839"
+                "reference": "4143bdf3a0984cbcefc1f887cfda4cda3026588a"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -3378,6 +3405,9 @@
                 "ext-redis": "^5 || ^6.0",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-redisearch-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -3461,7 +3491,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-solr-adapter",
-                "reference": "81fc94ee50b546952483c239649f660814e5a6c2"
+                "reference": "ed78726f0d617a81dc822a1b40e59aa4736601cb"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -3471,6 +3501,9 @@
             },
             "conflict": {
                 "solarium/solarium": "6.x-dev"
+            },
+            "replace": {
+                "schranz-search/seal-solr-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -3555,7 +3588,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-typesense-adapter",
-                "reference": "e2cc1062554955ae940f2b2d9ec059dd682aaece"
+                "reference": "1c9eec69e2eaf68bd0a268a525ba8bc040669194"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -3566,6 +3599,9 @@
             },
             "conflict": {
                 "monolog/monolog": "<2.0"
+            },
+            "replace": {
+                "schranz-search/seal-typesense-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",

--- a/integrations/mezzio/composer.json
+++ b/integrations/mezzio/composer.json
@@ -69,6 +69,9 @@
         "cmsig/seal-solr-adapter": "^0.6",
         "cmsig/seal-typesense-adapter": "^0.6"
     },
+    "replace": {
+        "schranz-search/mezzio-module": "self.version"
+    },
     "conflict": {
         "cmsig/seal-algolia-adapter": "<0.6 || >=0.7",
         "cmsig/seal-elasticsearch-adapter": "<0.6 || >=0.7",

--- a/integrations/mezzio/composer.lock
+++ b/integrations/mezzio/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "929457e85a2730ef2ad335fac6e57c96",
+    "content-hash": "edf47f90d59f836f705f14975fc4c26a",
     "packages": [
         {
             "name": "cmsig/seal",
@@ -12,10 +12,13 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal",
-                "reference": "65e8ff1785e5c47d02a13c068ff45d31c05935d3"
+                "reference": "16c36c2aeb74a061fd60b0eabd37411121b51bc8"
             },
             "require": {
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -1287,13 +1290,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-algolia-adapter",
-                "reference": "ba35c75e21bd11b75955a9fa4e768e12fc1630bf"
+                "reference": "f278cb1f3b39f9714b62700d97682eada26f2eda"
             },
             "require": {
                 "algolia/algoliasearch-client-php": "^4.4",
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-algolia-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -1376,13 +1382,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-elasticsearch-adapter",
-                "reference": "a6ffe8da480ce2a935489c7bf7df11a78b522e0c"
+                "reference": "27c9d6edce3e024e7a3d5edf37e81a883f95311a"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "elasticsearch/elasticsearch": "^8.5.3",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-elasticsearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/psr7": "^2.0",
@@ -1468,7 +1477,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "d783be53a6a41e5d6f587be48127bab61121b3b6"
+                "reference": "3b9b6ad4bbbfbb534f2e590da5f2bddc35ae2350"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -1478,6 +1487,9 @@
             },
             "conflict": {
                 "doctrine/dbal": "<3.6.0"
+            },
+            "replace": {
+                "schranz-search/seal-loupe-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -1560,13 +1572,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-meilisearch-adapter",
-                "reference": "8b2e2b44065a24ef850efec3e2be5829248ae4e6"
+                "reference": "b482ac1c2d277c3c374244cd38e0094a5e38fbcb"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "meilisearch/meilisearch-php": "^1.2",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-meilisearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/guzzle": "^7.5",
@@ -1651,11 +1666,14 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-memory-adapter",
-                "reference": "f60e4a6c42a98640034789db9ee09347f9cc6580"
+                "reference": "264676dad6f706a8482992b02f6bf513554cef2b"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal-memory-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -1737,12 +1755,15 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-multi-adapter",
-                "reference": "5461452681fece1b89cc7ab9662699d2570a8df1"
+                "reference": "1f75abafbff4938c97bdae4907b97d3c3970e821"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-multi-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -1824,13 +1845,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-opensearch-adapter",
-                "reference": "d680d39cf873f0d82a99d7d67ad979222a17beb7"
+                "reference": "ee5d4c6a701e5af30a6e39b469d1fc1990091422"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "opensearch-project/opensearch-php": "^2.0",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-opensearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/psr7": "^2.0",
@@ -1916,12 +1940,15 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-read-write-adapter",
-                "reference": "e9a18f15f5877a34b4ca476ac414a4bb11e41463"
+                "reference": "2964f33b44fdc5a1434f77c4175b640b67cc2e55"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-read-write-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -2003,7 +2030,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-redisearch-adapter",
-                "reference": "39cb0f3ef6f534ed4e2071b6f16cc646ddeec839"
+                "reference": "4143bdf3a0984cbcefc1f887cfda4cda3026588a"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -2011,6 +2038,9 @@
                 "ext-redis": "^5 || ^6.0",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-redisearch-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -2094,7 +2124,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-solr-adapter",
-                "reference": "81fc94ee50b546952483c239649f660814e5a6c2"
+                "reference": "ed78726f0d617a81dc822a1b40e59aa4736601cb"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -2104,6 +2134,9 @@
             },
             "conflict": {
                 "solarium/solarium": "6.x-dev"
+            },
+            "replace": {
+                "schranz-search/seal-solr-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -2188,7 +2221,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-typesense-adapter",
-                "reference": "e2cc1062554955ae940f2b2d9ec059dd682aaece"
+                "reference": "1c9eec69e2eaf68bd0a268a525ba8bc040669194"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -2199,6 +2232,9 @@
             },
             "conflict": {
                 "monolog/monolog": "<2.0"
+            },
+            "replace": {
+                "schranz-search/seal-typesense-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",

--- a/integrations/spiral/composer.json
+++ b/integrations/spiral/composer.json
@@ -69,6 +69,9 @@
         "cmsig/seal-solr-adapter": "^0.6",
         "cmsig/seal-typesense-adapter": "^0.6"
     },
+    "replace": {
+        "schranz-search/spiral-bridge": "self.version"
+    },
     "conflict": {
         "cmsig/seal-algolia-adapter": "<0.6 || >=0.7",
         "cmsig/seal-elasticsearch-adapter": "<0.6 || >=0.7",

--- a/integrations/spiral/composer.lock
+++ b/integrations/spiral/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "59aabafe73b7ad01e66162268381ad87",
+    "content-hash": "094ae2b3dda44935d9a4ee76e8f2c88b",
     "packages": [
         {
             "name": "cmsig/seal",
@@ -12,10 +12,13 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal",
-                "reference": "65e8ff1785e5c47d02a13c068ff45d31c05935d3"
+                "reference": "16c36c2aeb74a061fd60b0eabd37411121b51bc8"
             },
             "require": {
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -2322,13 +2325,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-algolia-adapter",
-                "reference": "ba35c75e21bd11b75955a9fa4e768e12fc1630bf"
+                "reference": "f278cb1f3b39f9714b62700d97682eada26f2eda"
             },
             "require": {
                 "algolia/algoliasearch-client-php": "^4.4",
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-algolia-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -2411,13 +2417,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-elasticsearch-adapter",
-                "reference": "a6ffe8da480ce2a935489c7bf7df11a78b522e0c"
+                "reference": "27c9d6edce3e024e7a3d5edf37e81a883f95311a"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "elasticsearch/elasticsearch": "^8.5.3",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-elasticsearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/psr7": "^2.0",
@@ -2503,7 +2512,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "d783be53a6a41e5d6f587be48127bab61121b3b6"
+                "reference": "3b9b6ad4bbbfbb534f2e590da5f2bddc35ae2350"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -2513,6 +2522,9 @@
             },
             "conflict": {
                 "doctrine/dbal": "<3.6.0"
+            },
+            "replace": {
+                "schranz-search/seal-loupe-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -2595,13 +2607,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-meilisearch-adapter",
-                "reference": "8b2e2b44065a24ef850efec3e2be5829248ae4e6"
+                "reference": "b482ac1c2d277c3c374244cd38e0094a5e38fbcb"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "meilisearch/meilisearch-php": "^1.2",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-meilisearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/guzzle": "^7.5",
@@ -2686,11 +2701,14 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-memory-adapter",
-                "reference": "f60e4a6c42a98640034789db9ee09347f9cc6580"
+                "reference": "264676dad6f706a8482992b02f6bf513554cef2b"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal-memory-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -2772,12 +2790,15 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-multi-adapter",
-                "reference": "5461452681fece1b89cc7ab9662699d2570a8df1"
+                "reference": "1f75abafbff4938c97bdae4907b97d3c3970e821"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-multi-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -2859,13 +2880,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-opensearch-adapter",
-                "reference": "d680d39cf873f0d82a99d7d67ad979222a17beb7"
+                "reference": "ee5d4c6a701e5af30a6e39b469d1fc1990091422"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "opensearch-project/opensearch-php": "^2.0",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-opensearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/psr7": "^2.0",
@@ -2951,12 +2975,15 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-read-write-adapter",
-                "reference": "e9a18f15f5877a34b4ca476ac414a4bb11e41463"
+                "reference": "2964f33b44fdc5a1434f77c4175b640b67cc2e55"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-read-write-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -3038,7 +3065,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-redisearch-adapter",
-                "reference": "39cb0f3ef6f534ed4e2071b6f16cc646ddeec839"
+                "reference": "4143bdf3a0984cbcefc1f887cfda4cda3026588a"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -3046,6 +3073,9 @@
                 "ext-redis": "^5 || ^6.0",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-redisearch-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -3129,7 +3159,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-solr-adapter",
-                "reference": "81fc94ee50b546952483c239649f660814e5a6c2"
+                "reference": "ed78726f0d617a81dc822a1b40e59aa4736601cb"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -3139,6 +3169,9 @@
             },
             "conflict": {
                 "solarium/solarium": "6.x-dev"
+            },
+            "replace": {
+                "schranz-search/seal-solr-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -3223,7 +3256,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-typesense-adapter",
-                "reference": "e2cc1062554955ae940f2b2d9ec059dd682aaece"
+                "reference": "1c9eec69e2eaf68bd0a268a525ba8bc040669194"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -3234,6 +3267,9 @@
             },
             "conflict": {
                 "monolog/monolog": "<2.0"
+            },
+            "replace": {
+                "schranz-search/seal-typesense-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",

--- a/integrations/symfony/composer.json
+++ b/integrations/symfony/composer.json
@@ -69,6 +69,9 @@
         "cmsig/seal-solr-adapter": "^0.6",
         "cmsig/seal-typesense-adapter": "^0.6"
     },
+    "replace": {
+        "schranz-search/symfony-bundle": "self.version"
+    },
     "conflict": {
         "cmsig/seal-algolia-adapter": "<0.6 || >=0.7",
         "cmsig/seal-elasticsearch-adapter": "<0.6 || >=0.7",

--- a/integrations/symfony/composer.lock
+++ b/integrations/symfony/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8248e4bbd89c2ff6b484d2f5fb25f302",
+    "content-hash": "3f27c6f6b9012ae211ae1313334c3a15",
     "packages": [
         {
             "name": "cmsig/seal",
@@ -12,10 +12,13 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal",
-                "reference": "65e8ff1785e5c47d02a13c068ff45d31c05935d3"
+                "reference": "16c36c2aeb74a061fd60b0eabd37411121b51bc8"
             },
             "require": {
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -1935,13 +1938,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-algolia-adapter",
-                "reference": "ba35c75e21bd11b75955a9fa4e768e12fc1630bf"
+                "reference": "f278cb1f3b39f9714b62700d97682eada26f2eda"
             },
             "require": {
                 "algolia/algoliasearch-client-php": "^4.4",
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-algolia-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -2024,13 +2030,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-elasticsearch-adapter",
-                "reference": "a6ffe8da480ce2a935489c7bf7df11a78b522e0c"
+                "reference": "27c9d6edce3e024e7a3d5edf37e81a883f95311a"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "elasticsearch/elasticsearch": "^8.5.3",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-elasticsearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/psr7": "^2.0",
@@ -2116,7 +2125,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "d783be53a6a41e5d6f587be48127bab61121b3b6"
+                "reference": "3b9b6ad4bbbfbb534f2e590da5f2bddc35ae2350"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -2126,6 +2135,9 @@
             },
             "conflict": {
                 "doctrine/dbal": "<3.6.0"
+            },
+            "replace": {
+                "schranz-search/seal-loupe-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -2208,13 +2220,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-meilisearch-adapter",
-                "reference": "8b2e2b44065a24ef850efec3e2be5829248ae4e6"
+                "reference": "b482ac1c2d277c3c374244cd38e0094a5e38fbcb"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "meilisearch/meilisearch-php": "^1.2",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-meilisearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/guzzle": "^7.5",
@@ -2299,11 +2314,14 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-memory-adapter",
-                "reference": "f60e4a6c42a98640034789db9ee09347f9cc6580"
+                "reference": "264676dad6f706a8482992b02f6bf513554cef2b"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal-memory-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -2385,12 +2403,15 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-multi-adapter",
-                "reference": "5461452681fece1b89cc7ab9662699d2570a8df1"
+                "reference": "1f75abafbff4938c97bdae4907b97d3c3970e821"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-multi-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -2472,13 +2493,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-opensearch-adapter",
-                "reference": "d680d39cf873f0d82a99d7d67ad979222a17beb7"
+                "reference": "ee5d4c6a701e5af30a6e39b469d1fc1990091422"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "opensearch-project/opensearch-php": "^2.0",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-opensearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/psr7": "^2.0",
@@ -2564,12 +2588,15 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-read-write-adapter",
-                "reference": "e9a18f15f5877a34b4ca476ac414a4bb11e41463"
+                "reference": "2964f33b44fdc5a1434f77c4175b640b67cc2e55"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-read-write-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -2651,7 +2678,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-redisearch-adapter",
-                "reference": "39cb0f3ef6f534ed4e2071b6f16cc646ddeec839"
+                "reference": "4143bdf3a0984cbcefc1f887cfda4cda3026588a"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -2659,6 +2686,9 @@
                 "ext-redis": "^5 || ^6.0",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-redisearch-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -2742,7 +2772,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-solr-adapter",
-                "reference": "81fc94ee50b546952483c239649f660814e5a6c2"
+                "reference": "ed78726f0d617a81dc822a1b40e59aa4736601cb"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -2752,6 +2782,9 @@
             },
             "conflict": {
                 "solarium/solarium": "6.x-dev"
+            },
+            "replace": {
+                "schranz-search/seal-solr-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -2836,7 +2869,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-typesense-adapter",
-                "reference": "e2cc1062554955ae940f2b2d9ec059dd682aaece"
+                "reference": "1c9eec69e2eaf68bd0a268a525ba8bc040669194"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -2847,6 +2880,9 @@
             },
             "conflict": {
                 "monolog/monolog": "<2.0"
+            },
+            "replace": {
+                "schranz-search/seal-typesense-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",

--- a/integrations/yii/composer.json
+++ b/integrations/yii/composer.json
@@ -68,6 +68,9 @@
         "cmsig/seal-solr-adapter": "^0.6",
         "cmsig/seal-typesense-adapter": "^0.6"
     },
+    "replace": {
+        "schranz-search/yii-module": "self.version"
+    },
     "conflict": {
         "cmsig/seal-algolia-adapter": "<0.6 || >=0.7",
         "cmsig/seal-elasticsearch-adapter": "<0.6 || >=0.7",

--- a/integrations/yii/composer.lock
+++ b/integrations/yii/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d201f2c100d28f6a5a9de59c87f91078",
+    "content-hash": "14b81ce6dd6374e5f2aa16684f13f59f",
     "packages": [
         {
             "name": "cmsig/seal",
@@ -12,10 +12,13 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal",
-                "reference": "65e8ff1785e5c47d02a13c068ff45d31c05935d3"
+                "reference": "16c36c2aeb74a061fd60b0eabd37411121b51bc8"
             },
             "require": {
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -1414,13 +1417,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-algolia-adapter",
-                "reference": "ba35c75e21bd11b75955a9fa4e768e12fc1630bf"
+                "reference": "f278cb1f3b39f9714b62700d97682eada26f2eda"
             },
             "require": {
                 "algolia/algoliasearch-client-php": "^4.4",
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-algolia-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -1503,13 +1509,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-elasticsearch-adapter",
-                "reference": "a6ffe8da480ce2a935489c7bf7df11a78b522e0c"
+                "reference": "27c9d6edce3e024e7a3d5edf37e81a883f95311a"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "elasticsearch/elasticsearch": "^8.5.3",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-elasticsearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/psr7": "^2.0",
@@ -1595,7 +1604,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "d783be53a6a41e5d6f587be48127bab61121b3b6"
+                "reference": "3b9b6ad4bbbfbb534f2e590da5f2bddc35ae2350"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -1605,6 +1614,9 @@
             },
             "conflict": {
                 "doctrine/dbal": "<3.6.0"
+            },
+            "replace": {
+                "schranz-search/seal-loupe-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -1687,13 +1699,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-meilisearch-adapter",
-                "reference": "8b2e2b44065a24ef850efec3e2be5829248ae4e6"
+                "reference": "b482ac1c2d277c3c374244cd38e0094a5e38fbcb"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "meilisearch/meilisearch-php": "^1.2",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-meilisearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/guzzle": "^7.5",
@@ -1778,11 +1793,14 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-memory-adapter",
-                "reference": "f60e4a6c42a98640034789db9ee09347f9cc6580"
+                "reference": "264676dad6f706a8482992b02f6bf513554cef2b"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal-memory-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -1864,12 +1882,15 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-multi-adapter",
-                "reference": "5461452681fece1b89cc7ab9662699d2570a8df1"
+                "reference": "1f75abafbff4938c97bdae4907b97d3c3970e821"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-multi-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -1951,13 +1972,16 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-opensearch-adapter",
-                "reference": "d680d39cf873f0d82a99d7d67ad979222a17beb7"
+                "reference": "ee5d4c6a701e5af30a6e39b469d1fc1990091422"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "opensearch-project/opensearch-php": "^2.0",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-opensearch-adapter": "self.version"
             },
             "require-dev": {
                 "guzzlehttp/psr7": "^2.0",
@@ -2043,12 +2067,15 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-read-write-adapter",
-                "reference": "e9a18f15f5877a34b4ca476ac414a4bb11e41463"
+                "reference": "2964f33b44fdc5a1434f77c4175b640b67cc2e55"
             },
             "require": {
                 "cmsig/seal": "^0.6",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-read-write-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -2130,7 +2157,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-redisearch-adapter",
-                "reference": "39cb0f3ef6f534ed4e2071b6f16cc646ddeec839"
+                "reference": "4143bdf3a0984cbcefc1f887cfda4cda3026588a"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -2138,6 +2165,9 @@
                 "ext-redis": "^5 || ^6.0",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "schranz-search/seal-redisearch-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -2221,7 +2251,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-solr-adapter",
-                "reference": "81fc94ee50b546952483c239649f660814e5a6c2"
+                "reference": "ed78726f0d617a81dc822a1b40e59aa4736601cb"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -2231,6 +2261,9 @@
             },
             "conflict": {
                 "solarium/solarium": "6.x-dev"
+            },
+            "replace": {
+                "schranz-search/seal-solr-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",
@@ -2315,7 +2348,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-typesense-adapter",
-                "reference": "e2cc1062554955ae940f2b2d9ec059dd682aaece"
+                "reference": "1c9eec69e2eaf68bd0a268a525ba8bc040669194"
             },
             "require": {
                 "cmsig/seal": "^0.6",
@@ -2326,6 +2359,9 @@
             },
             "conflict": {
                 "monolog/monolog": "<2.0"
+            },
+            "replace": {
+                "schranz-search/seal-typesense-adapter": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",

--- a/packages/seal-algolia-adapter/composer.json
+++ b/packages/seal-algolia-adapter/composer.json
@@ -40,6 +40,9 @@
         "phpunit/phpunit": "^10.3",
         "rector/rector": "^1.0"
     },
+    "replace": {
+        "schranz-search/seal-algolia-adapter": "self.version"
+    },
     "scripts": {
         "test": [
             "Composer\\Config::disableProcessTimeout",

--- a/packages/seal-algolia-adapter/composer.lock
+++ b/packages/seal-algolia-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ba232f1d4a9457b052ed9053e6882e82",
+    "content-hash": "64294d26965d641b56260e19e6aedaa9",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -79,10 +79,13 @@
             "dist": {
                 "type": "path",
                 "url": "./../seal",
-                "reference": "65e8ff1785e5c47d02a13c068ff45d31c05935d3"
+                "reference": "16c36c2aeb74a061fd60b0eabd37411121b51bc8"
             },
             "require": {
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",

--- a/packages/seal-elasticsearch-adapter/composer.json
+++ b/packages/seal-elasticsearch-adapter/composer.json
@@ -43,6 +43,9 @@
         "phpunit/phpunit": "^10.3",
         "rector/rector": "^1.0"
     },
+    "replace": {
+        "schranz-search/seal-elasticsearch-adapter": "self.version"
+    },
     "scripts": {
         "test": [
             "Composer\\Config::disableProcessTimeout",

--- a/packages/seal-elasticsearch-adapter/composer.lock
+++ b/packages/seal-elasticsearch-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f85e1d74ff8990be2127ebfb00b6a7fe",
+    "content-hash": "cca9bb0fdf5e08c2a68dd0135cbe05c2",
     "packages": [
         {
             "name": "cmsig/seal",
@@ -12,10 +12,13 @@
             "dist": {
                 "type": "path",
                 "url": "./../seal",
-                "reference": "65e8ff1785e5c47d02a13c068ff45d31c05935d3"
+                "reference": "16c36c2aeb74a061fd60b0eabd37411121b51bc8"
             },
             "require": {
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",

--- a/packages/seal-loupe-adapter/composer.json
+++ b/packages/seal-loupe-adapter/composer.json
@@ -43,6 +43,9 @@
         "phpunit/phpunit": "^10.3",
         "rector/rector": "^1.0"
     },
+    "replace": {
+        "schranz-search/seal-loupe-adapter": "self.version"
+    },
     "scripts": {
         "test": [
             "Composer\\Config::disableProcessTimeout",

--- a/packages/seal-loupe-adapter/composer.lock
+++ b/packages/seal-loupe-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0a26495ead8832aed4aec3fcbdf1d4ea",
+    "content-hash": "cdc8a3a23b345b1edf2fc884b4b88617",
     "packages": [
         {
             "name": "cmsig/seal",
@@ -12,10 +12,13 @@
             "dist": {
                 "type": "path",
                 "url": "./../seal",
-                "reference": "65e8ff1785e5c47d02a13c068ff45d31c05935d3"
+                "reference": "16c36c2aeb74a061fd60b0eabd37411121b51bc8"
             },
             "require": {
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",

--- a/packages/seal-meilisearch-adapter/composer.json
+++ b/packages/seal-meilisearch-adapter/composer.json
@@ -42,6 +42,9 @@
         "phpunit/phpunit": "^10.3",
         "rector/rector": "^1.0"
     },
+    "replace": {
+        "schranz-search/seal-meilisearch-adapter": "self.version"
+    },
     "scripts": {
         "test": [
             "Composer\\Config::disableProcessTimeout",

--- a/packages/seal-meilisearch-adapter/composer.lock
+++ b/packages/seal-meilisearch-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b8a57d78e41fe8a62a26ca560c814a4d",
+    "content-hash": "c207082c4ffeede83379e70fc76ba09c",
     "packages": [
         {
             "name": "cmsig/seal",
@@ -12,10 +12,13 @@
             "dist": {
                 "type": "path",
                 "url": "./../seal",
-                "reference": "65e8ff1785e5c47d02a13c068ff45d31c05935d3"
+                "reference": "16c36c2aeb74a061fd60b0eabd37411121b51bc8"
             },
             "require": {
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",

--- a/packages/seal-memory-adapter/composer.json
+++ b/packages/seal-memory-adapter/composer.json
@@ -37,6 +37,9 @@
         "phpunit/phpunit": "^10.3",
         "rector/rector": "^1.0"
     },
+    "replace": {
+        "schranz-search/seal-memory-adapter": "self.version"
+    },
     "scripts": {
         "test": [
             "Composer\\Config::disableProcessTimeout",

--- a/packages/seal-memory-adapter/composer.lock
+++ b/packages/seal-memory-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2033b521115334bf71543ec831670e24",
+    "content-hash": "27ec8b6456d74f8f55382b3f4e089db4",
     "packages": [
         {
             "name": "cmsig/seal",
@@ -12,10 +12,13 @@
             "dist": {
                 "type": "path",
                 "url": "./../seal",
-                "reference": "65e8ff1785e5c47d02a13c068ff45d31c05935d3"
+                "reference": "16c36c2aeb74a061fd60b0eabd37411121b51bc8"
             },
             "require": {
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",

--- a/packages/seal-multi-adapter/composer.json
+++ b/packages/seal-multi-adapter/composer.json
@@ -38,6 +38,9 @@
         "phpunit/phpunit": "^10.3",
         "rector/rector": "^1.0"
     },
+    "replace": {
+        "schranz-search/seal-multi-adapter": "self.version"
+    },
     "scripts": {
         "test": [
             "Composer\\Config::disableProcessTimeout",

--- a/packages/seal-multi-adapter/composer.lock
+++ b/packages/seal-multi-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "be9d60d60b02cdbeb153bbc65ca8404c",
+    "content-hash": "332d988fe4f7e7814f4ce12d1dd52568",
     "packages": [
         {
             "name": "cmsig/seal",
@@ -12,10 +12,13 @@
             "dist": {
                 "type": "path",
                 "url": "./../seal",
-                "reference": "65e8ff1785e5c47d02a13c068ff45d31c05935d3"
+                "reference": "16c36c2aeb74a061fd60b0eabd37411121b51bc8"
             },
             "require": {
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",

--- a/packages/seal-opensearch-adapter/composer.json
+++ b/packages/seal-opensearch-adapter/composer.json
@@ -43,6 +43,9 @@
         "phpunit/phpunit": "^10.3",
         "rector/rector": "^1.0"
     },
+    "replace": {
+        "schranz-search/seal-opensearch-adapter": "self.version"
+    },
     "scripts": {
         "test": [
             "Composer\\Config::disableProcessTimeout",

--- a/packages/seal-opensearch-adapter/composer.lock
+++ b/packages/seal-opensearch-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "27297a947b8b90e8027334ff8d688158",
+    "content-hash": "fa301b5fcfe31b5f1704314860501603",
     "packages": [
         {
             "name": "cmsig/seal",
@@ -12,10 +12,13 @@
             "dist": {
                 "type": "path",
                 "url": "./../seal",
-                "reference": "65e8ff1785e5c47d02a13c068ff45d31c05935d3"
+                "reference": "16c36c2aeb74a061fd60b0eabd37411121b51bc8"
             },
             "require": {
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",

--- a/packages/seal-read-write-adapter/composer.json
+++ b/packages/seal-read-write-adapter/composer.json
@@ -38,6 +38,9 @@
         "phpunit/phpunit": "^10.3",
         "rector/rector": "^1.0"
     },
+    "replace": {
+        "schranz-search/seal-read-write-adapter": "self.version"
+    },
     "scripts": {
         "test": [
             "Composer\\Config::disableProcessTimeout",

--- a/packages/seal-read-write-adapter/composer.lock
+++ b/packages/seal-read-write-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "86cdba011df4a0ee7ab1cae3b7f6eecd",
+    "content-hash": "e5348fd1a945996e917004efc94f8534",
     "packages": [
         {
             "name": "cmsig/seal",
@@ -12,10 +12,13 @@
             "dist": {
                 "type": "path",
                 "url": "./../seal",
-                "reference": "65e8ff1785e5c47d02a13c068ff45d31c05935d3"
+                "reference": "16c36c2aeb74a061fd60b0eabd37411121b51bc8"
             },
             "require": {
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",

--- a/packages/seal-redisearch-adapter/composer.json
+++ b/packages/seal-redisearch-adapter/composer.json
@@ -42,6 +42,9 @@
         "phpunit/phpunit": "^10.3",
         "rector/rector": "^1.0"
     },
+    "replace": {
+        "schranz-search/seal-redisearch-adapter": "self.version"
+    },
     "scripts": {
         "test": [
             "Composer\\Config::disableProcessTimeout",

--- a/packages/seal-redisearch-adapter/composer.lock
+++ b/packages/seal-redisearch-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fe7c023ca268d1e0f216f6b4765c0f0c",
+    "content-hash": "6a98019d607b54fda2a74053f5525f15",
     "packages": [
         {
             "name": "cmsig/seal",
@@ -12,10 +12,13 @@
             "dist": {
                 "type": "path",
                 "url": "./../seal",
-                "reference": "65e8ff1785e5c47d02a13c068ff45d31c05935d3"
+                "reference": "16c36c2aeb74a061fd60b0eabd37411121b51bc8"
             },
             "require": {
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",

--- a/packages/seal-solr-adapter/composer.json
+++ b/packages/seal-solr-adapter/composer.json
@@ -45,6 +45,9 @@
     "conflict": {
         "solarium/solarium": "6.x-dev"
     },
+    "replace": {
+        "schranz-search/seal-solr-adapter": "self.version"
+    },
     "scripts": {
         "test": [
             "Composer\\Config::disableProcessTimeout",

--- a/packages/seal-solr-adapter/composer.lock
+++ b/packages/seal-solr-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c96470c00ff90000102552f218523054",
+    "content-hash": "de91b3a238933d12c8d0e8a8357edbaf",
     "packages": [
         {
             "name": "cmsig/seal",
@@ -12,10 +12,13 @@
             "dist": {
                 "type": "path",
                 "url": "./../seal",
-                "reference": "65e8ff1785e5c47d02a13c068ff45d31c05935d3"
+                "reference": "16c36c2aeb74a061fd60b0eabd37411121b51bc8"
             },
             "require": {
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",

--- a/packages/seal-typesense-adapter/composer.json
+++ b/packages/seal-typesense-adapter/composer.json
@@ -46,6 +46,9 @@
     "conflict": {
         "monolog/monolog": "<2.0"
     },
+    "replace": {
+        "schranz-search/seal-typesense-adapter": "self.version"
+    },
     "scripts": {
         "test": [
             "Composer\\Config::disableProcessTimeout",

--- a/packages/seal-typesense-adapter/composer.lock
+++ b/packages/seal-typesense-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "344b85a7e5226bfff0fc82765bcdc296",
+    "content-hash": "eacf8f3516d43a8dcea0b06cef23009b",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -79,10 +79,13 @@
             "dist": {
                 "type": "path",
                 "url": "./../seal",
-                "reference": "65e8ff1785e5c47d02a13c068ff45d31c05935d3"
+                "reference": "16c36c2aeb74a061fd60b0eabd37411121b51bc8"
             },
             "require": {
                 "php": "^8.1"
+            },
+            "replace": {
+                "schranz-search/seal": "self.version"
             },
             "require-dev": {
                 "php-cs-fixer/shim": "^3.51",

--- a/packages/seal/composer.json
+++ b/packages/seal/composer.json
@@ -45,6 +45,9 @@
         "phpunit/phpunit": "^10.3",
         "rector/rector": "^1.0"
     },
+    "replace": {
+        "schranz-search/seal": "self.version"
+    },
     "scripts": {
         "test": [
             "Composer\\Config::disableProcessTimeout",

--- a/packages/seal/composer.lock
+++ b/packages/seal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f0ae6c4ec9d5181b2614cf350e9ad57e",
+    "content-hash": "3e312803e7ba53b6220a506e7ca02a70",
     "packages": [],
     "packages-dev": [
         {


### PR DESCRIPTION
after moving repositories in https://github.com/PHP-CMSIG/search/pull/458 to php-cmsig organisation. we can make migration easier by add replace to the composer.json.