### PR TITLE
Add Support for autocreate of an Index for Loupe and Memory Adapter

### DIFF
--- a/packages/seal-loupe-adapter/src/LoupeHelper.php
+++ b/packages/seal-loupe-adapter/src/LoupeHelper.php
@@ -78,21 +78,11 @@ final class LoupeHelper
         }
     }
 
-    public function createIndex(Index $index): Configuration
+    public function createIndex(Index $index): void
     {
-        $indexDirectory = $this->getIndexDirectory($index);
-        if (!\file_exists($indexDirectory)) {
-            \mkdir($indexDirectory, recursive: true);
-        }
-
-        // dumping the configuration allows us to search and index without knowing the configuration
-        // this way when a similar class like this would be part of loupe only the createIndex method
-        // would require then to know the configuration
-        $configuration = $this->createConfiguration($index);
+        $configuration = $this->createAndDumpConfiguration($index);
         \file_put_contents($this->getConfigurationFile($index), \serialize($configuration));
         $this->loupe[$index->name] = $this->createLoupe($index, $configuration);
-
-        return $configuration;
     }
 
     public function reset(): void
@@ -113,14 +103,14 @@ final class LoupeHelper
         if (!$configuration instanceof Configuration) {
             $configurationFile = $this->getConfigurationFile($index);
 
-            if (\file_exists($configurationFile)) {
+            if (!\file_exists($configurationFile)) {
+                $configuration = $this->createAndDumpConfiguration($index);
+            } else {
                 /** @var string $configurationContent */
                 $configurationContent = \file_get_contents($configurationFile);
 
                 /** @var Configuration $configuration */
                 $configuration = \unserialize($configurationContent);
-            } else {
-                $configuration = $this->createIndex($index);
             }
         }
 
@@ -129,6 +119,22 @@ final class LoupeHelper
         }
 
         return $this->loupeFactory->create($this->getIndexDirectory($index), $configuration);
+    }
+
+    private function createAndDumpConfiguration(Index $index): Configuration
+    {
+        $indexDirectory = $this->getIndexDirectory($index);
+        if (!\file_exists($indexDirectory)) {
+            \mkdir($indexDirectory, recursive: true);
+        }
+
+        // dumping the configuration allows us to search and index without knowing the configuration
+        // this way when a similar class like this would be part of loupe only the createIndex method
+        // would require then to know the configuration
+        $configuration = $this->createConfiguration($index);
+        \file_put_contents($this->getConfigurationFile($index), \serialize($configuration));
+
+        return $configuration;
     }
 
     private function createConfiguration(Index $index): Configuration

--- a/packages/seal-loupe-adapter/src/LoupeHelper.php
+++ b/packages/seal-loupe-adapter/src/LoupeHelper.php
@@ -78,7 +78,7 @@ final class LoupeHelper
         }
     }
 
-    public function createIndex(Index $index): void
+    public function createIndex(Index $index): Configuration
     {
         $indexDirectory = $this->getIndexDirectory($index);
         if (!\file_exists($indexDirectory)) {
@@ -91,6 +91,8 @@ final class LoupeHelper
         $configuration = $this->createConfiguration($index);
         \file_put_contents($this->getConfigurationFile($index), \serialize($configuration));
         $this->loupe[$index->name] = $this->createLoupe($index, $configuration);
+
+        return $configuration;
     }
 
     public function reset(): void
@@ -111,15 +113,15 @@ final class LoupeHelper
         if (!$configuration instanceof Configuration) {
             $configurationFile = $this->getConfigurationFile($index);
 
-            if (!\file_exists($configurationFile)) {
-                throw new \LogicException('Configuration need to exist before creating Loupe instance.');
+            if (\file_exists($configurationFile)) {
+                /** @var string $configurationContent */
+                $configurationContent = \file_get_contents($configurationFile);
+
+                /** @var Configuration $configuration */
+                $configuration = \unserialize($configurationContent);
+            } else {
+                $configuration = $this->createIndex($index);
             }
-
-            /** @var string $configurationContent */
-            $configurationContent = \file_get_contents($configurationFile);
-
-            /** @var Configuration $configuration */
-            $configuration = \unserialize($configurationContent);
         }
 
         if ('' === $this->directory) {

--- a/packages/seal-memory-adapter/src/MemoryStorage.php
+++ b/packages/seal-memory-adapter/src/MemoryStorage.php
@@ -36,7 +36,7 @@ final class MemoryStorage
     public static function getDocuments(Index $index): array
     {
         if (!\array_key_exists($index->name, self::$indexes)) {
-            throw new \RuntimeException('Index "' . $index->name . '" does not exist.');
+            self::$documents[$index->name] = [];
         }
 
         return self::$documents[$index->name];
@@ -50,7 +50,7 @@ final class MemoryStorage
     public static function save(Index $index, array $document): array
     {
         if (!\array_key_exists($index->name, self::$indexes)) {
-            throw new \RuntimeException('Index "' . $index->name . '" does not exist.');
+            self::$documents[$index->name] = [];
         }
 
         $identifierField = $index->getIdentifierField();
@@ -66,7 +66,7 @@ final class MemoryStorage
     public static function delete(Index $index, string $identifier): void
     {
         if (!\array_key_exists($index->name, self::$indexes)) {
-            throw new \RuntimeException('Index "' . $index->name . '" does not exist.');
+            self::$documents[$index->name] = [];
         }
 
         unset(self::$documents[$index->name][$identifier]);

--- a/packages/seal-memory-adapter/src/MemoryStorage.php
+++ b/packages/seal-memory-adapter/src/MemoryStorage.php
@@ -36,7 +36,7 @@ final class MemoryStorage
     public static function getDocuments(Index $index): array
     {
         if (!\array_key_exists($index->name, self::$indexes)) {
-            self::$documents[$index->name] = [];
+            self::createIndex($index);
         }
 
         return self::$documents[$index->name];
@@ -50,7 +50,7 @@ final class MemoryStorage
     public static function save(Index $index, array $document): array
     {
         if (!\array_key_exists($index->name, self::$indexes)) {
-            self::$documents[$index->name] = [];
+            self::createIndex($index);
         }
 
         $identifierField = $index->getIdentifierField();
@@ -66,7 +66,7 @@ final class MemoryStorage
     public static function delete(Index $index, string $identifier): void
     {
         if (!\array_key_exists($index->name, self::$indexes)) {
-            self::$documents[$index->name] = [];
+            self::createIndex($index);
         }
 
         unset(self::$documents[$index->name][$identifier]);


### PR DESCRIPTION
Sadly it seems like we are not able to standardize IndexNotFoundException (https://github.com/PHP-CMSIG/search/pull/470) for save, delete, bulk or search actions. 

We will still support in Loupe Autocreate of the Index if it does not yet exists.

While Indexes are in some cases autocreated we recommend to create Indexes via the frameworks CLI commands / scripts. Else Search Engine will create there own setting for the indexes and things like searchable, filterable, sortable, does may not work like expected. Why this is not the case for Loupe it is case for other Engine which also support auto create:

 - Elasticsearch
 - Opensearch
 - Algolia
 - Meilisearch
 
They all create indexes with some kind of default settings not the defined mapping of yours.

The following search engines will just fail if you try to save, delete, ... a document from it:

 - Solr
 - Typesense
 
The following search engines will not fail when adding, deleting a document but still no Index exist so nothing is searchable.

 - Redisearch

So fixes only parts of https://github.com/PHP-CMSIG/search/issues/463 (autocreate support).

---

TLDR; Only adapters which auto create indexes with correct configuration are with this PR:

 - Loupe
 - Memory
 
All others are created with the non correct default settings or will fail and createIndex should definitely still be called for them to update the settings of the specific engines correctly.