### PR TITLE
Skip testSearchConditionWithHighlight as not supported by RediSearch

### DIFF
--- a/packages/seal-redisearch-adapter/README.md
+++ b/packages/seal-redisearch-adapter/README.md
@@ -61,6 +61,11 @@ redis://phpredis:phpredis@127.0.0.1:6379
 The `ext-redis` and `ext-json` PHP extension is required for this adapter.
 The `Redisearch` and `RedisJson` module is required for the Redis Server.
 
+## Limitation
+
+- [No GeoBoundingBox support](https://github.com/PHP-CMSIG/search/issues/422)
+- [No HIGHLIGHT support](https://github.com/PHP-CMSIG/search/issues/491)
+
 ## Authors
 
 - [Alexander Schranz](https://github.com/alexander-schranz/)

--- a/packages/seal-redisearch-adapter/tests/RediSearchSearcherTest.php
+++ b/packages/seal-redisearch-adapter/tests/RediSearchSearcherTest.php
@@ -33,4 +33,12 @@ class RediSearchSearcherTest extends AbstractSearcherTestCase
     {
         $this->markTestSkipped('Not supported by RediSearch: https://github.com/RediSearch/RediSearch/issues/680 or https://github.com/RediSearch/RediSearch/issues/5032');
     }
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testSearchConditionWithHighlight(): void
+    {
+        $this->markTestSkipped('Not supported by RediSearch: https://github.com/RediSearch/RediSearch/issues/4420 or https://redis.io/docs/latest/develop/interact/search-and-query/indexing/#limitations');
+    }
 }


### PR DESCRIPTION
Currently not supported as tried in: https://github.com/PHP-CMSIG/search/pull/355