### PR TITLE
Add support for Loupe 0.10

### DIFF
--- a/.examples/laravel/composer.lock
+++ b/.examples/laravel/composer.lock
@@ -6444,11 +6444,11 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "b007020e3716d43f4e05732970e2a3295b177bef"
+                "reference": "83c3ec276069d4b985022ab62371ff5b2067e01d"
             },
             "require": {
                 "cmsig/seal": "^0.7",
-                "loupe/loupe": "^0.8 || ^0.9",
+                "loupe/loupe": "^0.8 || ^0.9 || ^0.10",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
             },
@@ -8231,16 +8231,16 @@
         },
         {
             "name": "loupe/loupe",
-            "version": "0.9.5",
+            "version": "0.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/loupe-php/loupe.git",
-                "reference": "1c65e9fff40da2247c951711166ef143bb2093df"
+                "reference": "0c47688ed4c139262446b083bfd9181b427d65e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/1c65e9fff40da2247c951711166ef143bb2093df",
-                "reference": "1c65e9fff40da2247c951711166ef143bb2093df",
+                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/0c47688ed4c139262446b083bfd9181b427d65e7",
+                "reference": "0c47688ed4c139262446b083bfd9181b427d65e7",
                 "shasum": ""
             },
             "require": {
@@ -8248,16 +8248,16 @@
                 "doctrine/lexer": "^2.0 || ^3.0",
                 "ext-intl": "*",
                 "ext-mbstring": "*",
-                "mjaschen/phpgeo": "^4.2",
-                "nitotm/efficient-language-detector": "^2.0",
+                "mjaschen/phpgeo": "^5.0 || ^6.0",
+                "nitotm/efficient-language-detector": "^3.0",
                 "php": "^8.1",
                 "psr/log": "^2.0 || ^3.0",
                 "toflar/state-set-index": "^3.0",
                 "wamania/php-stemmer": "^3.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^10.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^10.5",
                 "symfony/filesystem": "^6.2",
                 "symfony/finder": "^6.2",
                 "symfony/var-dumper": "^6.2",
@@ -8282,7 +8282,7 @@
             "description": "A full text search engine with tokenization, stemming, typo tolerance, filters and geo support based on only PHP and SQLite",
             "support": {
                 "issues": "https://github.com/loupe-php/loupe/issues",
-                "source": "https://github.com/loupe-php/loupe/tree/0.9.5"
+                "source": "https://github.com/loupe-php/loupe/tree/0.10.0"
             },
             "funding": [
                 {
@@ -8290,7 +8290,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-11T12:46:40+00:00"
+            "time": "2025-03-13T08:48:07+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -8428,25 +8428,25 @@
         },
         {
             "name": "mjaschen/phpgeo",
-            "version": "4.2.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mjaschen/phpgeo.git",
-                "reference": "5e16834f9433c7780cda7e16aa279814f98ca697"
+                "reference": "71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mjaschen/phpgeo/zipball/5e16834f9433c7780cda7e16aa279814f98ca697",
-                "reference": "5e16834f9433c7780cda7e16aa279814f98ca697",
+                "url": "https://api.github.com/repos/mjaschen/phpgeo/zipball/71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931",
+                "reference": "71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": "^8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5",
-                "squizlabs/php_codesniffer": "^3.6",
-                "vimeo/psalm": "^4.13"
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.0",
+                "squizlabs/php_codesniffer": "^3.7"
             },
             "type": "library",
             "autoload": {
@@ -8495,7 +8495,7 @@
                 "docs": "https://phpgeo.marcusjaschen.de/Installation.html",
                 "email": "mjaschen@gmail.com",
                 "issues": "https://github.com/mjaschen/phpgeo/issues",
-                "source": "https://github.com/mjaschen/phpgeo/tree/4.2.1"
+                "source": "https://github.com/mjaschen/phpgeo/tree/6.0.0"
             },
             "funding": [
                 {
@@ -8507,7 +8507,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-03T08:01:10+00:00"
+            "time": "2025-01-12T09:09:15+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -8654,27 +8654,21 @@
         },
         {
             "name": "nitotm/efficient-language-detector",
-            "version": "v2.1.2",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nitotm/efficient-language-detector.git",
-                "reference": "7c69b13a6b8774a663b6612afc4c2188587fa33a"
+                "reference": "f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nitotm/efficient-language-detector/zipball/7c69b13a6b8774a663b6612afc4c2188587fa33a",
-                "reference": "7c69b13a6b8774a663b6612afc4c2188587fa33a",
+                "url": "https://api.github.com/repos/nitotm/efficient-language-detector/zipball/f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab",
+                "reference": "f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "ext-json": "*",
-                "phpmd/phpmd": "^2.13",
-                "squizlabs/php_codesniffer": "3.*",
-                "vimeo/psalm": "^5.12"
             },
             "type": "library",
             "autoload": {
@@ -8698,15 +8692,17 @@
                 "detection",
                 "detector",
                 "language",
+                "language classification",
                 "language detection",
                 "language detector",
-                "language identification"
+                "language identification",
+                "language recognition"
             ],
             "support": {
                 "issues": "https://github.com/nitotm/efficient-language-detector/issues",
-                "source": "https://github.com/nitotm/efficient-language-detector/tree/v2.1.2"
+                "source": "https://github.com/nitotm/efficient-language-detector/tree/v3.0.0"
             },
-            "time": "2024-09-10T12:52:25+00:00"
+            "time": "2024-10-10T17:53:50+00:00"
         },
         {
             "name": "nunomaduro/collision",

--- a/.examples/mezzio/composer.lock
+++ b/.examples/mezzio/composer.lock
@@ -3162,11 +3162,11 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "b007020e3716d43f4e05732970e2a3295b177bef"
+                "reference": "83c3ec276069d4b985022ab62371ff5b2067e01d"
             },
             "require": {
                 "cmsig/seal": "^0.7",
-                "loupe/loupe": "^0.8 || ^0.9",
+                "loupe/loupe": "^0.8 || ^0.9 || ^0.10",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
             },
@@ -5034,16 +5034,16 @@
         },
         {
             "name": "loupe/loupe",
-            "version": "0.9.5",
+            "version": "0.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/loupe-php/loupe.git",
-                "reference": "1c65e9fff40da2247c951711166ef143bb2093df"
+                "reference": "0c47688ed4c139262446b083bfd9181b427d65e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/1c65e9fff40da2247c951711166ef143bb2093df",
-                "reference": "1c65e9fff40da2247c951711166ef143bb2093df",
+                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/0c47688ed4c139262446b083bfd9181b427d65e7",
+                "reference": "0c47688ed4c139262446b083bfd9181b427d65e7",
                 "shasum": ""
             },
             "require": {
@@ -5051,16 +5051,16 @@
                 "doctrine/lexer": "^2.0 || ^3.0",
                 "ext-intl": "*",
                 "ext-mbstring": "*",
-                "mjaschen/phpgeo": "^4.2",
-                "nitotm/efficient-language-detector": "^2.0",
+                "mjaschen/phpgeo": "^5.0 || ^6.0",
+                "nitotm/efficient-language-detector": "^3.0",
                 "php": "^8.1",
                 "psr/log": "^2.0 || ^3.0",
                 "toflar/state-set-index": "^3.0",
                 "wamania/php-stemmer": "^3.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^10.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^10.5",
                 "symfony/filesystem": "^6.2",
                 "symfony/finder": "^6.2",
                 "symfony/var-dumper": "^6.2",
@@ -5085,7 +5085,7 @@
             "description": "A full text search engine with tokenization, stemming, typo tolerance, filters and geo support based on only PHP and SQLite",
             "support": {
                 "issues": "https://github.com/loupe-php/loupe/issues",
-                "source": "https://github.com/loupe-php/loupe/tree/0.9.5"
+                "source": "https://github.com/loupe-php/loupe/tree/0.10.0"
             },
             "funding": [
                 {
@@ -5093,7 +5093,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-11T12:46:40+00:00"
+            "time": "2025-03-13T08:48:07+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -5314,25 +5314,25 @@
         },
         {
             "name": "mjaschen/phpgeo",
-            "version": "4.2.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mjaschen/phpgeo.git",
-                "reference": "5e16834f9433c7780cda7e16aa279814f98ca697"
+                "reference": "71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mjaschen/phpgeo/zipball/5e16834f9433c7780cda7e16aa279814f98ca697",
-                "reference": "5e16834f9433c7780cda7e16aa279814f98ca697",
+                "url": "https://api.github.com/repos/mjaschen/phpgeo/zipball/71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931",
+                "reference": "71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": "^8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5",
-                "squizlabs/php_codesniffer": "^3.6",
-                "vimeo/psalm": "^4.13"
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.0",
+                "squizlabs/php_codesniffer": "^3.7"
             },
             "type": "library",
             "autoload": {
@@ -5381,7 +5381,7 @@
                 "docs": "https://phpgeo.marcusjaschen.de/Installation.html",
                 "email": "mjaschen@gmail.com",
                 "issues": "https://github.com/mjaschen/phpgeo/issues",
-                "source": "https://github.com/mjaschen/phpgeo/tree/4.2.1"
+                "source": "https://github.com/mjaschen/phpgeo/tree/6.0.0"
             },
             "funding": [
                 {
@@ -5393,7 +5393,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-03T08:01:10+00:00"
+            "time": "2025-01-12T09:09:15+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -5560,27 +5560,21 @@
         },
         {
             "name": "nitotm/efficient-language-detector",
-            "version": "v2.1.2",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nitotm/efficient-language-detector.git",
-                "reference": "7c69b13a6b8774a663b6612afc4c2188587fa33a"
+                "reference": "f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nitotm/efficient-language-detector/zipball/7c69b13a6b8774a663b6612afc4c2188587fa33a",
-                "reference": "7c69b13a6b8774a663b6612afc4c2188587fa33a",
+                "url": "https://api.github.com/repos/nitotm/efficient-language-detector/zipball/f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab",
+                "reference": "f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "ext-json": "*",
-                "phpmd/phpmd": "^2.13",
-                "squizlabs/php_codesniffer": "3.*",
-                "vimeo/psalm": "^5.12"
             },
             "type": "library",
             "autoload": {
@@ -5604,15 +5598,17 @@
                 "detection",
                 "detector",
                 "language",
+                "language classification",
                 "language detection",
                 "language detector",
-                "language identification"
+                "language identification",
+                "language recognition"
             ],
             "support": {
                 "issues": "https://github.com/nitotm/efficient-language-detector/issues",
-                "source": "https://github.com/nitotm/efficient-language-detector/tree/v2.1.2"
+                "source": "https://github.com/nitotm/efficient-language-detector/tree/v3.0.0"
             },
-            "time": "2024-09-10T12:52:25+00:00"
+            "time": "2024-10-10T17:53:50+00:00"
         },
         {
             "name": "nyholm/psr7",
@@ -7349,12 +7345,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "9ec3309dcdef9afaf7649b5ddff330d58abe4d34"
+                "reference": "082338f65948c175f5d9be2f420571b40f254e58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/9ec3309dcdef9afaf7649b5ddff330d58abe4d34",
-                "reference": "9ec3309dcdef9afaf7649b5ddff330d58abe4d34",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/082338f65948c175f5d9be2f420571b40f254e58",
+                "reference": "082338f65948c175f5d9be2f420571b40f254e58",
                 "shasum": ""
             },
             "conflict": {
@@ -7447,12 +7443,14 @@
                 "chriskacerguis/codeigniter-restserver": "<=2.7.1",
                 "civicrm/civicrm-core": ">=4.2,<4.2.9|>=4.3,<4.3.3",
                 "ckeditor/ckeditor": "<4.25",
+                "clickstorm/cs-seo": ">=6,<6.7|>=7,<7.4|>=8,<8.3|>=9,<9.2",
                 "cockpit-hq/cockpit": "<2.7|==2.7",
                 "codeception/codeception": "<3.1.3|>=4,<4.1.22",
                 "codeigniter/framework": "<3.1.9",
                 "codeigniter4/framework": "<4.5.8",
                 "codeigniter4/shield": "<1.0.0.0-beta8",
                 "codiad/codiad": "<=2.8.4",
+                "codingms/additional-tca": ">=1.7,<1.15.17|>=1.16,<1.16.9",
                 "components/jquery": ">=1.0.3,<3.5",
                 "composer/composer": "<1.10.27|>=2,<2.2.24|>=2.3,<2.7.7",
                 "concrete5/concrete5": "<9.4.0.0-RC1-dev",
@@ -8218,7 +8216,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-17T22:04:58+00:00"
+            "time": "2025-03-18T11:05:04+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/.examples/spiral/composer.lock
+++ b/.examples/spiral/composer.lock
@@ -7133,11 +7133,11 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "b007020e3716d43f4e05732970e2a3295b177bef"
+                "reference": "83c3ec276069d4b985022ab62371ff5b2067e01d"
             },
             "require": {
                 "cmsig/seal": "^0.7",
-                "loupe/loupe": "^0.8 || ^0.9",
+                "loupe/loupe": "^0.8 || ^0.9 || ^0.10",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
             },
@@ -9128,16 +9128,16 @@
         },
         {
             "name": "loupe/loupe",
-            "version": "0.9.5",
+            "version": "0.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/loupe-php/loupe.git",
-                "reference": "1c65e9fff40da2247c951711166ef143bb2093df"
+                "reference": "0c47688ed4c139262446b083bfd9181b427d65e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/1c65e9fff40da2247c951711166ef143bb2093df",
-                "reference": "1c65e9fff40da2247c951711166ef143bb2093df",
+                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/0c47688ed4c139262446b083bfd9181b427d65e7",
+                "reference": "0c47688ed4c139262446b083bfd9181b427d65e7",
                 "shasum": ""
             },
             "require": {
@@ -9145,16 +9145,16 @@
                 "doctrine/lexer": "^2.0 || ^3.0",
                 "ext-intl": "*",
                 "ext-mbstring": "*",
-                "mjaschen/phpgeo": "^4.2",
-                "nitotm/efficient-language-detector": "^2.0",
+                "mjaschen/phpgeo": "^5.0 || ^6.0",
+                "nitotm/efficient-language-detector": "^3.0",
                 "php": "^8.1",
                 "psr/log": "^2.0 || ^3.0",
                 "toflar/state-set-index": "^3.0",
                 "wamania/php-stemmer": "^3.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^10.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^10.5",
                 "symfony/filesystem": "^6.2",
                 "symfony/finder": "^6.2",
                 "symfony/var-dumper": "^6.2",
@@ -9179,7 +9179,7 @@
             "description": "A full text search engine with tokenization, stemming, typo tolerance, filters and geo support based on only PHP and SQLite",
             "support": {
                 "issues": "https://github.com/loupe-php/loupe/issues",
-                "source": "https://github.com/loupe-php/loupe/tree/0.9.5"
+                "source": "https://github.com/loupe-php/loupe/tree/0.10.0"
             },
             "funding": [
                 {
@@ -9187,7 +9187,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-11T12:46:40+00:00"
+            "time": "2025-03-13T08:48:07+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -9325,25 +9325,25 @@
         },
         {
             "name": "mjaschen/phpgeo",
-            "version": "4.2.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mjaschen/phpgeo.git",
-                "reference": "5e16834f9433c7780cda7e16aa279814f98ca697"
+                "reference": "71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mjaschen/phpgeo/zipball/5e16834f9433c7780cda7e16aa279814f98ca697",
-                "reference": "5e16834f9433c7780cda7e16aa279814f98ca697",
+                "url": "https://api.github.com/repos/mjaschen/phpgeo/zipball/71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931",
+                "reference": "71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": "^8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5",
-                "squizlabs/php_codesniffer": "^3.6",
-                "vimeo/psalm": "^4.13"
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.0",
+                "squizlabs/php_codesniffer": "^3.7"
             },
             "type": "library",
             "autoload": {
@@ -9392,7 +9392,7 @@
                 "docs": "https://phpgeo.marcusjaschen.de/Installation.html",
                 "email": "mjaschen@gmail.com",
                 "issues": "https://github.com/mjaschen/phpgeo/issues",
-                "source": "https://github.com/mjaschen/phpgeo/tree/4.2.1"
+                "source": "https://github.com/mjaschen/phpgeo/tree/6.0.0"
             },
             "funding": [
                 {
@@ -9404,7 +9404,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-03T08:01:10+00:00"
+            "time": "2025-01-12T09:09:15+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -9542,27 +9542,21 @@
         },
         {
             "name": "nitotm/efficient-language-detector",
-            "version": "v2.1.2",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nitotm/efficient-language-detector.git",
-                "reference": "7c69b13a6b8774a663b6612afc4c2188587fa33a"
+                "reference": "f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nitotm/efficient-language-detector/zipball/7c69b13a6b8774a663b6612afc4c2188587fa33a",
-                "reference": "7c69b13a6b8774a663b6612afc4c2188587fa33a",
+                "url": "https://api.github.com/repos/nitotm/efficient-language-detector/zipball/f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab",
+                "reference": "f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "ext-json": "*",
-                "phpmd/phpmd": "^2.13",
-                "squizlabs/php_codesniffer": "3.*",
-                "vimeo/psalm": "^5.12"
             },
             "type": "library",
             "autoload": {
@@ -9586,15 +9580,17 @@
                 "detection",
                 "detector",
                 "language",
+                "language classification",
                 "language detection",
                 "language detector",
-                "language identification"
+                "language identification",
+                "language recognition"
             ],
             "support": {
                 "issues": "https://github.com/nitotm/efficient-language-detector/issues",
-                "source": "https://github.com/nitotm/efficient-language-detector/tree/v2.1.2"
+                "source": "https://github.com/nitotm/efficient-language-detector/tree/v3.0.0"
             },
-            "time": "2024-09-10T12:52:25+00:00"
+            "time": "2024-10-10T17:53:50+00:00"
         },
         {
             "name": "nunomaduro/termwind",

--- a/.examples/symfony/composer.lock
+++ b/.examples/symfony/composer.lock
@@ -3452,11 +3452,11 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "b007020e3716d43f4e05732970e2a3295b177bef"
+                "reference": "83c3ec276069d4b985022ab62371ff5b2067e01d"
             },
             "require": {
                 "cmsig/seal": "^0.7",
-                "loupe/loupe": "^0.8 || ^0.9",
+                "loupe/loupe": "^0.8 || ^0.9 || ^0.10",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
             },
@@ -5129,16 +5129,16 @@
         },
         {
             "name": "loupe/loupe",
-            "version": "0.9.5",
+            "version": "0.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/loupe-php/loupe.git",
-                "reference": "1c65e9fff40da2247c951711166ef143bb2093df"
+                "reference": "0c47688ed4c139262446b083bfd9181b427d65e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/1c65e9fff40da2247c951711166ef143bb2093df",
-                "reference": "1c65e9fff40da2247c951711166ef143bb2093df",
+                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/0c47688ed4c139262446b083bfd9181b427d65e7",
+                "reference": "0c47688ed4c139262446b083bfd9181b427d65e7",
                 "shasum": ""
             },
             "require": {
@@ -5146,16 +5146,16 @@
                 "doctrine/lexer": "^2.0 || ^3.0",
                 "ext-intl": "*",
                 "ext-mbstring": "*",
-                "mjaschen/phpgeo": "^4.2",
-                "nitotm/efficient-language-detector": "^2.0",
+                "mjaschen/phpgeo": "^5.0 || ^6.0",
+                "nitotm/efficient-language-detector": "^3.0",
                 "php": "^8.1",
                 "psr/log": "^2.0 || ^3.0",
                 "toflar/state-set-index": "^3.0",
                 "wamania/php-stemmer": "^3.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^10.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^10.5",
                 "symfony/filesystem": "^6.2",
                 "symfony/finder": "^6.2",
                 "symfony/var-dumper": "^6.2",
@@ -5180,7 +5180,7 @@
             "description": "A full text search engine with tokenization, stemming, typo tolerance, filters and geo support based on only PHP and SQLite",
             "support": {
                 "issues": "https://github.com/loupe-php/loupe/issues",
-                "source": "https://github.com/loupe-php/loupe/tree/0.9.5"
+                "source": "https://github.com/loupe-php/loupe/tree/0.10.0"
             },
             "funding": [
                 {
@@ -5188,7 +5188,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-11T12:46:40+00:00"
+            "time": "2025-03-13T08:48:07+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -5326,25 +5326,25 @@
         },
         {
             "name": "mjaschen/phpgeo",
-            "version": "4.2.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mjaschen/phpgeo.git",
-                "reference": "5e16834f9433c7780cda7e16aa279814f98ca697"
+                "reference": "71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mjaschen/phpgeo/zipball/5e16834f9433c7780cda7e16aa279814f98ca697",
-                "reference": "5e16834f9433c7780cda7e16aa279814f98ca697",
+                "url": "https://api.github.com/repos/mjaschen/phpgeo/zipball/71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931",
+                "reference": "71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": "^8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5",
-                "squizlabs/php_codesniffer": "^3.6",
-                "vimeo/psalm": "^4.13"
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.0",
+                "squizlabs/php_codesniffer": "^3.7"
             },
             "type": "library",
             "autoload": {
@@ -5393,7 +5393,7 @@
                 "docs": "https://phpgeo.marcusjaschen.de/Installation.html",
                 "email": "mjaschen@gmail.com",
                 "issues": "https://github.com/mjaschen/phpgeo/issues",
-                "source": "https://github.com/mjaschen/phpgeo/tree/4.2.1"
+                "source": "https://github.com/mjaschen/phpgeo/tree/6.0.0"
             },
             "funding": [
                 {
@@ -5405,7 +5405,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-03T08:01:10+00:00"
+            "time": "2025-01-12T09:09:15+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -5572,27 +5572,21 @@
         },
         {
             "name": "nitotm/efficient-language-detector",
-            "version": "v2.1.2",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nitotm/efficient-language-detector.git",
-                "reference": "7c69b13a6b8774a663b6612afc4c2188587fa33a"
+                "reference": "f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nitotm/efficient-language-detector/zipball/7c69b13a6b8774a663b6612afc4c2188587fa33a",
-                "reference": "7c69b13a6b8774a663b6612afc4c2188587fa33a",
+                "url": "https://api.github.com/repos/nitotm/efficient-language-detector/zipball/f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab",
+                "reference": "f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "ext-json": "*",
-                "phpmd/phpmd": "^2.13",
-                "squizlabs/php_codesniffer": "3.*",
-                "vimeo/psalm": "^5.12"
             },
             "type": "library",
             "autoload": {
@@ -5616,15 +5610,17 @@
                 "detection",
                 "detector",
                 "language",
+                "language classification",
                 "language detection",
                 "language detector",
-                "language identification"
+                "language identification",
+                "language recognition"
             ],
             "support": {
                 "issues": "https://github.com/nitotm/efficient-language-detector/issues",
-                "source": "https://github.com/nitotm/efficient-language-detector/tree/v2.1.2"
+                "source": "https://github.com/nitotm/efficient-language-detector/tree/v3.0.0"
             },
-            "time": "2024-09-10T12:52:25+00:00"
+            "time": "2024-10-10T17:53:50+00:00"
         },
         {
             "name": "nyholm/psr7",

--- a/.examples/yii/composer.lock
+++ b/.examples/yii/composer.lock
@@ -6192,11 +6192,11 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "b007020e3716d43f4e05732970e2a3295b177bef"
+                "reference": "83c3ec276069d4b985022ab62371ff5b2067e01d"
             },
             "require": {
                 "cmsig/seal": "^0.7",
-                "loupe/loupe": "^0.8 || ^0.9",
+                "loupe/loupe": "^0.8 || ^0.9 || ^0.10",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
             },
@@ -8613,16 +8613,16 @@
         },
         {
             "name": "loupe/loupe",
-            "version": "0.9.5",
+            "version": "0.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/loupe-php/loupe.git",
-                "reference": "1c65e9fff40da2247c951711166ef143bb2093df"
+                "reference": "0c47688ed4c139262446b083bfd9181b427d65e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/1c65e9fff40da2247c951711166ef143bb2093df",
-                "reference": "1c65e9fff40da2247c951711166ef143bb2093df",
+                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/0c47688ed4c139262446b083bfd9181b427d65e7",
+                "reference": "0c47688ed4c139262446b083bfd9181b427d65e7",
                 "shasum": ""
             },
             "require": {
@@ -8630,16 +8630,16 @@
                 "doctrine/lexer": "^2.0 || ^3.0",
                 "ext-intl": "*",
                 "ext-mbstring": "*",
-                "mjaschen/phpgeo": "^4.2",
-                "nitotm/efficient-language-detector": "^2.0",
+                "mjaschen/phpgeo": "^5.0 || ^6.0",
+                "nitotm/efficient-language-detector": "^3.0",
                 "php": "^8.1",
                 "psr/log": "^2.0 || ^3.0",
                 "toflar/state-set-index": "^3.0",
                 "wamania/php-stemmer": "^3.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^10.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^10.5",
                 "symfony/filesystem": "^6.2",
                 "symfony/finder": "^6.2",
                 "symfony/var-dumper": "^6.2",
@@ -8664,7 +8664,7 @@
             "description": "A full text search engine with tokenization, stemming, typo tolerance, filters and geo support based on only PHP and SQLite",
             "support": {
                 "issues": "https://github.com/loupe-php/loupe/issues",
-                "source": "https://github.com/loupe-php/loupe/tree/0.9.5"
+                "source": "https://github.com/loupe-php/loupe/tree/0.10.0"
             },
             "funding": [
                 {
@@ -8672,7 +8672,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-11T12:46:40+00:00"
+            "time": "2025-03-13T08:48:07+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -8810,25 +8810,25 @@
         },
         {
             "name": "mjaschen/phpgeo",
-            "version": "4.2.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mjaschen/phpgeo.git",
-                "reference": "5e16834f9433c7780cda7e16aa279814f98ca697"
+                "reference": "71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mjaschen/phpgeo/zipball/5e16834f9433c7780cda7e16aa279814f98ca697",
-                "reference": "5e16834f9433c7780cda7e16aa279814f98ca697",
+                "url": "https://api.github.com/repos/mjaschen/phpgeo/zipball/71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931",
+                "reference": "71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": "^8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5",
-                "squizlabs/php_codesniffer": "^3.6",
-                "vimeo/psalm": "^4.13"
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.0",
+                "squizlabs/php_codesniffer": "^3.7"
             },
             "type": "library",
             "autoload": {
@@ -8877,7 +8877,7 @@
                 "docs": "https://phpgeo.marcusjaschen.de/Installation.html",
                 "email": "mjaschen@gmail.com",
                 "issues": "https://github.com/mjaschen/phpgeo/issues",
-                "source": "https://github.com/mjaschen/phpgeo/tree/4.2.1"
+                "source": "https://github.com/mjaschen/phpgeo/tree/6.0.0"
             },
             "funding": [
                 {
@@ -8889,7 +8889,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-03T08:01:10+00:00"
+            "time": "2025-01-12T09:09:15+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -9114,27 +9114,21 @@
         },
         {
             "name": "nitotm/efficient-language-detector",
-            "version": "v2.1.2",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nitotm/efficient-language-detector.git",
-                "reference": "7c69b13a6b8774a663b6612afc4c2188587fa33a"
+                "reference": "f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nitotm/efficient-language-detector/zipball/7c69b13a6b8774a663b6612afc4c2188587fa33a",
-                "reference": "7c69b13a6b8774a663b6612afc4c2188587fa33a",
+                "url": "https://api.github.com/repos/nitotm/efficient-language-detector/zipball/f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab",
+                "reference": "f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "ext-json": "*",
-                "phpmd/phpmd": "^2.13",
-                "squizlabs/php_codesniffer": "3.*",
-                "vimeo/psalm": "^5.12"
             },
             "type": "library",
             "autoload": {
@@ -9158,15 +9152,17 @@
                 "detection",
                 "detector",
                 "language",
+                "language classification",
                 "language detection",
                 "language detector",
-                "language identification"
+                "language identification",
+                "language recognition"
             ],
             "support": {
                 "issues": "https://github.com/nitotm/efficient-language-detector/issues",
-                "source": "https://github.com/nitotm/efficient-language-detector/tree/v2.1.2"
+                "source": "https://github.com/nitotm/efficient-language-detector/tree/v3.0.0"
             },
-            "time": "2024-09-10T12:52:25+00:00"
+            "time": "2024-10-10T17:53:50+00:00"
         },
         {
             "name": "nyholm/psr7",
@@ -10951,12 +10947,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "9ec3309dcdef9afaf7649b5ddff330d58abe4d34"
+                "reference": "082338f65948c175f5d9be2f420571b40f254e58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/9ec3309dcdef9afaf7649b5ddff330d58abe4d34",
-                "reference": "9ec3309dcdef9afaf7649b5ddff330d58abe4d34",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/082338f65948c175f5d9be2f420571b40f254e58",
+                "reference": "082338f65948c175f5d9be2f420571b40f254e58",
                 "shasum": ""
             },
             "conflict": {
@@ -11049,12 +11045,14 @@
                 "chriskacerguis/codeigniter-restserver": "<=2.7.1",
                 "civicrm/civicrm-core": ">=4.2,<4.2.9|>=4.3,<4.3.3",
                 "ckeditor/ckeditor": "<4.25",
+                "clickstorm/cs-seo": ">=6,<6.7|>=7,<7.4|>=8,<8.3|>=9,<9.2",
                 "cockpit-hq/cockpit": "<2.7|==2.7",
                 "codeception/codeception": "<3.1.3|>=4,<4.1.22",
                 "codeigniter/framework": "<3.1.9",
                 "codeigniter4/framework": "<4.5.8",
                 "codeigniter4/shield": "<1.0.0.0-beta8",
                 "codiad/codiad": "<=2.8.4",
+                "codingms/additional-tca": ">=1.7,<1.15.17|>=1.16,<1.16.9",
                 "components/jquery": ">=1.0.3,<3.5",
                 "composer/composer": "<1.10.27|>=2,<2.2.24|>=2.3,<2.7.7",
                 "concrete5/concrete5": "<9.4.0.0-RC1-dev",
@@ -11820,7 +11818,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-17T22:04:58+00:00"
+            "time": "2025-03-18T11:05:04+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/integrations/laravel/composer.lock
+++ b/integrations/laravel/composer.lock
@@ -2848,11 +2848,11 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "b007020e3716d43f4e05732970e2a3295b177bef"
+                "reference": "83c3ec276069d4b985022ab62371ff5b2067e01d"
             },
             "require": {
                 "cmsig/seal": "^0.7",
-                "loupe/loupe": "^0.8 || ^0.9",
+                "loupe/loupe": "^0.8 || ^0.9 || ^0.10",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
             },
@@ -4529,16 +4529,16 @@
         },
         {
             "name": "loupe/loupe",
-            "version": "0.9.5",
+            "version": "0.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/loupe-php/loupe.git",
-                "reference": "1c65e9fff40da2247c951711166ef143bb2093df"
+                "reference": "0c47688ed4c139262446b083bfd9181b427d65e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/1c65e9fff40da2247c951711166ef143bb2093df",
-                "reference": "1c65e9fff40da2247c951711166ef143bb2093df",
+                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/0c47688ed4c139262446b083bfd9181b427d65e7",
+                "reference": "0c47688ed4c139262446b083bfd9181b427d65e7",
                 "shasum": ""
             },
             "require": {
@@ -4546,16 +4546,16 @@
                 "doctrine/lexer": "^2.0 || ^3.0",
                 "ext-intl": "*",
                 "ext-mbstring": "*",
-                "mjaschen/phpgeo": "^4.2",
-                "nitotm/efficient-language-detector": "^2.0",
+                "mjaschen/phpgeo": "^5.0 || ^6.0",
+                "nitotm/efficient-language-detector": "^3.0",
                 "php": "^8.1",
                 "psr/log": "^2.0 || ^3.0",
                 "toflar/state-set-index": "^3.0",
                 "wamania/php-stemmer": "^3.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^10.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^10.5",
                 "symfony/filesystem": "^6.2",
                 "symfony/finder": "^6.2",
                 "symfony/var-dumper": "^6.2",
@@ -4580,7 +4580,7 @@
             "description": "A full text search engine with tokenization, stemming, typo tolerance, filters and geo support based on only PHP and SQLite",
             "support": {
                 "issues": "https://github.com/loupe-php/loupe/issues",
-                "source": "https://github.com/loupe-php/loupe/tree/0.9.5"
+                "source": "https://github.com/loupe-php/loupe/tree/0.10.0"
             },
             "funding": [
                 {
@@ -4588,7 +4588,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-11T12:46:40+00:00"
+            "time": "2025-03-13T08:48:07+00:00"
         },
         {
             "name": "meilisearch/meilisearch-php",
@@ -4659,25 +4659,25 @@
         },
         {
             "name": "mjaschen/phpgeo",
-            "version": "4.2.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mjaschen/phpgeo.git",
-                "reference": "5e16834f9433c7780cda7e16aa279814f98ca697"
+                "reference": "71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mjaschen/phpgeo/zipball/5e16834f9433c7780cda7e16aa279814f98ca697",
-                "reference": "5e16834f9433c7780cda7e16aa279814f98ca697",
+                "url": "https://api.github.com/repos/mjaschen/phpgeo/zipball/71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931",
+                "reference": "71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": "^8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5",
-                "squizlabs/php_codesniffer": "^3.6",
-                "vimeo/psalm": "^4.13"
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.0",
+                "squizlabs/php_codesniffer": "^3.7"
             },
             "type": "library",
             "autoload": {
@@ -4726,7 +4726,7 @@
                 "docs": "https://phpgeo.marcusjaschen.de/Installation.html",
                 "email": "mjaschen@gmail.com",
                 "issues": "https://github.com/mjaschen/phpgeo/issues",
-                "source": "https://github.com/mjaschen/phpgeo/tree/4.2.1"
+                "source": "https://github.com/mjaschen/phpgeo/tree/6.0.0"
             },
             "funding": [
                 {
@@ -4738,7 +4738,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-03T08:01:10+00:00"
+            "time": "2025-01-12T09:09:15+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -4965,27 +4965,21 @@
         },
         {
             "name": "nitotm/efficient-language-detector",
-            "version": "v2.x-dev",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nitotm/efficient-language-detector.git",
-                "reference": "7c69b13a6b8774a663b6612afc4c2188587fa33a"
+                "reference": "f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nitotm/efficient-language-detector/zipball/7c69b13a6b8774a663b6612afc4c2188587fa33a",
-                "reference": "7c69b13a6b8774a663b6612afc4c2188587fa33a",
+                "url": "https://api.github.com/repos/nitotm/efficient-language-detector/zipball/f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab",
+                "reference": "f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "ext-json": "*",
-                "phpmd/phpmd": "^2.13",
-                "squizlabs/php_codesniffer": "3.*",
-                "vimeo/psalm": "^5.12"
             },
             "type": "library",
             "autoload": {
@@ -5009,15 +5003,17 @@
                 "detection",
                 "detector",
                 "language",
+                "language classification",
                 "language detection",
                 "language detector",
-                "language identification"
+                "language identification",
+                "language recognition"
             ],
             "support": {
                 "issues": "https://github.com/nitotm/efficient-language-detector/issues",
-                "source": "https://github.com/nitotm/efficient-language-detector/tree/v2.1.2"
+                "source": "https://github.com/nitotm/efficient-language-detector/tree/v3.0.0"
             },
-            "time": "2024-09-10T12:52:25+00:00"
+            "time": "2024-10-10T17:53:50+00:00"
         },
         {
             "name": "nyholm/psr7",

--- a/integrations/mezzio/composer.lock
+++ b/integrations/mezzio/composer.lock
@@ -1481,11 +1481,11 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "b007020e3716d43f4e05732970e2a3295b177bef"
+                "reference": "83c3ec276069d4b985022ab62371ff5b2067e01d"
             },
             "require": {
                 "cmsig/seal": "^0.7",
-                "loupe/loupe": "^0.8 || ^0.9",
+                "loupe/loupe": "^0.8 || ^0.9 || ^0.10",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
             },
@@ -3162,16 +3162,16 @@
         },
         {
             "name": "loupe/loupe",
-            "version": "0.9.5",
+            "version": "0.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/loupe-php/loupe.git",
-                "reference": "1c65e9fff40da2247c951711166ef143bb2093df"
+                "reference": "0c47688ed4c139262446b083bfd9181b427d65e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/1c65e9fff40da2247c951711166ef143bb2093df",
-                "reference": "1c65e9fff40da2247c951711166ef143bb2093df",
+                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/0c47688ed4c139262446b083bfd9181b427d65e7",
+                "reference": "0c47688ed4c139262446b083bfd9181b427d65e7",
                 "shasum": ""
             },
             "require": {
@@ -3179,16 +3179,16 @@
                 "doctrine/lexer": "^2.0 || ^3.0",
                 "ext-intl": "*",
                 "ext-mbstring": "*",
-                "mjaschen/phpgeo": "^4.2",
-                "nitotm/efficient-language-detector": "^2.0",
+                "mjaschen/phpgeo": "^5.0 || ^6.0",
+                "nitotm/efficient-language-detector": "^3.0",
                 "php": "^8.1",
                 "psr/log": "^2.0 || ^3.0",
                 "toflar/state-set-index": "^3.0",
                 "wamania/php-stemmer": "^3.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^10.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^10.5",
                 "symfony/filesystem": "^6.2",
                 "symfony/finder": "^6.2",
                 "symfony/var-dumper": "^6.2",
@@ -3213,7 +3213,7 @@
             "description": "A full text search engine with tokenization, stemming, typo tolerance, filters and geo support based on only PHP and SQLite",
             "support": {
                 "issues": "https://github.com/loupe-php/loupe/issues",
-                "source": "https://github.com/loupe-php/loupe/tree/0.9.5"
+                "source": "https://github.com/loupe-php/loupe/tree/0.10.0"
             },
             "funding": [
                 {
@@ -3221,7 +3221,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-11T12:46:40+00:00"
+            "time": "2025-03-13T08:48:07+00:00"
         },
         {
             "name": "meilisearch/meilisearch-php",
@@ -3292,25 +3292,25 @@
         },
         {
             "name": "mjaschen/phpgeo",
-            "version": "4.2.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mjaschen/phpgeo.git",
-                "reference": "5e16834f9433c7780cda7e16aa279814f98ca697"
+                "reference": "71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mjaschen/phpgeo/zipball/5e16834f9433c7780cda7e16aa279814f98ca697",
-                "reference": "5e16834f9433c7780cda7e16aa279814f98ca697",
+                "url": "https://api.github.com/repos/mjaschen/phpgeo/zipball/71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931",
+                "reference": "71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": "^8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5",
-                "squizlabs/php_codesniffer": "^3.6",
-                "vimeo/psalm": "^4.13"
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.0",
+                "squizlabs/php_codesniffer": "^3.7"
             },
             "type": "library",
             "autoload": {
@@ -3359,7 +3359,7 @@
                 "docs": "https://phpgeo.marcusjaschen.de/Installation.html",
                 "email": "mjaschen@gmail.com",
                 "issues": "https://github.com/mjaschen/phpgeo/issues",
-                "source": "https://github.com/mjaschen/phpgeo/tree/4.2.1"
+                "source": "https://github.com/mjaschen/phpgeo/tree/6.0.0"
             },
             "funding": [
                 {
@@ -3371,7 +3371,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-03T08:01:10+00:00"
+            "time": "2025-01-12T09:09:15+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -3598,27 +3598,21 @@
         },
         {
             "name": "nitotm/efficient-language-detector",
-            "version": "v2.x-dev",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nitotm/efficient-language-detector.git",
-                "reference": "7c69b13a6b8774a663b6612afc4c2188587fa33a"
+                "reference": "f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nitotm/efficient-language-detector/zipball/7c69b13a6b8774a663b6612afc4c2188587fa33a",
-                "reference": "7c69b13a6b8774a663b6612afc4c2188587fa33a",
+                "url": "https://api.github.com/repos/nitotm/efficient-language-detector/zipball/f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab",
+                "reference": "f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "ext-json": "*",
-                "phpmd/phpmd": "^2.13",
-                "squizlabs/php_codesniffer": "3.*",
-                "vimeo/psalm": "^5.12"
             },
             "type": "library",
             "autoload": {
@@ -3642,15 +3636,17 @@
                 "detection",
                 "detector",
                 "language",
+                "language classification",
                 "language detection",
                 "language detector",
-                "language identification"
+                "language identification",
+                "language recognition"
             ],
             "support": {
                 "issues": "https://github.com/nitotm/efficient-language-detector/issues",
-                "source": "https://github.com/nitotm/efficient-language-detector/tree/v2.1.2"
+                "source": "https://github.com/nitotm/efficient-language-detector/tree/v3.0.0"
             },
-            "time": "2024-09-10T12:52:25+00:00"
+            "time": "2024-10-10T17:53:50+00:00"
         },
         {
             "name": "nyholm/psr7",

--- a/integrations/spiral/composer.lock
+++ b/integrations/spiral/composer.lock
@@ -2514,11 +2514,11 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "b007020e3716d43f4e05732970e2a3295b177bef"
+                "reference": "83c3ec276069d4b985022ab62371ff5b2067e01d"
             },
             "require": {
                 "cmsig/seal": "^0.7",
-                "loupe/loupe": "^0.8 || ^0.9",
+                "loupe/loupe": "^0.8 || ^0.9 || ^0.10",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
             },
@@ -4195,16 +4195,16 @@
         },
         {
             "name": "loupe/loupe",
-            "version": "0.9.5",
+            "version": "0.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/loupe-php/loupe.git",
-                "reference": "1c65e9fff40da2247c951711166ef143bb2093df"
+                "reference": "0c47688ed4c139262446b083bfd9181b427d65e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/1c65e9fff40da2247c951711166ef143bb2093df",
-                "reference": "1c65e9fff40da2247c951711166ef143bb2093df",
+                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/0c47688ed4c139262446b083bfd9181b427d65e7",
+                "reference": "0c47688ed4c139262446b083bfd9181b427d65e7",
                 "shasum": ""
             },
             "require": {
@@ -4212,16 +4212,16 @@
                 "doctrine/lexer": "^2.0 || ^3.0",
                 "ext-intl": "*",
                 "ext-mbstring": "*",
-                "mjaschen/phpgeo": "^4.2",
-                "nitotm/efficient-language-detector": "^2.0",
+                "mjaschen/phpgeo": "^5.0 || ^6.0",
+                "nitotm/efficient-language-detector": "^3.0",
                 "php": "^8.1",
                 "psr/log": "^2.0 || ^3.0",
                 "toflar/state-set-index": "^3.0",
                 "wamania/php-stemmer": "^3.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^10.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^10.5",
                 "symfony/filesystem": "^6.2",
                 "symfony/finder": "^6.2",
                 "symfony/var-dumper": "^6.2",
@@ -4246,7 +4246,7 @@
             "description": "A full text search engine with tokenization, stemming, typo tolerance, filters and geo support based on only PHP and SQLite",
             "support": {
                 "issues": "https://github.com/loupe-php/loupe/issues",
-                "source": "https://github.com/loupe-php/loupe/tree/0.9.5"
+                "source": "https://github.com/loupe-php/loupe/tree/0.10.0"
             },
             "funding": [
                 {
@@ -4254,7 +4254,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-11T12:46:40+00:00"
+            "time": "2025-03-13T08:48:07+00:00"
         },
         {
             "name": "meilisearch/meilisearch-php",
@@ -4325,25 +4325,25 @@
         },
         {
             "name": "mjaschen/phpgeo",
-            "version": "4.2.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mjaschen/phpgeo.git",
-                "reference": "5e16834f9433c7780cda7e16aa279814f98ca697"
+                "reference": "71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mjaschen/phpgeo/zipball/5e16834f9433c7780cda7e16aa279814f98ca697",
-                "reference": "5e16834f9433c7780cda7e16aa279814f98ca697",
+                "url": "https://api.github.com/repos/mjaschen/phpgeo/zipball/71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931",
+                "reference": "71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": "^8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5",
-                "squizlabs/php_codesniffer": "^3.6",
-                "vimeo/psalm": "^4.13"
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.0",
+                "squizlabs/php_codesniffer": "^3.7"
             },
             "type": "library",
             "autoload": {
@@ -4392,7 +4392,7 @@
                 "docs": "https://phpgeo.marcusjaschen.de/Installation.html",
                 "email": "mjaschen@gmail.com",
                 "issues": "https://github.com/mjaschen/phpgeo/issues",
-                "source": "https://github.com/mjaschen/phpgeo/tree/4.2.1"
+                "source": "https://github.com/mjaschen/phpgeo/tree/6.0.0"
             },
             "funding": [
                 {
@@ -4404,7 +4404,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-03T08:01:10+00:00"
+            "time": "2025-01-12T09:09:15+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -4631,27 +4631,21 @@
         },
         {
             "name": "nitotm/efficient-language-detector",
-            "version": "v2.x-dev",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nitotm/efficient-language-detector.git",
-                "reference": "7c69b13a6b8774a663b6612afc4c2188587fa33a"
+                "reference": "f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nitotm/efficient-language-detector/zipball/7c69b13a6b8774a663b6612afc4c2188587fa33a",
-                "reference": "7c69b13a6b8774a663b6612afc4c2188587fa33a",
+                "url": "https://api.github.com/repos/nitotm/efficient-language-detector/zipball/f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab",
+                "reference": "f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "ext-json": "*",
-                "phpmd/phpmd": "^2.13",
-                "squizlabs/php_codesniffer": "3.*",
-                "vimeo/psalm": "^5.12"
             },
             "type": "library",
             "autoload": {
@@ -4675,15 +4669,17 @@
                 "detection",
                 "detector",
                 "language",
+                "language classification",
                 "language detection",
                 "language detector",
-                "language identification"
+                "language identification",
+                "language recognition"
             ],
             "support": {
                 "issues": "https://github.com/nitotm/efficient-language-detector/issues",
-                "source": "https://github.com/nitotm/efficient-language-detector/tree/v2.1.2"
+                "source": "https://github.com/nitotm/efficient-language-detector/tree/v3.0.0"
             },
-            "time": "2024-09-10T12:52:25+00:00"
+            "time": "2024-10-10T17:53:50+00:00"
         },
         {
             "name": "nyholm/psr7",

--- a/integrations/symfony/composer.lock
+++ b/integrations/symfony/composer.lock
@@ -2130,11 +2130,11 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "b007020e3716d43f4e05732970e2a3295b177bef"
+                "reference": "83c3ec276069d4b985022ab62371ff5b2067e01d"
             },
             "require": {
                 "cmsig/seal": "^0.7",
-                "loupe/loupe": "^0.8 || ^0.9",
+                "loupe/loupe": "^0.8 || ^0.9 || ^0.10",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
             },
@@ -3811,16 +3811,16 @@
         },
         {
             "name": "loupe/loupe",
-            "version": "0.9.5",
+            "version": "0.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/loupe-php/loupe.git",
-                "reference": "1c65e9fff40da2247c951711166ef143bb2093df"
+                "reference": "0c47688ed4c139262446b083bfd9181b427d65e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/1c65e9fff40da2247c951711166ef143bb2093df",
-                "reference": "1c65e9fff40da2247c951711166ef143bb2093df",
+                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/0c47688ed4c139262446b083bfd9181b427d65e7",
+                "reference": "0c47688ed4c139262446b083bfd9181b427d65e7",
                 "shasum": ""
             },
             "require": {
@@ -3828,16 +3828,16 @@
                 "doctrine/lexer": "^2.0 || ^3.0",
                 "ext-intl": "*",
                 "ext-mbstring": "*",
-                "mjaschen/phpgeo": "^4.2",
-                "nitotm/efficient-language-detector": "^2.0",
+                "mjaschen/phpgeo": "^5.0 || ^6.0",
+                "nitotm/efficient-language-detector": "^3.0",
                 "php": "^8.1",
                 "psr/log": "^2.0 || ^3.0",
                 "toflar/state-set-index": "^3.0",
                 "wamania/php-stemmer": "^3.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^10.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^10.5",
                 "symfony/filesystem": "^6.2",
                 "symfony/finder": "^6.2",
                 "symfony/var-dumper": "^6.2",
@@ -3862,7 +3862,7 @@
             "description": "A full text search engine with tokenization, stemming, typo tolerance, filters and geo support based on only PHP and SQLite",
             "support": {
                 "issues": "https://github.com/loupe-php/loupe/issues",
-                "source": "https://github.com/loupe-php/loupe/tree/0.9.5"
+                "source": "https://github.com/loupe-php/loupe/tree/0.10.0"
             },
             "funding": [
                 {
@@ -3870,7 +3870,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-11T12:46:40+00:00"
+            "time": "2025-03-13T08:48:07+00:00"
         },
         {
             "name": "meilisearch/meilisearch-php",
@@ -3941,25 +3941,25 @@
         },
         {
             "name": "mjaschen/phpgeo",
-            "version": "4.2.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mjaschen/phpgeo.git",
-                "reference": "5e16834f9433c7780cda7e16aa279814f98ca697"
+                "reference": "71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mjaschen/phpgeo/zipball/5e16834f9433c7780cda7e16aa279814f98ca697",
-                "reference": "5e16834f9433c7780cda7e16aa279814f98ca697",
+                "url": "https://api.github.com/repos/mjaschen/phpgeo/zipball/71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931",
+                "reference": "71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": "^8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5",
-                "squizlabs/php_codesniffer": "^3.6",
-                "vimeo/psalm": "^4.13"
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.0",
+                "squizlabs/php_codesniffer": "^3.7"
             },
             "type": "library",
             "autoload": {
@@ -4008,7 +4008,7 @@
                 "docs": "https://phpgeo.marcusjaschen.de/Installation.html",
                 "email": "mjaschen@gmail.com",
                 "issues": "https://github.com/mjaschen/phpgeo/issues",
-                "source": "https://github.com/mjaschen/phpgeo/tree/4.2.1"
+                "source": "https://github.com/mjaschen/phpgeo/tree/6.0.0"
             },
             "funding": [
                 {
@@ -4020,7 +4020,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-03T08:01:10+00:00"
+            "time": "2025-01-12T09:09:15+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -4247,27 +4247,21 @@
         },
         {
             "name": "nitotm/efficient-language-detector",
-            "version": "v2.x-dev",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nitotm/efficient-language-detector.git",
-                "reference": "7c69b13a6b8774a663b6612afc4c2188587fa33a"
+                "reference": "f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nitotm/efficient-language-detector/zipball/7c69b13a6b8774a663b6612afc4c2188587fa33a",
-                "reference": "7c69b13a6b8774a663b6612afc4c2188587fa33a",
+                "url": "https://api.github.com/repos/nitotm/efficient-language-detector/zipball/f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab",
+                "reference": "f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "ext-json": "*",
-                "phpmd/phpmd": "^2.13",
-                "squizlabs/php_codesniffer": "3.*",
-                "vimeo/psalm": "^5.12"
             },
             "type": "library",
             "autoload": {
@@ -4291,15 +4285,17 @@
                 "detection",
                 "detector",
                 "language",
+                "language classification",
                 "language detection",
                 "language detector",
-                "language identification"
+                "language identification",
+                "language recognition"
             ],
             "support": {
                 "issues": "https://github.com/nitotm/efficient-language-detector/issues",
-                "source": "https://github.com/nitotm/efficient-language-detector/tree/v2.1.2"
+                "source": "https://github.com/nitotm/efficient-language-detector/tree/v3.0.0"
             },
-            "time": "2024-09-10T12:52:25+00:00"
+            "time": "2024-10-10T17:53:50+00:00"
         },
         {
             "name": "nyholm/psr7",

--- a/integrations/yii/composer.lock
+++ b/integrations/yii/composer.lock
@@ -1606,11 +1606,11 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
-                "reference": "b007020e3716d43f4e05732970e2a3295b177bef"
+                "reference": "83c3ec276069d4b985022ab62371ff5b2067e01d"
             },
             "require": {
                 "cmsig/seal": "^0.7",
-                "loupe/loupe": "^0.8 || ^0.9",
+                "loupe/loupe": "^0.8 || ^0.9 || ^0.10",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0"
             },
@@ -3287,16 +3287,16 @@
         },
         {
             "name": "loupe/loupe",
-            "version": "0.9.5",
+            "version": "0.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/loupe-php/loupe.git",
-                "reference": "1c65e9fff40da2247c951711166ef143bb2093df"
+                "reference": "0c47688ed4c139262446b083bfd9181b427d65e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/1c65e9fff40da2247c951711166ef143bb2093df",
-                "reference": "1c65e9fff40da2247c951711166ef143bb2093df",
+                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/0c47688ed4c139262446b083bfd9181b427d65e7",
+                "reference": "0c47688ed4c139262446b083bfd9181b427d65e7",
                 "shasum": ""
             },
             "require": {
@@ -3304,16 +3304,16 @@
                 "doctrine/lexer": "^2.0 || ^3.0",
                 "ext-intl": "*",
                 "ext-mbstring": "*",
-                "mjaschen/phpgeo": "^4.2",
-                "nitotm/efficient-language-detector": "^2.0",
+                "mjaschen/phpgeo": "^5.0 || ^6.0",
+                "nitotm/efficient-language-detector": "^3.0",
                 "php": "^8.1",
                 "psr/log": "^2.0 || ^3.0",
                 "toflar/state-set-index": "^3.0",
                 "wamania/php-stemmer": "^3.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^10.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^10.5",
                 "symfony/filesystem": "^6.2",
                 "symfony/finder": "^6.2",
                 "symfony/var-dumper": "^6.2",
@@ -3338,7 +3338,7 @@
             "description": "A full text search engine with tokenization, stemming, typo tolerance, filters and geo support based on only PHP and SQLite",
             "support": {
                 "issues": "https://github.com/loupe-php/loupe/issues",
-                "source": "https://github.com/loupe-php/loupe/tree/0.9.5"
+                "source": "https://github.com/loupe-php/loupe/tree/0.10.0"
             },
             "funding": [
                 {
@@ -3346,7 +3346,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-11T12:46:40+00:00"
+            "time": "2025-03-13T08:48:07+00:00"
         },
         {
             "name": "meilisearch/meilisearch-php",
@@ -3417,25 +3417,25 @@
         },
         {
             "name": "mjaschen/phpgeo",
-            "version": "4.2.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mjaschen/phpgeo.git",
-                "reference": "5e16834f9433c7780cda7e16aa279814f98ca697"
+                "reference": "71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mjaschen/phpgeo/zipball/5e16834f9433c7780cda7e16aa279814f98ca697",
-                "reference": "5e16834f9433c7780cda7e16aa279814f98ca697",
+                "url": "https://api.github.com/repos/mjaschen/phpgeo/zipball/71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931",
+                "reference": "71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": "^8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5",
-                "squizlabs/php_codesniffer": "^3.6",
-                "vimeo/psalm": "^4.13"
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.0",
+                "squizlabs/php_codesniffer": "^3.7"
             },
             "type": "library",
             "autoload": {
@@ -3484,7 +3484,7 @@
                 "docs": "https://phpgeo.marcusjaschen.de/Installation.html",
                 "email": "mjaschen@gmail.com",
                 "issues": "https://github.com/mjaschen/phpgeo/issues",
-                "source": "https://github.com/mjaschen/phpgeo/tree/4.2.1"
+                "source": "https://github.com/mjaschen/phpgeo/tree/6.0.0"
             },
             "funding": [
                 {
@@ -3496,7 +3496,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-03T08:01:10+00:00"
+            "time": "2025-01-12T09:09:15+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -3723,27 +3723,21 @@
         },
         {
             "name": "nitotm/efficient-language-detector",
-            "version": "v2.x-dev",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nitotm/efficient-language-detector.git",
-                "reference": "7c69b13a6b8774a663b6612afc4c2188587fa33a"
+                "reference": "f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nitotm/efficient-language-detector/zipball/7c69b13a6b8774a663b6612afc4c2188587fa33a",
-                "reference": "7c69b13a6b8774a663b6612afc4c2188587fa33a",
+                "url": "https://api.github.com/repos/nitotm/efficient-language-detector/zipball/f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab",
+                "reference": "f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "ext-json": "*",
-                "phpmd/phpmd": "^2.13",
-                "squizlabs/php_codesniffer": "3.*",
-                "vimeo/psalm": "^5.12"
             },
             "type": "library",
             "autoload": {
@@ -3767,15 +3761,17 @@
                 "detection",
                 "detector",
                 "language",
+                "language classification",
                 "language detection",
                 "language detector",
-                "language identification"
+                "language identification",
+                "language recognition"
             ],
             "support": {
                 "issues": "https://github.com/nitotm/efficient-language-detector/issues",
-                "source": "https://github.com/nitotm/efficient-language-detector/tree/v2.1.2"
+                "source": "https://github.com/nitotm/efficient-language-detector/tree/v3.0.0"
             },
-            "time": "2024-09-10T12:52:25+00:00"
+            "time": "2024-10-10T17:53:50+00:00"
         },
         {
             "name": "nyholm/psr7",

--- a/packages/seal-loupe-adapter/composer.json
+++ b/packages/seal-loupe-adapter/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": "^8.1",
         "cmsig/seal": "^0.7",
-        "loupe/loupe": "^0.8 || ^0.9",
+        "loupe/loupe": "^0.8 || ^0.9 || ^0.10",
         "psr/container": "^1.0 || ^2.0"
     },
     "require-dev": {

--- a/packages/seal-loupe-adapter/composer.lock
+++ b/packages/seal-loupe-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8f0c36c2a68c4fc2616fd1b198e85192",
+    "content-hash": "3a7b2c5a3f5285814341fdd45915e209",
     "packages": [
         {
             "name": "cmsig/seal",
@@ -334,16 +334,16 @@
         },
         {
             "name": "loupe/loupe",
-            "version": "0.9.5",
+            "version": "0.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/loupe-php/loupe.git",
-                "reference": "1c65e9fff40da2247c951711166ef143bb2093df"
+                "reference": "0c47688ed4c139262446b083bfd9181b427d65e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/1c65e9fff40da2247c951711166ef143bb2093df",
-                "reference": "1c65e9fff40da2247c951711166ef143bb2093df",
+                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/0c47688ed4c139262446b083bfd9181b427d65e7",
+                "reference": "0c47688ed4c139262446b083bfd9181b427d65e7",
                 "shasum": ""
             },
             "require": {
@@ -351,16 +351,16 @@
                 "doctrine/lexer": "^2.0 || ^3.0",
                 "ext-intl": "*",
                 "ext-mbstring": "*",
-                "mjaschen/phpgeo": "^4.2",
-                "nitotm/efficient-language-detector": "^2.0",
+                "mjaschen/phpgeo": "^5.0 || ^6.0",
+                "nitotm/efficient-language-detector": "^3.0",
                 "php": "^8.1",
                 "psr/log": "^2.0 || ^3.0",
                 "toflar/state-set-index": "^3.0",
                 "wamania/php-stemmer": "^3.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^10.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^10.5",
                 "symfony/filesystem": "^6.2",
                 "symfony/finder": "^6.2",
                 "symfony/var-dumper": "^6.2",
@@ -385,7 +385,7 @@
             "description": "A full text search engine with tokenization, stemming, typo tolerance, filters and geo support based on only PHP and SQLite",
             "support": {
                 "issues": "https://github.com/loupe-php/loupe/issues",
-                "source": "https://github.com/loupe-php/loupe/tree/0.9.5"
+                "source": "https://github.com/loupe-php/loupe/tree/0.10.0"
             },
             "funding": [
                 {
@@ -393,29 +393,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-11T12:46:40+00:00"
+            "time": "2025-03-13T08:48:07+00:00"
         },
         {
             "name": "mjaschen/phpgeo",
-            "version": "4.2.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mjaschen/phpgeo.git",
-                "reference": "5e16834f9433c7780cda7e16aa279814f98ca697"
+                "reference": "71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mjaschen/phpgeo/zipball/5e16834f9433c7780cda7e16aa279814f98ca697",
-                "reference": "5e16834f9433c7780cda7e16aa279814f98ca697",
+                "url": "https://api.github.com/repos/mjaschen/phpgeo/zipball/71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931",
+                "reference": "71074ce618dbaa4f048c8ee6b4e0c2d0e51a0931",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": "^8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5",
-                "squizlabs/php_codesniffer": "^3.6",
-                "vimeo/psalm": "^4.13"
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.0",
+                "squizlabs/php_codesniffer": "^3.7"
             },
             "type": "library",
             "autoload": {
@@ -464,7 +464,7 @@
                 "docs": "https://phpgeo.marcusjaschen.de/Installation.html",
                 "email": "mjaschen@gmail.com",
                 "issues": "https://github.com/mjaschen/phpgeo/issues",
-                "source": "https://github.com/mjaschen/phpgeo/tree/4.2.1"
+                "source": "https://github.com/mjaschen/phpgeo/tree/6.0.0"
             },
             "funding": [
                 {
@@ -476,31 +476,25 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-03T08:01:10+00:00"
+            "time": "2025-01-12T09:09:15+00:00"
         },
         {
             "name": "nitotm/efficient-language-detector",
-            "version": "v2.x-dev",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nitotm/efficient-language-detector.git",
-                "reference": "7c69b13a6b8774a663b6612afc4c2188587fa33a"
+                "reference": "f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nitotm/efficient-language-detector/zipball/7c69b13a6b8774a663b6612afc4c2188587fa33a",
-                "reference": "7c69b13a6b8774a663b6612afc4c2188587fa33a",
+                "url": "https://api.github.com/repos/nitotm/efficient-language-detector/zipball/f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab",
+                "reference": "f7f999d8bfd7e4aaf3fb1cf4ba8ca91ea9bbddab",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "ext-json": "*",
-                "phpmd/phpmd": "^2.13",
-                "squizlabs/php_codesniffer": "3.*",
-                "vimeo/psalm": "^5.12"
             },
             "type": "library",
             "autoload": {
@@ -524,15 +518,17 @@
                 "detection",
                 "detector",
                 "language",
+                "language classification",
                 "language detection",
                 "language detector",
-                "language identification"
+                "language identification",
+                "language recognition"
             ],
             "support": {
                 "issues": "https://github.com/nitotm/efficient-language-detector/issues",
-                "source": "https://github.com/nitotm/efficient-language-detector/tree/v2.1.2"
+                "source": "https://github.com/nitotm/efficient-language-detector/tree/v3.0.0"
             },
-            "time": "2024-09-10T12:52:25+00:00"
+            "time": "2024-10-10T17:53:50+00:00"
         },
         {
             "name": "psr/cache",


### PR DESCRIPTION
This will allow to use also the latest Loupe PHP 0.10 version. There are no changes which effects our code: https://github.com/loupe-php/loupe/releases/tag/0.10.0. Thx to @Toflar