### PR TITLE
Upgrade elasticsearch docker images to 8.18.0

### DIFF
--- a/.examples/laravel/docker-compose.yml
+++ b/.examples/laravel/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.17.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.18.0
     environment:
       discovery.type: single-node
       xpack.security.enabled: 'false'

--- a/.examples/mezzio/docker-compose.yml
+++ b/.examples/mezzio/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.17.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.18.0
     environment:
       discovery.type: single-node
       xpack.security.enabled: 'false'

--- a/.examples/spiral/docker-compose.yml
+++ b/.examples/spiral/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.17.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.18.0
     environment:
       discovery.type: single-node
       xpack.security.enabled: 'false'

--- a/.examples/symfony/docker-compose.yml
+++ b/.examples/symfony/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.17.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.18.0
     environment:
       discovery.type: single-node
       xpack.security.enabled: 'false'

--- a/.examples/yii/docker-compose.yml
+++ b/.examples/yii/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.17.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.18.0
     environment:
       discovery.type: single-node
       xpack.security.enabled: 'false'

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -1506,7 +1506,7 @@ search engine.
 
             services:
               elasticsearch:
-                image: docker.elastic.co/elasticsearch/elasticsearch:8.17.0
+                image: docker.elastic.co/elasticsearch/elasticsearch:8.18.0
                 environment:
                   discovery.type: single-node
                   xpack.security.enabled: 'false'

--- a/packages/seal-elasticsearch-adapter/docker-compose.yml
+++ b/packages/seal-elasticsearch-adapter/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.17.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.18.0
     environment:
       discovery.type: single-node
       xpack.security.enabled: 'false'


### PR DESCRIPTION
Keep the docker image of documentation, examples and tests uptodate as elasticsearch does not support minor or major based tags to get latest version of a specific minor or major version.