### PR TITLE
Add missing Loupe example to Integration READMEs

### DIFF
--- a/integrations/laravel/README.md
+++ b/integrations/laravel/README.md
@@ -38,6 +38,7 @@ The following adapters are available:
  - [OpensearchAdapter](../../packages/seal-opensearch-adapter): `cmsig/seal-opensearch-adapter`
  - [MeilisearchAdapter](../../packages/seal-meilisearch-adapter): `cmsig/seal-meilisearch-adapter`
  - [AlgoliaAdapter](../../packages/seal-algolia-adapter): `cmsig/seal-algolia-adapter`
+ - [LoupeAdapter](../../packages/seal-loupe-adapter): `cmsig/seal-loupe-adapter`
  - [SolrAdapter](../../packages/seal-solr-adapter): `cmsig/seal-solr-adapter`
  - [RediSearchAdapter](../../packages/seal-redisearch-adapter): `cmsig/seal-redisearch-adapter`
  - [TypesenseAdapter](../../packages/seal-typesense-adapter): `cmsig/seal-typesense-adapter`
@@ -134,6 +135,9 @@ return [
         ],
         'elasticsearch' => [
             'adapter' => 'elasticsearch://127.0.0.1:9200',
+        ],
+        'loupe' => [
+            'adapter' => 'loupe://var/indexes',
         ],
         'meilisearch' => [
             'adapter' => 'meilisearch://127.0.0.1:7700',

--- a/integrations/mezzio/README.md
+++ b/integrations/mezzio/README.md
@@ -38,6 +38,7 @@ The following adapters are available:
  - [OpensearchAdapter](../../packages/seal-opensearch-adapter): `cmsig/seal-opensearch-adapter`
  - [MeilisearchAdapter](../../packages/seal-meilisearch-adapter): `cmsig/seal-meilisearch-adapter`
  - [AlgoliaAdapter](../../packages/seal-algolia-adapter): `cmsig/seal-algolia-adapter`
+ - [LoupeAdapter](../../packages/seal-loupe-adapter): `cmsig/seal-loupe-adapter`
  - [SolrAdapter](../../packages/seal-solr-adapter): `cmsig/seal-solr-adapter`
  - [RediSearchAdapter](../../packages/seal-redisearch-adapter): `cmsig/seal-redisearch-adapter`
  - [TypesenseAdapter](../../packages/seal-typesense-adapter): `cmsig/seal-typesense-adapter`
@@ -112,6 +113,9 @@ class ConfigProvider
                     ],
                     'elasticsearch' => [
                         'adapter' => 'elasticsearch://127.0.0.1:9200',
+                    ],
+                    'loupe' => [
+                        'adapter' => 'loupe://var/indexes',
                     ],
                     'meilisearch' => [
                         'adapter' => 'meilisearch://127.0.0.1:7700',

--- a/integrations/spiral/README.md
+++ b/integrations/spiral/README.md
@@ -38,6 +38,7 @@ The following adapters are available:
  - [OpensearchAdapter](../../packages/seal-opensearch-adapter): `cmsig/seal-opensearch-adapter`
  - [MeilisearchAdapter](../../packages/seal-meilisearch-adapter): `cmsig/seal-meilisearch-adapter`
  - [AlgoliaAdapter](../../packages/seal-algolia-adapter): `cmsig/seal-algolia-adapter`
+ - [LoupeAdapter](../../packages/seal-loupe-adapter): `cmsig/seal-loupe-adapter`
  - [SolrAdapter](../../packages/seal-solr-adapter): `cmsig/seal-solr-adapter`
  - [RediSearchAdapter](../../packages/seal-redisearch-adapter): `cmsig/seal-redisearch-adapter`
  - [TypesenseAdapter](../../packages/seal-typesense-adapter): `cmsig/seal-typesense-adapter`
@@ -97,6 +98,9 @@ return [
         ],
         'elasticsearch' => [
             'adapter' => 'elasticsearch://127.0.0.1:9200',
+        ],
+        'loupe' => [
+            'adapter' => 'loupe://var/indexes',
         ],
         'meilisearch' => [
             'adapter' => 'meilisearch://127.0.0.1:7700',

--- a/integrations/symfony/README.md
+++ b/integrations/symfony/README.md
@@ -38,6 +38,7 @@ The following adapters are available:
  - [OpensearchAdapter](../../packages/seal-opensearch-adapter): `cmsig/seal-opensearch-adapter`
  - [MeilisearchAdapter](../../packages/seal-meilisearch-adapter): `cmsig/seal-meilisearch-adapter`
  - [AlgoliaAdapter](../../packages/seal-algolia-adapter): `cmsig/seal-algolia-adapter`
+ - [LoupeAdapter](../../packages/seal-loupe-adapter): `cmsig/seal-loupe-adapter`
  - [SolrAdapter](../../packages/seal-solr-adapter): `cmsig/seal-solr-adapter`
  - [RediSearchAdapter](../../packages/seal-redisearch-adapter): `cmsig/seal-redisearch-adapter`
  - [TypesenseAdapter](../../packages/seal-typesense-adapter): `cmsig/seal-typesense-adapter`
@@ -84,6 +85,8 @@ cmsig_seal:
             adapter: 'algolia://%env(ALGOLIA_APPLICATION_ID)%:%env(ALGOLIA_ADMIN_API_KEY)%'
         elasticsearch:
             adapter: 'elasticsearch://127.0.0.1:9200'
+        loupe:
+            adapter: 'loupe://var/indexes'
         meilisearch:
             adapter: 'meilisearch://127.0.0.1:7700'
         memory:

--- a/integrations/yii/README.md
+++ b/integrations/yii/README.md
@@ -38,6 +38,7 @@ The following adapters are available:
  - [OpensearchAdapter](../../packages/seal-opensearch-adapter): `cmsig/seal-opensearch-adapter`
  - [MeilisearchAdapter](../../packages/seal-meilisearch-adapter): `cmsig/seal-meilisearch-adapter`
  - [AlgoliaAdapter](../../packages/seal-algolia-adapter): `cmsig/seal-algolia-adapter`
+ - [LoupeAdapter](../../packages/seal-loupe-adapter): `cmsig/seal-loupe-adapter`
  - [SolrAdapter](../../packages/seal-solr-adapter): `cmsig/seal-solr-adapter`
  - [RediSearchAdapter](../../packages/seal-redisearch-adapter): `cmsig/seal-redisearch-adapter`
  - [TypesenseAdapter](../../packages/seal-typesense-adapter): `cmsig/seal-typesense-adapter`
@@ -106,6 +107,9 @@ return [
             ],
             'elasticsearch' => [
                 'adapter' => 'elasticsearch://127.0.0.1:9200',
+            ],
+            'loupe' => [
+                'adapter' => 'loupe://var/indexes',
             ],
             'meilisearch' => [
                 'adapter' => 'meilisearch://127.0.0.1:7700',


### PR DESCRIPTION
This was missed in the integration of loupe adapter.