### PR TITLE
Fix CI issues checking out old commits

### DIFF
--- a/.github/workflows/callable-test.yml
+++ b/.github/workflows/callable-test.yml
@@ -31,9 +31,6 @@ jobs:
                       dependency-versions: 'highest'
 
         steps:
-            - name: Wait for 5 seconds
-              run: sleep 5
-
             - name: Output infos
               run: |
                   echo "${{ github.event.pull_request.merge_commit_sha }}"
@@ -42,7 +39,7 @@ jobs:
             - name: Checkout project
               uses: actions/checkout@v4
               with:
-                  ref: "${{ github.event.pull_request.merge_commit_sha }}"
+                  ref: "${{ github.event.pull_request.head.sha }}"
 
             - name: Git infos
               run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,12 +13,20 @@ jobs:
     docs:
         runs-on: ubuntu-latest
         steps:
-            - name: Wait for 5 seconds
-              run: sleep 5
+            - name: Output infos
+              run: |
+                  echo "${{ github.event.pull_request.merge_commit_sha }}"
+                  echo "${{ github.event.pull_request.head.sha }}"
 
-            - uses: actions/checkout@v4
+            - name: Checkout project
+              uses: actions/checkout@v4
               with:
-                  ref: "${{ github.event.pull_request.merge_commit_sha }}"
+                  ref: "${{ github.event.pull_request.head.sha }}"
+
+            - name: Git infos
+              run: |
+                  git rev-parse HEAD
+                  git branch --show-current
 
             - uses: actions/setup-python@v5
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,13 +12,20 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - name: Wait for 5 seconds
-              run: sleep 5
+            - name: Output infos
+              run: |
+                  echo "${{ github.event.pull_request.merge_commit_sha }}"
+                  echo "${{ github.event.pull_request.head.sha }}"
 
             - name: Checkout project
               uses: actions/checkout@v4
               with:
-                  ref: "${{ github.event.pull_request.merge_commit_sha }}"
+                  ref: "${{ github.event.pull_request.head.sha }}"
+
+            - name: Git infos
+              run: |
+                  git rev-parse HEAD
+                  git branch --show-current
 
             - name: Install and configure PHP
               uses: shivammathur/setup-php@v2

--- a/integrations/spiral/src/Console/ReindexCommand.php
+++ b/integrations/spiral/src/Console/ReindexCommand.php
@@ -61,9 +61,9 @@ final class ReindexCommand extends Command
         EngineRegistry $engineRegistry,
     ): int {
         /** @var \DateTimeImmutable|null $dateTimeBoundary */
-        $dateTimeBoundary = $this->datetimeBoundary ? new \DateTimeImmutable((string) $this->datetimeBoundary) : null;
+        $dateTimeBoundary = $this->datetimeBoundary ? new \DateTimeImmutable((string) $this->datetimeBoundary) : null; // @phpstan-ignore-line
         /** @var array<string> $identifiers */
-        $identifiers = \array_filter(\explode(',', (string) $this->identifiers));
+        $identifiers = \array_filter(\explode(',', (string) $this->identifiers)); // @phpstan-ignore-line
 
         $reindexConfig = ReindexConfig::create()
             ->withIndex($this->indexName)


### PR DESCRIPTION
The used `github.event.pull_request.merge_commit_sha` seems to be broken and has the old commit always. Instead we try now use the `github.event.pull_request.head.sha`. This is required because we use secrets and need so use `pull_request_target` instead of `pull_request` event which behaves differently.