### PR TITLE
Introducing statistics to adapters

### DIFF
--- a/packages/seal-loupe-adapter/src/LoupeAdapter.php
+++ b/packages/seal-loupe-adapter/src/LoupeAdapter.php
@@ -17,6 +17,7 @@ use CmsIg\Seal\Adapter\AdapterInterface;
 use CmsIg\Seal\Adapter\IndexerInterface;
 use CmsIg\Seal\Adapter\SchemaManagerInterface;
 use CmsIg\Seal\Adapter\SearcherInterface;
+use CmsIg\Seal\Adapter\StatisticsInterface;
 
 final class LoupeAdapter implements AdapterInterface
 {
@@ -26,15 +27,19 @@ final class LoupeAdapter implements AdapterInterface
 
     private readonly SearcherInterface $searcher;
 
+    private readonly StatisticsInterface $statistics;
+
     public function __construct(
         LoupeHelper $loupeHelper,
         SchemaManagerInterface|null $schemaManager = null,
         IndexerInterface|null $indexer = null,
         SearcherInterface|null $searcher = null,
+        StatisticsInterface|null $statistics = null,
     ) {
         $this->schemaManager = $schemaManager ?? new LoupeSchemaManager($loupeHelper);
         $this->indexer = $indexer ?? new LoupeIndexer($loupeHelper);
         $this->searcher = $searcher ?? new LoupeSearcher($loupeHelper);
+        $this->statistics = $statistics ?? new LoupeStatistics($loupeHelper);
     }
 
     public function getSchemaManager(): SchemaManagerInterface
@@ -50,5 +55,10 @@ final class LoupeAdapter implements AdapterInterface
     public function getSearcher(): SearcherInterface
     {
         return $this->searcher;
+    }
+
+    public function getStatistics(): StatisticsInterface
+    {
+        return $this->statistics;
     }
 }

--- a/packages/seal-loupe-adapter/src/LoupeStatistics.php
+++ b/packages/seal-loupe-adapter/src/LoupeStatistics.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS-IG SEAL project.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CmsIg\Seal\Adapter\Loupe;
+
+use CmsIg\Seal\Adapter\SearcherInterface;
+use CmsIg\Seal\Adapter\StatisticsInterface;
+use CmsIg\Seal\Marshaller\FlattenMarshaller;
+use CmsIg\Seal\Schema\Index;
+use CmsIg\Seal\Search\Condition;
+use CmsIg\Seal\Search\Result;
+use CmsIg\Seal\Search\Search;
+use CmsIg\Seal\Statistics\Statistics;
+use Loupe\Loupe\SearchParameters;
+
+final class LoupeStatistics implements StatisticsInterface
+{
+    public function __construct(
+        private readonly LoupeHelper $loupeHelper,
+    ) {
+    }
+
+    public function getStatistics(Index $index): Statistics
+    {
+        $loupe = $this->loupeHelper->getLoupe($index);
+
+        return new Statistics($loupe->countDocuments());
+    }
+}

--- a/packages/seal-loupe-adapter/tests/LoupeStatisticsTest.php
+++ b/packages/seal-loupe-adapter/tests/LoupeStatisticsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS-IG SEAL project.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CmsIg\Seal\Adapter\Loupe\Tests;
+
+use CmsIg\Seal\Adapter\Loupe\LoupeAdapter;
+use CmsIg\Seal\Testing\AbstractStatisticsTestCase;
+
+class LoupeStatisticsTest extends AbstractStatisticsTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        $helper = ClientHelper::getHelper();
+        self::$adapter = new LoupeAdapter($helper);
+
+        parent::setUpBeforeClass();
+    }
+}

--- a/packages/seal-meilisearch-adapter/src/MeilisearchAdapter.php
+++ b/packages/seal-meilisearch-adapter/src/MeilisearchAdapter.php
@@ -17,6 +17,7 @@ use CmsIg\Seal\Adapter\AdapterInterface;
 use CmsIg\Seal\Adapter\IndexerInterface;
 use CmsIg\Seal\Adapter\SchemaManagerInterface;
 use CmsIg\Seal\Adapter\SearcherInterface;
+use CmsIg\Seal\Adapter\StatisticsInterface;
 use Meilisearch\Client;
 
 final class MeilisearchAdapter implements AdapterInterface
@@ -27,15 +28,19 @@ final class MeilisearchAdapter implements AdapterInterface
 
     private readonly SearcherInterface $searcher;
 
+    private readonly StatisticsInterface $statistics;
+
     public function __construct(
         Client $client,
         SchemaManagerInterface|null $schemaManager = null,
         IndexerInterface|null $indexer = null,
         SearcherInterface|null $searcher = null,
+        StatisticsInterface|null $statistics = null,
     ) {
         $this->schemaManager = $schemaManager ?? new MeilisearchSchemaManager($client);
         $this->indexer = $indexer ?? new MeilisearchIndexer($client);
         $this->searcher = $searcher ?? new MeilisearchSearcher($client);
+        $this->statistics = $statistics ?? new MeilisearchStatistics($client);
     }
 
     public function getSchemaManager(): SchemaManagerInterface
@@ -51,5 +56,10 @@ final class MeilisearchAdapter implements AdapterInterface
     public function getSearcher(): SearcherInterface
     {
         return $this->searcher;
+    }
+
+    public function getStatistics(): StatisticsInterface
+    {
+        return $this->statistics;
     }
 }

--- a/packages/seal-meilisearch-adapter/src/MeilisearchStatistics.php
+++ b/packages/seal-meilisearch-adapter/src/MeilisearchStatistics.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS-IG SEAL project.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CmsIg\Seal\Adapter\Meilisearch;
+
+use CmsIg\Seal\Adapter\StatisticsInterface;
+use CmsIg\Seal\Marshaller\Marshaller;
+use CmsIg\Seal\Schema\Index;
+use CmsIg\Seal\Statistics\Statistics;
+use Meilisearch\Client;
+
+final class MeilisearchStatistics implements StatisticsInterface
+{
+    private readonly Marshaller $marshaller;
+
+    public function __construct(
+        private readonly Client $client,
+    ) {
+    }
+
+    public function getStatistics(Index $index): Statistics
+    {
+        return new Statistics($this->client->stats()[$index->name]['numberOfDocuments']);
+    }
+}

--- a/packages/seal-meilisearch-adapter/src/MeilisearchStatistics.php
+++ b/packages/seal-meilisearch-adapter/src/MeilisearchStatistics.php
@@ -30,6 +30,6 @@ final class MeilisearchStatistics implements StatisticsInterface
 
     public function getStatistics(Index $index): Statistics
     {
-        return new Statistics($this->client->stats()[$index->name]['numberOfDocuments']);
+        return new Statistics($this->client->stats()['indexes'][$index->name]['numberOfDocuments']);
     }
 }

--- a/packages/seal-meilisearch-adapter/tests/MeilisearchStatisticsTest.php
+++ b/packages/seal-meilisearch-adapter/tests/MeilisearchStatisticsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS-IG SEAL project.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CmsIg\Seal\Adapter\Meilisearch\Tests;
+
+use CmsIg\Seal\Adapter\Meilisearch\MeilisearchAdapter;
+use CmsIg\Seal\Testing\AbstractStatisticsTestCase;
+
+class MeilisearchStatisticsTest extends AbstractStatisticsTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        $client = ClientHelper::getClient();
+        self::$adapter = new MeilisearchAdapter($client);
+
+        parent::setUpBeforeClass();
+    }
+}

--- a/packages/seal/src/Adapter/StatisticsInterface.php
+++ b/packages/seal/src/Adapter/StatisticsInterface.php
@@ -13,13 +13,10 @@ declare(strict_types=1);
 
 namespace CmsIg\Seal\Adapter;
 
-interface AdapterInterface
+use CmsIg\Seal\Schema\Index;
+use CmsIg\Seal\Statistics\Statistics;
+
+interface StatisticsInterface
 {
-    public function getSchemaManager(): SchemaManagerInterface;
-
-    public function getIndexer(): IndexerInterface;
-
-    public function getSearcher(): SearcherInterface;
-
-    public function getStatistics(): StatisticsInterface;
+    public function getStatistics(Index $index): Statistics;
 }

--- a/packages/seal/src/Engine.php
+++ b/packages/seal/src/Engine.php
@@ -20,6 +20,7 @@ use CmsIg\Seal\Reindex\ReindexProviderInterface;
 use CmsIg\Seal\Schema\Schema;
 use CmsIg\Seal\Search\Condition\IdentifierCondition;
 use CmsIg\Seal\Search\SearchBuilder;
+use CmsIg\Seal\Statistics\Statistics;
 use CmsIg\Seal\Task\MultiTask;
 use CmsIg\Seal\Task\TaskInterface;
 
@@ -79,6 +80,11 @@ final class Engine implements EngineInterface
         }
 
         return $document;
+    }
+
+    public function getStatistics(string $index): Statistics
+    {
+        return $this->adapter->getStatistics()->getStatistics($this->schema->indexes[$index]);
     }
 
     public function createSearchBuilder(string $index): SearchBuilder

--- a/packages/seal/src/EngineInterface.php
+++ b/packages/seal/src/EngineInterface.php
@@ -17,6 +17,7 @@ use CmsIg\Seal\Exception\DocumentNotFoundException;
 use CmsIg\Seal\Reindex\ReindexConfig;
 use CmsIg\Seal\Reindex\ReindexProviderInterface;
 use CmsIg\Seal\Search\SearchBuilder;
+use CmsIg\Seal\Statistics\Statistics;
 use CmsIg\Seal\Task\TaskInterface;
 
 interface EngineInterface
@@ -51,6 +52,8 @@ interface EngineInterface
      * @return array<string, mixed>
      */
     public function getDocument(string $index, string $identifier): array;
+
+    public function getStatistics(string $index): Statistics;
 
     public function createSearchBuilder(string $index): SearchBuilder;
 

--- a/packages/seal/src/Statistics/Statistics.php
+++ b/packages/seal/src/Statistics/Statistics.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace CmsIg\Seal\Statistics;
+
+class Statistics
+{
+    public function __construct(private int $numberOfDocuments)
+    {
+
+    }
+
+    public function getNumberOfDocuments(): int
+    {
+        return $this->numberOfDocuments;
+    }
+}

--- a/packages/seal/src/Testing/AbstractStatisticsTestCase.php
+++ b/packages/seal/src/Testing/AbstractStatisticsTestCase.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS-IG SEAL project.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CmsIg\Seal\Testing;
+
+use CmsIg\Seal\Adapter\AdapterInterface;
+use CmsIg\Seal\Adapter\IndexerInterface;
+use CmsIg\Seal\Adapter\SchemaManagerInterface;
+use CmsIg\Seal\Adapter\SearcherInterface;
+use CmsIg\Seal\Schema\Schema;
+use CmsIg\Seal\Search\Condition;
+use CmsIg\Seal\Search\SearchBuilder;
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractStatisticsTestCase extends TestCase
+{
+    protected static AdapterInterface $adapter;
+
+    protected static SchemaManagerInterface $schemaManager;
+
+    protected static IndexerInterface $indexer;
+
+    protected static SearcherInterface $searcher;
+
+    protected static Schema $schema;
+
+    private static TaskHelper $taskHelper;
+
+    protected function setUp(): void
+    {
+        self::$taskHelper = new TaskHelper();
+    }
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$schemaManager = self::$adapter->getSchemaManager();
+        self::$indexer = self::$adapter->getIndexer();
+        self::$searcher = self::$adapter->getSearcher();
+
+        self::$taskHelper = new TaskHelper();
+        foreach (self::getSchema()->indexes as $index) {
+            if (self::$schemaManager->existIndex($index)) {
+                self::$schemaManager->dropIndex($index, ['return_slow_promise_result' => true])->wait();
+            }
+
+            self::$taskHelper->tasks[] = self::$schemaManager->createIndex($index, ['return_slow_promise_result' => true]);
+        }
+
+        self::$taskHelper->waitForAll();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::$taskHelper->waitForAll();
+
+        foreach (self::getSchema()->indexes as $index) {
+            self::$taskHelper->tasks[] = self::$schemaManager->dropIndex($index, ['return_slow_promise_result' => true]);
+        }
+
+        self::$taskHelper->waitForAll();
+    }
+
+    protected static function getSchema(): Schema
+    {
+        if (!isset(self::$schema)) {
+            self::$schema = TestingHelper::createSchema();
+        }
+
+        return self::$schema;
+    }
+
+    public function testDocumentCount(): void
+    {
+        $schema = self::getSchema();
+        $this->assertSame(
+            0,
+            self::$adapter->getStatistics()->getStatistics($schema->indexes[TestingHelper::INDEX_COMPLEX])->getNumberOfDocuments()
+        );
+
+        $documents = TestingHelper::createComplexFixtures();
+
+        foreach ($documents as $document) {
+            self::$taskHelper->tasks[] = self::$indexer->save(
+                $schema->indexes[TestingHelper::INDEX_COMPLEX],
+                $document,
+                ['return_slow_promise_result' => true],
+            );
+        }
+        self::$taskHelper->waitForAll();
+
+        $this->assertSame(
+            \count($documents),
+            self::$adapter->getStatistics()->getStatistics($schema->indexes[TestingHelper::INDEX_COMPLEX])->getNumberOfDocuments()
+        );
+    }
+}


### PR DESCRIPTION
Currently, the number of documents in an index is the only thing that I could see is available across the board. Potentially there could also be the index size in bytes etc. in the future. So I decided for a `Statistics` object in our abstraction layer that would allow us to easily add more information in the future.

This is just a quick draft, looking for feedback @alexander-schranz :) 