### PR TITLE
Introduce IndexNotFoundException (BC Break)

### DIFF
--- a/.examples/laravel/docker-compose.yml
+++ b/.examples/laravel/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       discovery.type: single-node
       xpack.security.enabled: 'false'
       cluster.routing.allocation.disk.threshold_enabled: 'false'
+      action.auto_create_index: 'false'
     ports:
       - "9200:9200"
     healthcheck:
@@ -34,6 +35,7 @@ services:
     environment:
       discovery.type: single-node
       cluster.routing.allocation.disk.threshold_enabled: 'false'
+      action.auto_create_index: 'false'
       DISABLE_SECURITY_PLUGIN: true
       http.port: 9201
     ports:

--- a/.examples/mezzio/docker-compose.yml
+++ b/.examples/mezzio/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       discovery.type: single-node
       xpack.security.enabled: 'false'
       cluster.routing.allocation.disk.threshold_enabled: 'false'
+      action.auto_create_index: 'false'
     ports:
       - "9200:9200"
     healthcheck:
@@ -34,6 +35,7 @@ services:
     environment:
       discovery.type: single-node
       cluster.routing.allocation.disk.threshold_enabled: 'false'
+      action.auto_create_index: 'false'
       DISABLE_SECURITY_PLUGIN: true
       http.port: 9201
     ports:

--- a/.examples/spiral/docker-compose.yml
+++ b/.examples/spiral/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       discovery.type: single-node
       xpack.security.enabled: 'false'
       cluster.routing.allocation.disk.threshold_enabled: 'false'
+      action.auto_create_index: 'false'
     ports:
       - "9200:9200"
     healthcheck:
@@ -34,6 +35,7 @@ services:
     environment:
       discovery.type: single-node
       cluster.routing.allocation.disk.threshold_enabled: 'false'
+      action.auto_create_index: 'false'
       DISABLE_SECURITY_PLUGIN: true
       http.port: 9201
     ports:

--- a/.examples/symfony/docker-compose.yml
+++ b/.examples/symfony/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       discovery.type: single-node
       xpack.security.enabled: 'false'
       cluster.routing.allocation.disk.threshold_enabled: 'false'
+      action.auto_create_index: 'false'
     ports:
       - "9200:9200"
     healthcheck:
@@ -34,6 +35,7 @@ services:
     environment:
       discovery.type: single-node
       cluster.routing.allocation.disk.threshold_enabled: 'false'
+      action.auto_create_index: 'false'
       DISABLE_SECURITY_PLUGIN: true
       http.port: 9201
     ports:

--- a/.examples/yii/docker-compose.yml
+++ b/.examples/yii/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       discovery.type: single-node
       xpack.security.enabled: 'false'
       cluster.routing.allocation.disk.threshold_enabled: 'false'
+      action.auto_create_index: 'false'
     ports:
       - "9200:9200"
     healthcheck:
@@ -34,6 +35,7 @@ services:
     environment:
       discovery.type: single-node
       cluster.routing.allocation.disk.threshold_enabled: 'false'
+      action.auto_create_index: 'false'
       DISABLE_SECURITY_PLUGIN: true
       http.port: 9201
     ports:

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -1511,6 +1511,7 @@ search engine.
                   discovery.type: single-node
                   xpack.security.enabled: 'false'
                   cluster.routing.allocation.disk.threshold_enabled: 'false'
+                  action.auto_create_index: 'false'
                 ports:
                   - "9200:9200"
                 healthcheck:
@@ -1547,6 +1548,7 @@ search engine.
                 environment:
                   discovery.type: single-node
                   cluster.routing.allocation.disk.threshold_enabled: 'false'
+                  action.auto_create_index: 'false'
                   DISABLE_SECURITY_PLUGIN: true
                 ports:
                   - "9200:9200"

--- a/packages/seal-elasticsearch-adapter/docker-compose.yml
+++ b/packages/seal-elasticsearch-adapter/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       discovery.type: single-node
       xpack.security.enabled: 'false'
       cluster.routing.allocation.disk.threshold_enabled: 'false'
+      action.auto_create_index: 'false'
     ports:
       - "9200:9200"
     healthcheck:

--- a/packages/seal-loupe-adapter/src/LoupeHelper.php
+++ b/packages/seal-loupe-adapter/src/LoupeHelper.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CmsIg\Seal\Adapter\Loupe;
 
+use CmsIg\Seal\Schema\Exception\IndexNotFoundException;
 use CmsIg\Seal\Schema\Index;
 use Loupe\Loupe\Configuration;
 use Loupe\Loupe\Loupe;
@@ -75,6 +76,8 @@ final class LoupeHelper
             }
 
             \rmdir($indexDirectory);
+
+            unset($this->loupe[$index->name]);
         }
     }
 
@@ -112,7 +115,10 @@ final class LoupeHelper
             $configurationFile = $this->getConfigurationFile($index);
 
             if (!\file_exists($configurationFile)) {
-                throw new \LogicException('Configuration need to exist before creating Loupe instance.');
+                throw new IndexNotFoundException(
+                    $index->name,
+                    new \LogicException('Configuration need to exist before creating Loupe instance.'),
+                );
             }
 
             /** @var string $configurationContent */

--- a/packages/seal-memory-adapter/src/MemoryStorage.php
+++ b/packages/seal-memory-adapter/src/MemoryStorage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CmsIg\Seal\Adapter\Memory;
 
+use CmsIg\Seal\Schema\Exception\IndexNotFoundException;
 use CmsIg\Seal\Schema\Index;
 
 /**
@@ -36,7 +37,7 @@ final class MemoryStorage
     public static function getDocuments(Index $index): array
     {
         if (!\array_key_exists($index->name, self::$indexes)) {
-            throw new \RuntimeException('Index "' . $index->name . '" does not exist.');
+            throw new IndexNotFoundException($index->name);
         }
 
         return self::$documents[$index->name];
@@ -50,7 +51,7 @@ final class MemoryStorage
     public static function save(Index $index, array $document): array
     {
         if (!\array_key_exists($index->name, self::$indexes)) {
-            throw new \RuntimeException('Index "' . $index->name . '" does not exist.');
+            throw new IndexNotFoundException($index->name);
         }
 
         $identifierField = $index->getIdentifierField();
@@ -66,7 +67,7 @@ final class MemoryStorage
     public static function delete(Index $index, string $identifier): void
     {
         if (!\array_key_exists($index->name, self::$indexes)) {
-            throw new \RuntimeException('Index "' . $index->name . '" does not exist.');
+            throw new IndexNotFoundException($index->name);
         }
 
         unset(self::$documents[$index->name][$identifier]);

--- a/packages/seal-opensearch-adapter/docker-compose.yml
+++ b/packages/seal-opensearch-adapter/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     environment:
       discovery.type: single-node
       cluster.routing.allocation.disk.threshold_enabled: 'false'
+      action.auto_create_index: 'false'
       DISABLE_SECURITY_PLUGIN: true
     ports:
       - "9200:9200"

--- a/packages/seal/src/Schema/Exception/IndexNotFoundException.php
+++ b/packages/seal/src/Schema/Exception/IndexNotFoundException.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS-IG SEAL project.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CmsIg\Seal\Schema\Exception;
+
+final class IndexNotFoundException extends \RuntimeException
+{
+    public function __construct(string $indexName, \Throwable|null $previous = null)
+    {
+        parent::__construct(
+            'Index "' . $indexName . '" does not exist.',
+            0,
+            $previous,
+        );
+    }
+}

--- a/packages/seal/src/Testing/AbstractAdapterTestCase.php
+++ b/packages/seal/src/Testing/AbstractAdapterTestCase.php
@@ -17,6 +17,7 @@ use CmsIg\Seal\Adapter\AdapterInterface;
 use CmsIg\Seal\Engine;
 use CmsIg\Seal\EngineInterface;
 use CmsIg\Seal\Exception\DocumentNotFoundException;
+use CmsIg\Seal\Schema\Exception\IndexNotFoundException;
 use CmsIg\Seal\Schema\Schema;
 use PHPUnit\Framework\TestCase;
 
@@ -65,6 +66,45 @@ abstract class AbstractAdapterTestCase extends TestCase
         $task->wait();
 
         $this->assertFalse($engine->existIndex($indexName));
+    }
+
+    public function testIndexNotFoundSave(): void
+    {
+        $this->expectException(IndexNotFoundException::class);
+
+        $engine = self::getEngine();
+        $indexName = TestingHelper::INDEX_SIMPLE;
+
+        $documents = TestingHelper::createSimpleFixtures();
+        $document = $documents[0];
+
+        $task = $engine->saveDocument($indexName, $document, ['return_slow_promise_result' => true]);
+        $task->wait();
+    }
+
+    public function testIndexNotFoundDelete(): void
+    {
+        $this->expectException(IndexNotFoundException::class);
+
+        $engine = self::getEngine();
+        $indexName = TestingHelper::INDEX_SIMPLE;
+
+        $documents = TestingHelper::createSimpleFixtures();
+        $document = $documents[0];
+
+        $task = $engine->deleteDocument($indexName, $document['id'], ['return_slow_promise_result' => true]);
+        $task->wait();
+    }
+
+    public function testIndexNotFoundSearch(): void
+    {
+        $this->expectException(IndexNotFoundException::class);
+
+        $engine = self::getEngine();
+        $indexName = TestingHelper::INDEX_SIMPLE;
+
+        $engine->createSearchBuilder($indexName)
+            ->getResult();
     }
 
     public function testSchema(): void

--- a/packages/seal/src/Testing/AbstractAdapterTestCase.php
+++ b/packages/seal/src/Testing/AbstractAdapterTestCase.php
@@ -78,8 +78,7 @@ abstract class AbstractAdapterTestCase extends TestCase
         $documents = TestingHelper::createSimpleFixtures();
         $document = $documents[0];
 
-        $task = $engine->saveDocument($indexName, $document, ['return_slow_promise_result' => true]);
-        $task->wait();
+        $task = $engine->saveDocument($indexName, $document);
     }
 
     public function testIndexNotFoundDelete(): void
@@ -92,8 +91,20 @@ abstract class AbstractAdapterTestCase extends TestCase
         $documents = TestingHelper::createSimpleFixtures();
         $document = $documents[0];
 
-        $task = $engine->deleteDocument($indexName, $document['id'], ['return_slow_promise_result' => true]);
-        $task->wait();
+        $task = $engine->deleteDocument($indexName, $document['id']);
+    }
+
+    public function testIndexNotFoundBulk(): void
+    {
+        $this->expectException(IndexNotFoundException::class);
+
+        $engine = self::getEngine();
+        $indexName = TestingHelper::INDEX_SIMPLE;
+
+        $documents = TestingHelper::createSimpleFixtures();
+        $document = $documents[0];
+
+        $task = $engine->bulk($indexName, [$document], [$document['id']], 100);
     }
 
     public function testIndexNotFoundSearch(): void

--- a/packages/seal/src/Testing/AbstractAdapterTestCase.php
+++ b/packages/seal/src/Testing/AbstractAdapterTestCase.php
@@ -78,7 +78,7 @@ abstract class AbstractAdapterTestCase extends TestCase
         $documents = TestingHelper::createSimpleFixtures();
         $document = $documents[0];
 
-        $task = $engine->saveDocument($indexName, $document);
+        $engine->saveDocument($indexName, $document);
     }
 
     public function testIndexNotFoundDelete(): void
@@ -91,10 +91,10 @@ abstract class AbstractAdapterTestCase extends TestCase
         $documents = TestingHelper::createSimpleFixtures();
         $document = $documents[0];
 
-        $task = $engine->deleteDocument($indexName, $document['id']);
+        $engine->deleteDocument($indexName, $document['id']);
     }
 
-    public function testIndexNotFoundBulk(): void
+    public function testIndexNotFoundBulkSave(): void
     {
         $this->expectException(IndexNotFoundException::class);
 
@@ -104,7 +104,20 @@ abstract class AbstractAdapterTestCase extends TestCase
         $documents = TestingHelper::createSimpleFixtures();
         $document = $documents[0];
 
-        $task = $engine->bulk($indexName, [$document], [$document['id']], 100);
+        $engine->bulk($indexName, [$document], []);
+    }
+
+    public function testIndexNotFoundBulkDelete(): void
+    {
+        $this->expectException(IndexNotFoundException::class);
+
+        $engine = self::getEngine();
+        $indexName = TestingHelper::INDEX_SIMPLE;
+
+        $documents = TestingHelper::createSimpleFixtures();
+        $document = $documents[0];
+
+        $engine->bulk($indexName, [], [$document['id']]);
     }
 
     public function testIndexNotFoundSearch(): void
@@ -116,6 +129,18 @@ abstract class AbstractAdapterTestCase extends TestCase
 
         $engine->createSearchBuilder($indexName)
             ->getResult();
+    }
+
+    public function testIndexNotFoundDocument(): void
+    {
+        $this->expectException(IndexNotFoundException::class);
+
+        $engine = self::getEngine();
+        $indexName = TestingHelper::INDEX_SIMPLE;
+        $documents = TestingHelper::createSimpleFixtures();
+        $document = $documents[0];
+
+        $engine->getDocument($indexName, $document['id']);
     }
 
     public function testSchema(): void


### PR DESCRIPTION
This PR should let us check if all search engines throw a not found exception which we may can catch and rethrow our own exception to maybe build up a auto setup in future (see #463).

## BC Breaks

New recommended way to setup `Elasticsearch` and `Opensearch` is to disable auto create of indexes, this avoids that a false Schema of your index is created in any case:

```diff
services:
  elasticsearch:
    image: # ...
    environment:
      # ...
+     action.auto_create_index: 'false'
    # ...
```

Existing clusters can be updated with:

```bash
curl -X PUT "http://localhost:9200/_cluster/settings" \
-H "Content-Type: application/json" \
-d '{
  "persistent": {
    "action.auto_create_index": "false"
  }
}'
```

## Todo

 - [x] ⚪ Memory (custom handeled)
 - [x] ⚪ Loupe (custom handeled / by default autocreated with custom settings)
 - [x] ⚠️ Elasticsearch (only with custom setting we get error or 404 else autocreated with basic engine specific  settings)
 - [x] ⚠️ Opensearch (not tested but think same as Elasticsearch)
 - [ ] ❌ Algolia (no error thrown - autocreated with basic engine specific  settings)
 - [ ] ❌ Meilisearch (no error thrown - autocreated with basic engine specific settings)
 - [ ] ❌ Redisearch (no error thrown - document created but Index not as 2 JSON.SET and FT are two different modules)
 - [ ] ⚪ Solr (throws 404)
 - [ ] ⚪ Typesense (throws a NotFoundObject exception)