### PR TITLE
Add facet or aggregatable option to schema index field definition

### DIFF
--- a/packages/seal-algolia-adapter/src/AlgoliaSchemaManager.php
+++ b/packages/seal-algolia-adapter/src/AlgoliaSchemaManager.php
@@ -92,9 +92,14 @@ final class AlgoliaSchemaManager implements SchemaManagerInterface
             }
         }
 
+        $filterableAndFacetFields = \array_unique([
+            ...$index->filterableFields,
+            ...$index->facetFields,
+        ]);
+
         $attributes = [
             'searchableAttributes' => $index->searchableFields,
-            'attributesForFaceting' => $index->filterableFields,
+            'attributesForFaceting' => $filterableAndFacetFields,
             'replicas' => $replicas,
         ];
 

--- a/packages/seal-elasticsearch-adapter/src/ElasticsearchSchemaManager.php
+++ b/packages/seal-elasticsearch-adapter/src/ElasticsearchSchemaManager.php
@@ -86,12 +86,12 @@ final class ElasticsearchSchemaManager implements SchemaManagerInterface
                 $field instanceof Field\IdentifierField => $properties[$name] = [
                     'type' => 'keyword',
                     'index' => $field->searchable,
-                    'doc_values' => $field->filterable || $field->sortable, // @phpstan-ignore-line
+                    'doc_values' => $field->filterable || $field->sortable || $field->facet, // @phpstan-ignore-line
                 ],
                 $field instanceof Field\TextField => $properties[$name] = \array_replace([
                     'type' => 'text',
                     'index' => $field->searchable,
-                ], ($field->filterable || $field->sortable) ? [
+                ], ($field->filterable || $field->sortable || $field->facet) ? [
                     'fields' => [
                         'raw' => ['type' => 'keyword'],
                     ],
@@ -99,27 +99,27 @@ final class ElasticsearchSchemaManager implements SchemaManagerInterface
                 $field instanceof Field\BooleanField => $properties[$name] = [
                     'type' => 'boolean',
                     'index' => $field->searchable,
-                    'doc_values' => $field->filterable || $field->sortable,
+                    'doc_values' => $field->filterable || $field->sortable || $field->facet,
                 ],
                 $field instanceof Field\DateTimeField => $properties[$name] = [
                     'type' => 'date',
                     'index' => $field->searchable,
-                    'doc_values' => $field->filterable || $field->sortable,
+                    'doc_values' => $field->filterable || $field->sortable || $field->facet,
                 ],
                 $field instanceof Field\IntegerField => $properties[$name] = [
                     'type' => 'integer',
                     'index' => $field->searchable,
-                    'doc_values' => $field->filterable || $field->sortable,
+                    'doc_values' => $field->filterable || $field->sortable || $field->facet,
                 ],
                 $field instanceof Field\FloatField => $properties[$name] = [
                     'type' => 'float',
                     'index' => $field->searchable,
-                    'doc_values' => $field->filterable || $field->sortable,
+                    'doc_values' => $field->filterable || $field->sortable || $field->facet,
                 ],
                 $field instanceof Field\GeoPointField => $properties[$name] = [
                     'type' => 'geo_point',
                     'index' => $field->searchable,
-                    'doc_values' => $field->filterable || $field->sortable,
+                    'doc_values' => $field->filterable || $field->sortable || $field->facet, // @phpstan-ignore-line
                 ],
                 $field instanceof Field\ObjectField => $properties[$name] = [
                     'type' => 'object',

--- a/packages/seal-loupe-adapter/src/LoupeHelper.php
+++ b/packages/seal-loupe-adapter/src/LoupeHelper.php
@@ -139,10 +139,15 @@ final class LoupeHelper
 
     private function createConfiguration(Index $index): Configuration
     {
+        $filterableAndFacetFields = \array_unique([
+            ...$index->filterableFields,
+            ...$index->facetFields,
+        ]);
+
         return Configuration::create()
             ->withPrimaryKey($index->getIdentifierField()->name)
             ->withSearchableAttributes(\array_map(fn (string $field) => $this->formatField($field), $index->searchableFields))
-            ->withFilterableAttributes(\array_map(fn (string $field) => $this->formatField($field), $index->filterableFields))
+            ->withFilterableAttributes(\array_map(fn (string $field) => $this->formatField($field), $filterableAndFacetFields))
             ->withSortableAttributes(\array_map(fn (string $field) => $this->formatField($field), $index->sortableFields));
     }
 

--- a/packages/seal-meilisearch-adapter/src/MeilisearchSchemaManager.php
+++ b/packages/seal-meilisearch-adapter/src/MeilisearchSchemaManager.php
@@ -65,9 +65,14 @@ final class MeilisearchSchemaManager implements SchemaManagerInterface
             ],
         );
 
+        $filterableAndFacetFields = \array_unique([
+            ...$index->filterableFields,
+            ...$index->facetFields,
+        ]);
+
         $attributes = [
             'searchableAttributes' => $index->searchableFields,
-            'filterableAttributes' => $index->filterableFields,
+            'filterableAttributes' => $filterableAndFacetFields,
             'sortableAttributes' => $index->sortableFields,
         ];
 

--- a/packages/seal-opensearch-adapter/src/OpensearchSchemaManager.php
+++ b/packages/seal-opensearch-adapter/src/OpensearchSchemaManager.php
@@ -81,45 +81,45 @@ final class OpensearchSchemaManager implements SchemaManagerInterface
             match (true) {
                 $field instanceof Field\IdentifierField => $properties[$name] = [
                     'type' => 'keyword',
-                    'index' => $field->searchable || $field->filterable, // @phpstan-ignore-line // TODO recheck doc_values https://github.com/php-cmsig/search/issues/65
-                    'doc_values' => $field->filterable,
+                    'index' => $field->searchable || $field->filterable || $field->facet, // @phpstan-ignore-line // TODO recheck doc_values https://github.com/php-cmsig/search/issues/65
+                    'doc_values' => $field->filterable || $field->facet, // @phpstan-ignore-line
                 ],
                 $field instanceof Field\TextField => $properties[$name] = \array_replace([
                     'type' => 'text',
-                    'index' => $field->searchable || $field->filterable, // TODO recheck doc_values https://github.com/php-cmsig/search/issues/65
-                ], ($field->filterable || $field->sortable) ? [
+                    'index' => $field->searchable || $field->filterable || $field->facet, // TODO recheck doc_values https://github.com/php-cmsig/search/issues/65
+                ], ($field->filterable || $field->sortable || $field->facet) ? [
                     'fields' => [
                         'raw' => [
                             'type' => 'keyword',
-                            'index' => $field->searchable || $field->filterable, // TODO recheck doc_values https://github.com/php-cmsig/search/issues/65
-                            'doc_values' => $field->filterable,
+                            'index' => $field->searchable || $field->filterable || $field->facet, // TODO recheck doc_values https://github.com/php-cmsig/search/issues/65
+                            'doc_values' => $field->filterable || $field->facet,
                         ],
                     ],
                 ] : []),
                 $field instanceof Field\BooleanField => $properties[$name] = [
                     'type' => 'boolean',
-                    'index' => $field->searchable || $field->filterable, // @phpstan-ignore-line // TODO recheck doc_values https://github.com/php-cmsig/search/issues/65
-                    'doc_values' => $field->filterable,
+                    'index' => $field->searchable || $field->filterable || $field->facet, // @phpstan-ignore-line // TODO recheck doc_values https://github.com/php-cmsig/search/issues/65
+                    'doc_values' => $field->filterable || $field->facet,
                 ],
                 $field instanceof Field\DateTimeField => $properties[$name] = [
                     'type' => 'date',
-                    'index' => $field->searchable || $field->filterable, // @phpstan-ignore-line // TODO recheck doc_values https://github.com/php-cmsig/search/issues/65
-                    'doc_values' => $field->filterable,
+                    'index' => $field->searchable || $field->filterable || $field->facet, // @phpstan-ignore-line // TODO recheck doc_values https://github.com/php-cmsig/search/issues/65
+                    'doc_values' => $field->filterable || $field->facet,
                 ],
                 $field instanceof Field\IntegerField => $properties[$name] = [
                     'type' => 'integer',
-                    'index' => $field->searchable || $field->filterable, // @phpstan-ignore-line // TODO recheck doc_values https://github.com/php-cmsig/search/issues/65
-                    'doc_values' => $field->filterable,
+                    'index' => $field->searchable || $field->filterable || $field->facet, // @phpstan-ignore-line // TODO recheck doc_values https://github.com/php-cmsig/search/issues/65
+                    'doc_values' => $field->filterable || $field->facet,
                 ],
                 $field instanceof Field\FloatField => $properties[$name] = [
                     'type' => 'float',
-                    'index' => $field->searchable || $field->filterable, // @phpstan-ignore-line // TODO recheck doc_values https://github.com/php-cmsig/search/issues/65
-                    'doc_values' => $field->filterable,
+                    'index' => $field->searchable || $field->filterable || $field->facet, // @phpstan-ignore-line // TODO recheck doc_values https://github.com/php-cmsig/search/issues/65
+                    'doc_values' => $field->filterable || $field->facet,
                 ],
                 $field instanceof Field\GeoPointField => $properties[$name] = [
                     'type' => 'geo_point',
                     'index' => $field->searchable,
-                    'doc_values' => $field->filterable || $field->sortable,
+                    'doc_values' => $field->filterable || $field->sortable || $field->facet, // @phpstan-ignore-line
                 ],
                 $field instanceof Field\ObjectField => $properties[$name] = [
                     'type' => 'object',

--- a/packages/seal-solr-adapter/src/SolrSchemaManager.php
+++ b/packages/seal-solr-adapter/src/SolrSchemaManager.php
@@ -147,7 +147,7 @@ final class SolrSchemaManager implements SchemaManagerInterface
                     'name' => $name,
                     'type' => $field->searchable ? 'text_general' : 'string',
                     'indexed' => $field->searchable,
-                    'docValues' => $field->filterable || $field->sortable,
+                    'docValues' => $field->filterable || $field->sortable || $field->facet,
                     'stored' => true, // required to be set to stored for highlighting
                     'useDocValuesAsStored' => false,
                     'multiValued' => $isMultiple,
@@ -156,7 +156,7 @@ final class SolrSchemaManager implements SchemaManagerInterface
                     'name' => $name,
                     'type' => 'boolean',
                     'indexed' => $field->searchable,
-                    'docValues' => $field->filterable || $field->sortable,
+                    'docValues' => $field->filterable || $field->sortable || $field->facet,
                     'stored' => false,
                     'useDocValuesAsStored' => false,
                     'multiValued' => $isMultiple,
@@ -165,7 +165,7 @@ final class SolrSchemaManager implements SchemaManagerInterface
                     'name' => $name,
                     'type' => 'pdate',
                     'indexed' => $field->searchable,
-                    'docValues' => $field->filterable || $field->sortable,
+                    'docValues' => $field->filterable || $field->sortable || $field->facet,
                     'stored' => false,
                     'useDocValuesAsStored' => false,
                     'multiValued' => $isMultiple,
@@ -174,7 +174,7 @@ final class SolrSchemaManager implements SchemaManagerInterface
                     'name' => $name,
                     'type' => 'pint',
                     'indexed' => $field->searchable,
-                    'docValues' => $field->filterable || $field->sortable,
+                    'docValues' => $field->filterable || $field->sortable || $field->facet,
                     'stored' => false,
                     'useDocValuesAsStored' => false,
                     'multiValued' => $isMultiple,
@@ -183,7 +183,7 @@ final class SolrSchemaManager implements SchemaManagerInterface
                     'name' => $name,
                     'type' => 'pfloat',
                     'indexed' => $field->searchable,
-                    'docValues' => $field->filterable || $field->sortable,
+                    'docValues' => $field->filterable || $field->sortable || $field->facet,
                     'stored' => false,
                     'useDocValuesAsStored' => false,
                     'multiValued' => $isMultiple,
@@ -192,7 +192,7 @@ final class SolrSchemaManager implements SchemaManagerInterface
                     'name' => $name,
                     'type' => 'location',
                     'indexed' => $field->searchable,
-                    'docValues' => $field->filterable || $field->sortable,
+                    'docValues' => $field->filterable || $field->sortable || $field->facet, // @phpstan-ignore-line
                     'stored' => false,
                     'useDocValuesAsStored' => false,
                     'multiValued' => $isMultiple,
@@ -204,8 +204,8 @@ final class SolrSchemaManager implements SchemaManagerInterface
                 default => throw new \RuntimeException(\sprintf('Field type "%s" is not supported.', $field::class)),
             };
 
-            if ($field instanceof Field\TextField && $field->searchable && ($field->filterable || $field->sortable)) {
-                // add additional raw field for field which is filterable/sortable but also searchable
+            if ($field instanceof Field\TextField && $field->searchable && ($field->filterable || $field->sortable || $field->facet)) {
+                // add additional raw field for field which is filterable/sortable/facet but also searchable
                 $fieldSettings = $indexFields[$name];
 
                 $fieldSettings['name'] = $name . '.raw';

--- a/packages/seal-typesense-adapter/src/TypesenseSchemaManager.php
+++ b/packages/seal-typesense-adapter/src/TypesenseSchemaManager.php
@@ -97,49 +97,49 @@ final class TypesenseSchemaManager implements SchemaManagerInterface
                     'name' => $name,
                     'type' => 'string',
                     'index' => $field->searchable || $field->filterable, // @phpstan-ignore-line
-                    'facet' => $field->filterable,
+                    'facet' => $field->filterable || $field->facet, // @phpstan-ignore-line
                 ],
                 $field instanceof Field\TextField => $fields[] = [
                     'name' => $name,
                     'type' => $field->multiple ? 'string[]' : 'string',
                     'optional' => true,
                     'index' => $field->searchable || $field->filterable,
-                    'facet' => $field->filterable,
+                    'facet' => $field->filterable || $field->facet,
                 ],
                 $field instanceof Field\BooleanField => $fields[] = [
                     'name' => $name,
                     'type' => $field->multiple ? 'bool[]' : 'bool',
                     'optional' => true,
                     'index' => $field->searchable || $field->filterable, // @phpstan-ignore-line
-                    'facet' => $field->filterable,
+                    'facet' => $field->filterable || $field->facet,
                 ],
                 $field instanceof Field\IntegerField => $fields[] = [
                     'name' => $name,
                     'type' => $field->multiple ? 'int64[]' : 'int64',
                     'optional' => true,
                     'index' => $field->searchable || $field->filterable, // @phpstan-ignore-line
-                    'facet' => $field->filterable,
+                    'facet' => $field->filterable || $field->facet,
                 ],
                 $field instanceof Field\DateTimeField => $fields[] = [
                     'name' => $name,
                     'type' => $field->multiple ? 'int64[]' : 'int64',
                     'optional' => true,
                     'index' => $field->searchable || $field->filterable, // @phpstan-ignore-line
-                    'facet' => $field->filterable,
+                    'facet' => $field->filterable || $field->facet,
                 ],
                 $field instanceof Field\FloatField => $fields[] = [
                     'name' => $name,
                     'type' => $field->multiple ? 'float[]' : 'float',
                     'optional' => true,
                     'index' => $field->searchable || $field->filterable, // @phpstan-ignore-line
-                    'facet' => $field->filterable,
+                    'facet' => $field->filterable || $field->facet,
                 ],
                 $field instanceof Field\GeoPointField => $fields[] = [
                     'name' => $name,
                     'type' => $field->multiple ? 'geopoint[]' : 'geopoint',
                     'optional' => true,
                     'index' => $field->searchable || $field->filterable, // @phpstan-ignore-line
-                    'facet' => $field->filterable,
+                    'facet' => $field->filterable || $field->facet, // @phpstan-ignore-line
                 ],
                 $field instanceof Field\ObjectField => $fields = [...$fields, ...$this->createObjectFields($name, $field)],
                 $field instanceof Field\TypedField => $fields = [...$fields, ...$this->createTypedFields($name, $field)],

--- a/packages/seal/src/Schema/Field/AbstractField.php
+++ b/packages/seal/src/Schema/Field/AbstractField.php
@@ -27,6 +27,7 @@ abstract class AbstractField
         public readonly bool $searchable,
         public readonly bool $filterable,
         public readonly bool $sortable,
+        public readonly bool $facet,
         public readonly array $options,
     ) {
     }

--- a/packages/seal/src/Schema/Field/BooleanField.php
+++ b/packages/seal/src/Schema/Field/BooleanField.php
@@ -32,6 +32,7 @@ final class BooleanField extends AbstractField
         bool $searchable = false,
         bool $filterable = false,
         bool $sortable = false,
+        bool $facet = false,
         array $options = [],
     ) {
         if ($searchable) { // @phpstan-ignore-line
@@ -44,6 +45,7 @@ final class BooleanField extends AbstractField
             $searchable,
             $filterable,
             $sortable,
+            $facet,
             $options,
         );
     }

--- a/packages/seal/src/Schema/Field/DateTimeField.php
+++ b/packages/seal/src/Schema/Field/DateTimeField.php
@@ -32,6 +32,7 @@ final class DateTimeField extends AbstractField
         bool $searchable = false,
         bool $filterable = false,
         bool $sortable = false,
+        bool $facet = false,
         array $options = [],
     ) {
         if ($searchable) { // @phpstan-ignore-line
@@ -44,6 +45,7 @@ final class DateTimeField extends AbstractField
             $searchable,
             $filterable,
             $sortable,
+            $facet,
             $options,
         );
     }

--- a/packages/seal/src/Schema/Field/FloatField.php
+++ b/packages/seal/src/Schema/Field/FloatField.php
@@ -32,6 +32,7 @@ final class FloatField extends AbstractField
         bool $searchable = false,
         bool $filterable = false,
         bool $sortable = false,
+        bool $facet = false,
         array $options = [],
     ) {
         if ($searchable) { // @phpstan-ignore-line
@@ -39,12 +40,13 @@ final class FloatField extends AbstractField
         }
 
         parent::__construct(
-            $name,
-            $multiple,
-            $searchable,
-            $filterable,
-            $sortable,
-            $options,
+            name: $name,
+            multiple: $multiple,
+            searchable: $searchable,
+            filterable: $filterable,
+            sortable: $sortable,
+            facet: $facet,
+            options: $options,
         );
     }
 }

--- a/packages/seal/src/Schema/Field/GeoPointField.php
+++ b/packages/seal/src/Schema/Field/GeoPointField.php
@@ -22,6 +22,7 @@ namespace CmsIg\Seal\Schema\Field;
  * ATTENTION: Different search engines support only one field for geopoint per index.
  *
  * @property false $searchable
+ * @property false $facet
  *
  * @readonly
  */
@@ -30,6 +31,7 @@ final class GeoPointField extends AbstractField
     /**
      * @param false $searchable
      * @param false $multiple
+     * @param false $facet
      * @param array<string, mixed> $options
      */
     public function __construct(
@@ -38,19 +40,25 @@ final class GeoPointField extends AbstractField
         bool $searchable = false,
         bool $filterable = false,
         bool $sortable = false,
+        bool $facet = false,
         array $options = [],
     ) {
         if ($searchable) { // @phpstan-ignore-line
             throw new \InvalidArgumentException('Searchability for GeoPointField is not yet implemented: https://github.com/php-cmsig/search/issues/97');
         }
 
+        if ($facet) { // @phpstan-ignore-line
+            throw new \InvalidArgumentException('Facet for GeoPointField is not yet implemented: <TODO create issue>');
+        }
+
         parent::__construct(
-            $name,
-            $multiple,
-            $searchable,
-            $filterable,
-            $sortable,
-            $options,
+            name: $name,
+            multiple: $multiple,
+            searchable: $searchable,
+            filterable: $filterable,
+            sortable: $sortable,
+            facet: $facet,
+            options: $options,
         );
     }
 }

--- a/packages/seal/src/Schema/Field/IdentifierField.php
+++ b/packages/seal/src/Schema/Field/IdentifierField.php
@@ -20,6 +20,7 @@ namespace CmsIg\Seal\Schema\Field;
  * @property false $searchable
  * @property true $filterable
  * @property true $sortable
+ * @property false $facet
  *
  * @readonly
  */
@@ -33,6 +34,7 @@ final class IdentifierField extends AbstractField
             searchable: false,
             filterable: true,
             sortable: true,
+            facet: false,
             options: [],
         );
     }

--- a/packages/seal/src/Schema/Field/IntegerField.php
+++ b/packages/seal/src/Schema/Field/IntegerField.php
@@ -32,6 +32,7 @@ final class IntegerField extends AbstractField
         bool $searchable = false,
         bool $filterable = false,
         bool $sortable = false,
+        bool $facet = false,
         array $options = [],
     ) {
         if ($searchable) { // @phpstan-ignore-line
@@ -39,12 +40,13 @@ final class IntegerField extends AbstractField
         }
 
         parent::__construct(
-            $name,
-            $multiple,
-            $searchable,
-            $filterable,
-            $sortable,
-            $options,
+            name: $name,
+            multiple: $multiple,
+            searchable: $searchable,
+            filterable: $filterable,
+            sortable: $sortable,
+            facet: $facet,
+            options: $options,
         );
     }
 }

--- a/packages/seal/src/Schema/Field/ObjectField.php
+++ b/packages/seal/src/Schema/Field/ObjectField.php
@@ -33,6 +33,7 @@ final class ObjectField extends AbstractField
         $searchable = false;
         $filterable = false;
         $sortable = false;
+        $facet = false;
 
         foreach ($fields as $field) {
             if ($field->searchable) {
@@ -46,15 +47,20 @@ final class ObjectField extends AbstractField
             if ($field->sortable) {
                 $sortable = true;
             }
+
+            if ($field->facet) {
+                $facet = true;
+            }
         }
 
         parent::__construct(
-            $name,
-            $multiple,
-            $searchable,
-            $filterable,
-            $sortable,
-            $options,
+            name: $name,
+            multiple: $multiple,
+            searchable: $searchable,
+            filterable: $filterable,
+            sortable: $sortable,
+            facet: $facet,
+            options: $options,
         );
     }
 }

--- a/packages/seal/src/Schema/Field/TextField.php
+++ b/packages/seal/src/Schema/Field/TextField.php
@@ -29,15 +29,17 @@ final class TextField extends AbstractField
         bool $searchable = true,
         bool $filterable = false,
         bool $sortable = false,
+        bool $facet = false,
         array $options = [],
     ) {
         parent::__construct(
-            $name,
-            $multiple,
-            $searchable,
-            $filterable,
-            $sortable,
-            $options,
+            name: $name,
+            multiple: $multiple,
+            searchable: $searchable,
+            filterable: $filterable,
+            sortable: $sortable,
+            facet: $facet,
+            options: $options,
         );
     }
 }

--- a/packages/seal/src/Schema/Field/TypedField.php
+++ b/packages/seal/src/Schema/Field/TypedField.php
@@ -34,6 +34,7 @@ final class TypedField extends AbstractField
         $searchable = false;
         $filterable = false;
         $sortable = false;
+        $facet = false;
 
         foreach ($types as $fields) {
             foreach ($fields as $field) {
@@ -48,16 +49,21 @@ final class TypedField extends AbstractField
                 if ($field->sortable) {
                     $sortable = true;
                 }
+
+                if ($field->facet) {
+                    $facet = true;
+                }
             }
         }
 
         parent::__construct(
-            $name,
-            $multiple,
-            $searchable,
-            $filterable,
-            $sortable,
-            $options,
+            name: $name,
+            multiple: $multiple,
+            searchable: $searchable,
+            filterable: $filterable,
+            sortable: $sortable,
+            facet: $facet,
+            options: $options,
         );
     }
 }

--- a/packages/seal/src/Schema/Index.php
+++ b/packages/seal/src/Schema/Index.php
@@ -43,6 +43,11 @@ final class Index
     public readonly array $filterableFields;
 
     /**
+     * @var string[]
+     */
+    public readonly array $facetFields;
+
+    /**
      * @param array<string, AbstractField> $fields
      */
     public function __construct(
@@ -53,6 +58,7 @@ final class Index
         $this->searchableFields = $attributes['searchableFields'];
         $this->filterableFields = $attributes['filterableFields'];
         $this->sortableFields = $attributes['sortableFields'];
+        $this->facetFields = $attributes['facetFields'];
         $this->identifierField = $attributes['identifierField'];
     }
 
@@ -105,11 +111,13 @@ final class Index
      *     searchableFields: string[],
      *     filterableFields: string[],
      *     sortableFields: string[],
+     *     facetFields: string[],
      *     identifierField: IdentifierField|null,
      * } : array{
      *     searchableFields: string[],
      *     filterableFields: string[],
      *     sortableFields: string[],
+     *     facetFields: string[],
      * })
      */
     private function getAttributes(array $fields, bool $withoutIdentifierField = false): array
@@ -120,6 +128,7 @@ final class Index
             'searchableFields' => [],
             'filterableFields' => [],
             'sortableFields' => [],
+            'facetFields' => [],
         ];
 
         foreach ($fields as $name => $field) {
@@ -172,6 +181,10 @@ final class Index
 
             if ($field->sortable) {
                 $attributes['sortableFields'][] = $name;
+            }
+
+            if ($field->facet) {
+                $attributes['facetFields'][] = $name;
             }
 
             if ($field instanceof IdentifierField) {


### PR DESCRIPTION
## The Idea:

### Schema Definition

For ecommerce websites it would great if we could support some kind of facets or aggregations to allow better filtering.

The first case for supporting this is adding it to the schema metadata via:

```php
new Field\TextField(name: 'category', filterable: true, facet: true);
new Field\IntegerField(name: 'downloads', filterable: true, facet: true);
new Field\FloatField(name: 'rating', filterable: true, facet: true);
new Field\DateTimeField(name: 'createdAt', filterable: true, facet: true);
new Field\BooleanField(name: 'isSpecial', filterable: true, facet: true);
```

> [!NOTE]  
> Not sure if `aggregatable` is a better name in the schema index field definition.
>
> ```php
> new Field\TextField(name: 'category', filterable: true, aggregatable: true);
> ```


> [!WARNING]  
> Maybe there need to be no different between `filterable` or `aggregatable` / `facet` > currently all engines seems support facets for filterable fields. If not required we can remove the first two commits.

### Search with Facet Result

The facet should be possible to add to the SearchBuilder:

```php
$result = $this->engine->createSearchBuilder('blog')
    ->addFilter(/* ... */)
    ->addFacet(new TermFacet(field: 'category')) // TODO
    ->addFacet(new CountFacet(field: 'category')) // alternative to Term?
    ->addFacet(new MinMaxFacet(field: 'category')) // TODO
    ->getResult();
```

> [!NOTE]  
> Not sure if `addAggregation` is a better with:
>
> ```php
> ->addAggregation(new TermAggregation(field: 'category')) // TODO
> ->addAggregation(new CountAggregation(field: 'category')) // alternative to Term?
> ->addAggregation(new MinMaxAggregation(field: 'category')) // TODO
> ```

We need maybe know what kind of facets:

# Todo Facets / Aggregations

For the first case I think Term aggregation / facet is best way yet to support categorized search results. Min/Max seems not all engine supported so we will keep that outside currently. AVG / SUM is in Algolia for example return when do facetStats to get min, max, avg, sum but not sure about AVG / SUM as I don't know yet a real usecase for searches and ecommerce sites yet for it.

 - [ ] Term
 - [ ] Min/Max / range ?
 - [ ] AVG / SUM ? (don't know usage about this yet)

# ToDo Decide naming

 - [ ] facet vs. aggregatable

# ToDo Search Engines

 - [ ] Memory
 - [ ] Elasticsearch
 - [ ] Opensearch
 - [ ] Algolia
 - [ ] Meilisearch
 - [ ] Typesense
 - [ ] Solr
 - [ ] Typesense
 - [ ] Loupe

fixes https://github.com/PHP-CMSIG/search/issues/182