### PR TITLE
Add helper to ease creating an empty result

### DIFF
--- a/packages/seal/src/Search/Result.php
+++ b/packages/seal/src/Search/Result.php
@@ -33,7 +33,7 @@ final class Result extends \IteratorIterator
         return $this->total;
     }
 
-    public static function empty(): static
+    public static function createEmpty(): static
     {
         return new self((static function (): \Generator {
             yield from [];

--- a/packages/seal/src/Search/Result.php
+++ b/packages/seal/src/Search/Result.php
@@ -32,4 +32,11 @@ class Result extends \IteratorIterator
     {
         return $this->total;
     }
+
+    public static function empty(): static
+    {
+        return new static((static function (): \Generator {
+            yield from [];
+        })(), 0);
+    }
 }

--- a/packages/seal/src/Search/Result.php
+++ b/packages/seal/src/Search/Result.php
@@ -16,7 +16,7 @@ namespace CmsIg\Seal\Search;
 /**
  * @extends \IteratorIterator<int, array<string, mixed>, \Generator>
  */
-class Result extends \IteratorIterator
+final class Result extends \IteratorIterator
 {
     /**
      * @param \Generator<int, array<string, mixed>> $documents
@@ -35,7 +35,7 @@ class Result extends \IteratorIterator
 
     public static function empty(): static
     {
-        return new static((static function (): \Generator {
+        return new self((static function (): \Generator {
             yield from [];
         })(), 0);
     }

--- a/packages/seal/tests/Search/ResultTest.php
+++ b/packages/seal/tests/Search/ResultTest.php
@@ -30,7 +30,7 @@ class ResultTest extends TestCase
 
     public function testCreateEmptyResult(): void
     {
-        $result = Result::empty();
+        $result = Result::createEmpty();
         $this->assertSame(0, $result->total());
         $this->assertSame([], \iterator_to_array($result));
     }

--- a/packages/seal/tests/Search/ResultTest.php
+++ b/packages/seal/tests/Search/ResultTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS-IG SEAL project.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CmsIg\Seal\Tests\Search;
+
+use CmsIg\Seal\Search\Result;
+use PHPUnit\Framework\TestCase;
+
+class ResultTest extends TestCase
+{
+    public function testIteratingResult(): void
+    {
+        $result = new Result((static function (): \Generator {
+            yield ['id' => 42];
+        })(), 1);
+
+        $this->assertSame(1, $result->total());
+        $this->assertSame([['id' => 42]], \iterator_to_array($result));
+    }
+
+    public function testCreateEmptyResult(): void
+    {
+        $result = Result::empty();
+        $this->assertSame(0, $result->total());
+        $this->assertSame([], \iterator_to_array($result));
+    }
+}


### PR DESCRIPTION
Creating an empty search result is a very valid case and because creating an empty generator is a bit cumbersome, I think this qualifies for a helper factory method 😊 