### PR TITLE
Add community section to research docs

### DIFF
--- a/docs/research/index.rst
+++ b/docs/research/index.rst
@@ -67,6 +67,11 @@ UI/UX related links:
 
 - `https://design4users.com/design-search-in-user-interfaces/ <https://design4users.com/design-search-in-user-interfaces/>`__
 
+Communities:
+------------
+
+- `https://opensourceconnections.com/slack <https://opensourceconnections.com/slack>`__ A community around Search and AI build by `Charlie Hull <https://x.com/flaxsearch>`__ alias "thesearchjuggler"
+
 Optimization links:
 -------------------
 


### PR DESCRIPTION
SEAL should not only be a library for PHP devs it should also be a source for everybody around the topic search. So adding a link to https://opensourceconnections.com/slack which is community created @flaxsearch where search specific topics are discussed, member of Vespa, ParadeDB and others are part of it around ~5600 members are inside this Slack.