### PR TITLE
Add mezcalito/ux-search to list about alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Following projects in the past target similar problem:
 
 - [https://github.com/nresni/Ariadne](https://github.com/nresni/Ariadne) (Solr, Elasticsearch, Zendsearch: outdated 12 years ago)
 - [https://github.com/massiveart/MassiveSearchBundle](https://github.com/massiveart/MassiveSearchBundle) (ZendSearch, Elasticsearch)
-- [https://github.com/laravel/scout](https://github.com/laravel/scout) (Algolia, Meilisearch)
+- [https://github.com/laravel/scout](https://github.com/laravel/scout) (Algolia, Meilisearch, Typesense)
 - [https://github.com/Mezcalito/ux-search/](Doctrine, Meilisearch)
 
 ## 📩 Authors

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Following projects in the past target similar problem:
 - [https://github.com/nresni/Ariadne](https://github.com/nresni/Ariadne) (Solr, Elasticsearch, Zendsearch: outdated 12 years ago)
 - [https://github.com/massiveart/MassiveSearchBundle](https://github.com/massiveart/MassiveSearchBundle) (ZendSearch, Elasticsearch)
 - [https://github.com/laravel/scout](https://github.com/laravel/scout) (Algolia, Meilisearch)
+- [https://github.com/Mezcalito/ux-search/](Doctrine, Meilisearch)
 
 ## 📩 Authors
 

--- a/docs/research/index.rst
+++ b/docs/research/index.rst
@@ -359,3 +359,13 @@ Paradedb
 A search and analytics engine ontop of Postgres, with own Postgres extensions written in Rust:
 
 - Server: `Paradedb Server <https://github.com/paradedb/paradedb>`__
+
+Similar Projects
+----------------
+
+Following projects in the past target similar problem:
+
+- `https://github.com/nresni/Ariadne <https://github.com/nresni/Ariadne>`__  (Solr, Elasticsearch, Zendsearch: outdated 12 years ago)
+- `https://github.com/massiveart/MassiveSearchBundle <https://github.com/massiveart/MassiveSearchBundle>`__ (ZendSearch, Elasticsearch)
+- `https://github.com/laravel/scout <https://github.com/laravel/scout>`__  (Algolia, Meilisearch, Typesense)
+- `https://github.com/Mezcalito/ux-search/ <https://github.com/Mezcalito/ux-search/>`__  (Doctrine, Meilisearch)


### PR DESCRIPTION
Open source should be about sharing and I always want SEAL to be a source around search topic even for people who don't use the library in there projects. I really liked the idea of Frank De Jonge the creator of flysystem listing in the `object-mapper` what other alternatives exist in the open source world [here](https://github.com/thephpleague/object-mapper?tab=readme-ov-file#alternatives). Aslong I stumbling over alternatives or topics I want to keep the research document and readme uptodate with it.

So list @Mezcalito `ux-search` by @AlexandrePetrone to the list of alternatives to SEAL.   Also update laravel scout that they have Typesense integration also.