### PR TITLE
 Move Mono Repo hint to the top of the sub readme files

### DIFF
--- a/integrations/laravel/README.md
+++ b/integrations/laravel/README.md
@@ -1,3 +1,6 @@
+> **Note**:
+> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>
@@ -10,9 +13,6 @@
 <br />
 
 Integration of the CMS-IG — Search Engine Abstraction Layer (SEAL) into Laravel.
-
-> **Note**:
-> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
 > **Note**:
 > This project is heavily under development and any feedback is greatly appreciated.

--- a/integrations/laravel/README.md
+++ b/integrations/laravel/README.md
@@ -1,6 +1,8 @@
 > **Note**:
 > This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
+---
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>

--- a/integrations/mezzio/README.md
+++ b/integrations/mezzio/README.md
@@ -1,3 +1,6 @@
+> **Note**:
+> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>
@@ -10,9 +13,6 @@
 <br />
 
 Integration of the CMS-IG — Search Engine Abstraction Layer (SEAL) into Mezzio.
-
-> **Note**:
-> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
 > **Note**:
 > This project is heavily under development and any feedback is greatly appreciated.

--- a/integrations/mezzio/README.md
+++ b/integrations/mezzio/README.md
@@ -1,6 +1,8 @@
 > **Note**:
 > This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
+---
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>

--- a/integrations/spiral/README.md
+++ b/integrations/spiral/README.md
@@ -1,3 +1,6 @@
+> **Note**:
+> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>
@@ -10,9 +13,6 @@
 <br />
 
 Integration of the CMS-IG — Search Engine Abstraction Layer (SEAL) into Spiral.
-
-> **Note**:
-> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
 > **Note**:
 > This project is heavily under development and any feedback is greatly appreciated.

--- a/integrations/spiral/README.md
+++ b/integrations/spiral/README.md
@@ -1,6 +1,8 @@
 > **Note**:
 > This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
+---
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>

--- a/integrations/symfony/README.md
+++ b/integrations/symfony/README.md
@@ -1,3 +1,6 @@
+> **Note**:
+> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>
@@ -10,9 +13,6 @@
 <br />
 
 Integration of the CMS-IG — Search Engine Abstraction Layer (SEAL) into Symfony.
-
-> **Note**:
-> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
 > **Note**:
 > This project is heavily under development and any feedback is greatly appreciated.

--- a/integrations/symfony/README.md
+++ b/integrations/symfony/README.md
@@ -1,6 +1,8 @@
 > **Note**:
 > This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
+---
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>

--- a/integrations/yii/README.md
+++ b/integrations/yii/README.md
@@ -1,3 +1,6 @@
+> **Note**:
+> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>
@@ -10,9 +13,6 @@
 <br />
 
 Integration of the CMS-IG — Search Engine Abstraction Layer (SEAL) into Yii.
-
-> **Note**:
-> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
 > **Note**:
 > This project is heavily under development and any feedback is greatly appreciated.

--- a/integrations/yii/README.md
+++ b/integrations/yii/README.md
@@ -1,6 +1,8 @@
 > **Note**:
 > This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
+---
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>

--- a/packages/seal-algolia-adapter/README.md
+++ b/packages/seal-algolia-adapter/README.md
@@ -1,3 +1,6 @@
+> **Note**:
+> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>
@@ -10,9 +13,6 @@
 <br />
 
 The `AlgoliaAdapter` write the documents into the [Algolia](https://www.algolia.com/de/) SaaS.
-
-> **Note**:
-> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
 > **Note**:
 > This project is heavily under development and any feedback is greatly appreciated.

--- a/packages/seal-algolia-adapter/README.md
+++ b/packages/seal-algolia-adapter/README.md
@@ -1,6 +1,8 @@
 > **Note**:
 > This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
+---
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>

--- a/packages/seal-elasticsearch-adapter/README.md
+++ b/packages/seal-elasticsearch-adapter/README.md
@@ -1,6 +1,8 @@
 > **Note**:
 > This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
+---
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>

--- a/packages/seal-elasticsearch-adapter/README.md
+++ b/packages/seal-elasticsearch-adapter/README.md
@@ -1,3 +1,6 @@
+> **Note**:
+> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>
@@ -10,9 +13,6 @@
 <br />
 
 The `ElasticsearchAdapter` write the documents into an [Elasticsearch](https://github.com/elastic/elasticsearch) server instance.
-
-> **Note**:
-> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
 > **Note**:
 > This project is heavily under development and any feedback is greatly appreciated.

--- a/packages/seal-loupe-adapter/README.md
+++ b/packages/seal-loupe-adapter/README.md
@@ -1,3 +1,6 @@
+> **Note**:
+> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>
@@ -10,9 +13,6 @@
 <br />
 
 The `LoupeAdapter` write the documents into a [Loupe](https://github.com/loupe-php/loupe) SQLite instance.
-
-> **Note**:
-> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
 > **Note**:
 > This project is heavily under development and any feedback is greatly appreciated.

--- a/packages/seal-loupe-adapter/README.md
+++ b/packages/seal-loupe-adapter/README.md
@@ -1,6 +1,8 @@
 > **Note**:
 > This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
+---
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>

--- a/packages/seal-meilisearch-adapter/README.md
+++ b/packages/seal-meilisearch-adapter/README.md
@@ -1,3 +1,6 @@
+> **Note**:
+> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>
@@ -10,9 +13,6 @@
 <br />
 
 The `MeilisearchAdapter` write the documents into a [Meilisearch](https://github.com/meilisearch/meilisearch) server instance.
-
-> **Note**:
-> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
 > **Note**:
 > This project is heavily under development and any feedback is greatly appreciated.

--- a/packages/seal-meilisearch-adapter/README.md
+++ b/packages/seal-meilisearch-adapter/README.md
@@ -1,6 +1,8 @@
 > **Note**:
 > This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
+---
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>

--- a/packages/seal-memory-adapter/README.md
+++ b/packages/seal-memory-adapter/README.md
@@ -1,3 +1,6 @@
+> **Note**:
+> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>
@@ -10,9 +13,6 @@
 <br />
 
 The `MemoryAdapter` write the documents into an in-memory array.
-
-> **Note**:
-> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
 > **Note**:
 > This project is heavily under development and any feedback is greatly appreciated.

--- a/packages/seal-memory-adapter/README.md
+++ b/packages/seal-memory-adapter/README.md
@@ -1,6 +1,8 @@
 > **Note**:
 > This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
+---
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>

--- a/packages/seal-multi-adapter/README.md
+++ b/packages/seal-multi-adapter/README.md
@@ -1,3 +1,6 @@
+> **Note**:
+> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>
@@ -10,9 +13,6 @@
 <br />
 
 The `MultiAdapter` allows to write into multiple adapters.
-
-> **Note**:
-> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
 > **Note**:
 > This project is heavily under development and any feedback is greatly appreciated.

--- a/packages/seal-multi-adapter/README.md
+++ b/packages/seal-multi-adapter/README.md
@@ -1,6 +1,8 @@
 > **Note**:
 > This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
+---
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>

--- a/packages/seal-opensearch-adapter/README.md
+++ b/packages/seal-opensearch-adapter/README.md
@@ -1,3 +1,6 @@
+> **Note**:
+> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>
@@ -10,9 +13,6 @@
 <br />
 
 The `OpensearchAdapter` write the documents into an [Opensearch](https://github.com/opensearch-project/OpenSearch) server instance.
-
-> **Note**:
-> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
 > **Note**:
 > This project is heavily under development and any feedback is greatly appreciated.

--- a/packages/seal-opensearch-adapter/README.md
+++ b/packages/seal-opensearch-adapter/README.md
@@ -1,6 +1,8 @@
 > **Note**:
 > This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
+---
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>

--- a/packages/seal-read-write-adapter/README.md
+++ b/packages/seal-read-write-adapter/README.md
@@ -1,3 +1,6 @@
+> **Note**:
+> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>
@@ -12,9 +15,6 @@
 The `ReadWriteAdapter` allows to use one adapter instance for reading
 and one for writing. This is useful if you want to reindex something
 without a downtime.
-
-> **Note**:
-> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
 > **Note**:
 > This project is heavily under development and any feedback is greatly appreciated.

--- a/packages/seal-read-write-adapter/README.md
+++ b/packages/seal-read-write-adapter/README.md
@@ -1,6 +1,8 @@
 > **Note**:
 > This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
+---
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>

--- a/packages/seal-redisearch-adapter/README.md
+++ b/packages/seal-redisearch-adapter/README.md
@@ -1,3 +1,6 @@
+> **Note**:
+> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>
@@ -10,9 +13,6 @@
 <br />
 
 The `RediSearchAdapter` write the documents into a [RediSearch](https://redis.io/docs/stack/search/) server instance. The Redis Server requires to run with the RedisSearch and JSON module.
-
-> **Note**:
-> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
 > **Note**:
 > This project is heavily under development and any feedback is greatly appreciated.

--- a/packages/seal-redisearch-adapter/README.md
+++ b/packages/seal-redisearch-adapter/README.md
@@ -1,6 +1,8 @@
 > **Note**:
 > This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
+---
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>

--- a/packages/seal-solr-adapter/README.md
+++ b/packages/seal-solr-adapter/README.md
@@ -1,6 +1,8 @@
 > **Note**:
 > This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
+---
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>

--- a/packages/seal-solr-adapter/README.md
+++ b/packages/seal-solr-adapter/README.md
@@ -1,3 +1,6 @@
+> **Note**:
+> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>
@@ -10,9 +13,6 @@
 <br />
 
 The `SolrAdapter` write the documents into a [Apache Solr](https://github.com/apache/solr) server instance. The Apache Solr server is running in the [`cloud mode`](https://solr.apache.org/guide/solr/latest/getting-started/tutorial-solrcloud.html) as we require to use collections for indexes.
-
-> **Note**:
-> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
 > **Note**:
 > This project is heavily under development and any feedback is greatly appreciated.

--- a/packages/seal-typesense-adapter/README.md
+++ b/packages/seal-typesense-adapter/README.md
@@ -1,3 +1,6 @@
+> **Note**:
+> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>
@@ -10,9 +13,6 @@
 <br />
 
 The `TypesenseAdapter` write the documents into a [Typesense](https://github.com/typesense/typesense) server instance.
-
-> **Note**:
-> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
 > **Note**:
 > This project is heavily under development and any feedback is greatly appreciated.

--- a/packages/seal-typesense-adapter/README.md
+++ b/packages/seal-typesense-adapter/README.md
@@ -1,6 +1,8 @@
 > **Note**:
 > This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
+---
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>

--- a/packages/seal/README.md
+++ b/packages/seal/README.md
@@ -1,3 +1,6 @@
+> **Note**:
+> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>
@@ -17,9 +20,6 @@
 
 This package was highly inspired by [Doctrine DBAL](https://github.com/doctrine/dbal)
 and [Flysystem](https://github.com/thephpleague/flysystem).
-
-> **Note**:
-> This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
 > **Note**:
 > This project is heavily under development and any feedback is greatly appreciated.

--- a/packages/seal/README.md
+++ b/packages/seal/README.md
@@ -1,6 +1,8 @@
 > **Note**:
 > This is part of the `cmsig/search` project create issues in the [main repository](https://github.com/php-cmsig/search).
 
+---
+
 <div align="center">
     <img alt="SEAL Logo with an abstract seal sitting on a telescope." src="https://avatars.githubusercontent.com/u/120221538?s=400&v=6" width="200" height="200">
 </div>


### PR DESCRIPTION
Make it more clear where new issues and pull requests can be created.