### PR TITLE
Add loupe context cropper library reference to documentation

### DIFF
--- a/docs/search-and-filters/index.rst
+++ b/docs/search-and-filters/index.rst
@@ -421,6 +421,13 @@ The abstraction can also be used to highlight the search term in the result.
     The ``Highlighting`` is currently not supported by ``RediSearch`` adapter.
     See `this GitHub Issue <https://github.com/PHP-CMSIG/search/issues/491>`__ for more information.
 
+On a search results page, you may only need a shortened version of the highlighted text.
+To achieve this, you can install the `loupe/context-cropper <https://github.com/loupe-php/context-cropper>`__
+package via Composer.
+
+The ``loupe/context-cropper`` package is a lightweight string manipulation library specifically designed for
+this purpose. It is independent of Loupe Search usage — with minimal dependencies.
+
 --------------
 
 Summary


### PR DESCRIPTION
Mentioning of `loupe/context-cropper` library for only get a matched context.

https://github.com/loupe-php/context-cropper

fixes https://github.com/PHP-CMSIG/search/issues/496
closes https://github.com/PHP-CMSIG/search/issues/502 