### PR TITLE
Fix and normalize handling of none matching highlight fields (BC Break)

### DIFF
--- a/docs/search-and-filters/index.rst
+++ b/docs/search-and-filters/index.rst
@@ -413,8 +413,14 @@ The abstraction can also be used to highlight the search term in the result.
         ->getResult();
 
     foreach ($result as $document) {
-        $titleWithHighlight = $document['_formatted']['title'] ?? '';
+        $titleWithHighlight = $document['_formatted']['title']
+            ?? $document['title']
+            ?? '';
     }
+
+If the highlight is applied to multiple fields, only the fields that had a match are returned inside ``_formatted``.
+Fields without a match are returned as ``null``. You might want to use the null coalescing operator (``??``)
+to fall back to the original field, as shown above.
 
 .. note::
 

--- a/packages/seal-algolia-adapter/src/AlgoliaSearcher.php
+++ b/packages/seal-algolia-adapter/src/AlgoliaSearcher.php
@@ -55,13 +55,13 @@ final class AlgoliaSearcher implements SearcherInterface
                 );
             } catch (NotFoundException) {
                 return new Result(
-                    $this->hitsToDocuments($search->index, [], []),
+                    $this->hitsToDocuments($search->index, [], [], $search->highlightPreTag),
                     0,
                 );
             }
 
             return new Result(
-                $this->hitsToDocuments($search->index, [$data], []),
+                $this->hitsToDocuments($search->index, [$data], [], $search->highlightPreTag),
                 1,
             );
         }
@@ -117,7 +117,7 @@ final class AlgoliaSearcher implements SearcherInterface
         \assert(isset($data['nbHits']) && \is_int($data['nbHits']), 'The "nbHits" value is expected to be returned by algolia client.');
 
         return new Result(
-            $this->hitsToDocuments($search->index, $data['hits'], $search->highlightFields),
+            $this->hitsToDocuments($search->index, $data['hits'], $search->highlightFields, $search->highlightPreTag),
             $data['nbHits'] ?? null, // @phpstan-ignore-line
         );
     }
@@ -128,7 +128,7 @@ final class AlgoliaSearcher implements SearcherInterface
      *
      * @return \Generator<int, array<string, mixed>>
      */
-    private function hitsToDocuments(Index $index, iterable $hits, array $highlightFields): \Generator
+    private function hitsToDocuments(Index $index, iterable $hits, array $highlightFields, string $highlightPreTag): \Generator
     {
         foreach ($hits as $hit) {
             // remove Algolia Metadata
@@ -159,7 +159,15 @@ final class AlgoliaSearcher implements SearcherInterface
                     'Expected highlight field to be set.',
                 );
 
-                $document['_formatted'][$highlightField] = $hit['_highlightResult'][$highlightField]['value'];
+                $value = $hit['_highlightResult'][$highlightField]['value'];
+
+                if (!\is_string($value)
+                    || !\str_contains($value, $highlightPreTag)
+                ) {
+                    $value = null;
+                }
+
+                $document['_formatted'][$highlightField] = $value;
             }
 
             yield $document;

--- a/packages/seal-elasticsearch-adapter/src/ElasticsearchSearcher.php
+++ b/packages/seal-elasticsearch-adapter/src/ElasticsearchSearcher.php
@@ -162,16 +162,16 @@ final class ElasticsearchSearcher implements SearcherInterface
                 'Document with key "_formatted" expected to be array.',
             );
 
-            foreach ($highlightFields as $highlightField) {
-                \assert(
-                    isset($hit['highlight'])
-                    && \is_array($hit['highlight'])
-                    && isset($hit['highlight'][$highlightField])
-                    && \is_array($hit['highlight'][$highlightField]),
-                    'Expected highlight field to be set.',
-                );
+            $hit['highlight'] ??= [];
 
-                $document['_formatted'][$highlightField] = $hit['highlight'][$highlightField][0] ?? null;
+            \assert(
+                \is_array($hit['highlight']),
+                'Hit with key "highlight" expected to be array.',
+            );
+
+            foreach ($highlightFields as $highlightField) {
+                $document['_formatted'][$highlightField] = $hit['highlight'][$highlightField][0]
+                    ?? null;
             }
 
             yield $document;

--- a/packages/seal-loupe-adapter/src/LoupeSearcher.php
+++ b/packages/seal-loupe-adapter/src/LoupeSearcher.php
@@ -53,13 +53,13 @@ final class LoupeSearcher implements SearcherInterface
 
             if (!$data) {
                 return new Result(
-                    $this->hitsToDocuments($search->index, [], []),
+                    $this->hitsToDocuments($search->index, [], [], $search->highlightPreTag),
                     0,
                 );
             }
 
             return new Result(
-                $this->hitsToDocuments($search->index, [$data], []),
+                $this->hitsToDocuments($search->index, [$data], [], $search->highlightPreTag),
                 1,
             );
         }
@@ -109,7 +109,7 @@ final class LoupeSearcher implements SearcherInterface
         $result = $loupe->search($searchParameters);
 
         return new Result(
-            $this->hitsToDocuments($search->index, $result->getHits(), $search->highlightFields),
+            $this->hitsToDocuments($search->index, $result->getHits(), $search->highlightFields, $search->highlightPreTag),
             $result->getTotalHits(),
         );
     }
@@ -125,7 +125,7 @@ final class LoupeSearcher implements SearcherInterface
      *
      * @return \Generator<int, array<string, mixed>>
      */
-    private function hitsToDocuments(Index $index, iterable $hits, array $highlightFields): \Generator
+    private function hitsToDocuments(Index $index, iterable $hits, array $highlightFields, string $highlightPreTag): \Generator
     {
         foreach ($hits as $hit) {
             $document = $this->marshaller->unmarshall($index->fields, $hit);
@@ -151,7 +151,15 @@ final class LoupeSearcher implements SearcherInterface
                     'Expected highlight field to be set.',
                 );
 
-                $document['_formatted'][$highlightField] = $hit['_formatted'][$highlightField];
+                $value = $hit['_formatted'][$highlightField];
+
+                if (!\is_string($value)
+                    || !\str_contains($value, $highlightPreTag)
+                ) {
+                    $value = null;
+                }
+
+                $document['_formatted'][$highlightField] = $value;
             }
 
             yield $document;

--- a/packages/seal-meilisearch-adapter/src/MeilisearchSearcher.php
+++ b/packages/seal-meilisearch-adapter/src/MeilisearchSearcher.php
@@ -55,13 +55,13 @@ final class MeilisearchSearcher implements SearcherInterface
                 }
 
                 return new Result(
-                    $this->hitsToDocuments($search->index, [], []),
+                    $this->hitsToDocuments($search->index, [], [], $search->highlightPreTag),
                     0,
                 );
             }
 
             return new Result(
-                $this->hitsToDocuments($search->index, [$data], []),
+                $this->hitsToDocuments($search->index, [$data], [], $search->highlightPreTag),
                 1,
             );
         }
@@ -97,7 +97,7 @@ final class MeilisearchSearcher implements SearcherInterface
         $data = $searchIndex->search($query, $searchParams)->toArray();
 
         return new Result(
-            $this->hitsToDocuments($search->index, $data['hits'], $search->highlightFields),
+            $this->hitsToDocuments($search->index, $data['hits'], $search->highlightFields, $search->highlightPreTag),
             $data['totalHits'] ?? $data['estimatedTotalHits'] ?? null,
         );
     }
@@ -108,7 +108,7 @@ final class MeilisearchSearcher implements SearcherInterface
      *
      * @return \Generator<int, array<string, mixed>>
      */
-    private function hitsToDocuments(Index $index, iterable $hits, array $highlightFields): \Generator
+    private function hitsToDocuments(Index $index, iterable $hits, array $highlightFields, string $highlightPreTag): \Generator
     {
         foreach ($hits as $hit) {
             $document = $this->marshaller->unmarshall($index->fields, $hit);
@@ -134,7 +134,15 @@ final class MeilisearchSearcher implements SearcherInterface
                     'Expected highlight field to be set.',
                 );
 
-                $document['_formatted'][$highlightField] = $hit['_formatted'][$highlightField];
+                $value = $hit['_formatted'][$highlightField];
+
+                if (!\is_string($value)
+                    || !\str_contains($value, $highlightPreTag)
+                ) {
+                    $value = null;
+                }
+
+                $document['_formatted'][$highlightField] = $value;
             }
 
             yield $document;

--- a/packages/seal-memory-adapter/src/MemorySearcher.php
+++ b/packages/seal-memory-adapter/src/MemorySearcher.php
@@ -81,13 +81,13 @@ final class MemorySearcher implements SearcherInterface
                     }
 
                     $highlightFieldContent = \str_replace(
-                        $search->highlightPostTag . $search->highlightPostTag,
+                        $search->highlightPostTag . $search->highlightPreTag,
                         '',
                         $highlightFieldContent,
                     );
 
                     $highlightFieldContent = \str_replace(
-                        $search->highlightPostTag . ' ' . $search->highlightPostTag,
+                        $search->highlightPostTag . ' ' . $search->highlightPreTag,
                         ' ',
                         $highlightFieldContent,
                     );
@@ -98,6 +98,10 @@ final class MemorySearcher implements SearcherInterface
                         \is_array($document['_formatted']),
                         'Document with key "_formatted" expected to be array.',
                     );
+
+                    if (!\str_contains($highlightFieldContent, $search->highlightPreTag)) {
+                        $highlightFieldContent = 'null';
+                    }
 
                     $document['_formatted'][$highlightField] = \json_decode($highlightFieldContent, true, 512, \JSON_THROW_ON_ERROR);
                 }

--- a/packages/seal-opensearch-adapter/src/OpensearchSearcher.php
+++ b/packages/seal-opensearch-adapter/src/OpensearchSearcher.php
@@ -139,16 +139,16 @@ final class OpensearchSearcher implements SearcherInterface
                 'Document with key "_formatted" expected to be array.',
             );
 
-            foreach ($highlightFields as $highlightField) {
-                \assert(
-                    isset($hit['highlight'])
-                    && \is_array($hit['highlight'])
-                    && isset($hit['highlight'][$highlightField])
-                    && \is_array($hit['highlight'][$highlightField]),
-                    'Expected highlight field to be set.',
-                );
+            $hit['highlight'] ??= [];
 
-                $document['_formatted'][$highlightField] = $hit['highlight'][$highlightField][0] ?? null;
+            \assert(
+                \is_array($hit['highlight']),
+                'Hit with key "highlight" expected to be array.',
+            );
+
+            foreach ($highlightFields as $highlightField) {
+                $document['_formatted'][$highlightField] = $hit['highlight'][$highlightField][0]
+                    ?? null;
             }
 
             yield $document;

--- a/packages/seal-solr-adapter/src/SolrSearcher.php
+++ b/packages/seal-solr-adapter/src/SolrSearcher.php
@@ -60,13 +60,13 @@ final class SolrSearcher implements SearcherInterface
 
             if (!$result->getNumFound()) {
                 return new Result(
-                    $this->hitsToDocuments($search->index, []),
+                    $this->hitsToDocuments($search->index, [], null, $search->highlightFields),
                     0,
                 );
             }
 
             return new Result(
-                $this->hitsToDocuments($search->index, [$result->getDocument()]),
+                $this->hitsToDocuments($search->index, [$result->getDocument()], null, $search->highlightFields),
                 1,
             );
         }
@@ -112,17 +112,18 @@ final class SolrSearcher implements SearcherInterface
         $result = $this->client->select($query);
 
         return new Result(
-            $this->hitsToDocuments($search->index, $result->getDocuments(), $result->getHighlighting()),
+            $this->hitsToDocuments($search->index, $result->getDocuments(), $result->getHighlighting(), $search->highlightFields),
             (int) $result->getNumFound(),
         );
     }
 
     /**
      * @param iterable<DocumentInterface> $hits
+     * @param array<string> $highlightFields
      *
      * @return \Generator<int, array<string, mixed>>
      */
-    private function hitsToDocuments(Index $index, iterable $hits, Highlighting|null $highlighting = null): \Generator
+    private function hitsToDocuments(Index $index, iterable $hits, Highlighting|null $highlighting, array $highlightFields): \Generator
     {
         foreach ($hits as $hit) {
             /** @var array<string, mixed> $hit */
@@ -163,6 +164,10 @@ final class SolrSearcher implements SearcherInterface
                     }
 
                     $document['_formatted'][$key] = $value;
+                }
+
+                foreach ($highlightFields as $highlightField) {
+                    $document['_formatted'][$highlightField] ??= null;
                 }
             }
 

--- a/packages/seal-typesense-adapter/src/TypesenseSearcher.php
+++ b/packages/seal-typesense-adapter/src/TypesenseSearcher.php
@@ -134,13 +134,16 @@ final class TypesenseSearcher implements SearcherInterface
                 'Document with key "_formatted" expected to be array.',
             );
 
-            foreach ($highlightFields as $highlightField) {
-                \assert(
-                    isset($hit['highlight'][$highlightField]['snippet']),
-                    'Expected highlight field to be set.',
-                );
+            $hit['highlight'] ??= [];
 
-                $document['_formatted'][$highlightField] = $hit['highlight'][$highlightField]['snippet'];
+            \assert(
+                \is_array($hit['highlight']),
+                'Hit with key "highlight" expected to be array.',
+            );
+
+            foreach ($highlightFields as $highlightField) {
+                $document['_formatted'][$highlightField] = $hit['highlight'][$highlightField]['snippet']
+                    ?? null;
             }
 
             yield $document;

--- a/packages/seal/src/Testing/AbstractSearcherTestCase.php
+++ b/packages/seal/src/Testing/AbstractSearcherTestCase.php
@@ -149,7 +149,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
         $search->addFilter(new Condition\SearchCondition('Blog'));
-        $search->highlight(['title'], '<mark>', '</mark>');
+        $search->highlight(['title', 'article'], '<mark>', '</mark>');
 
         $expectedDocumentA = $documents[0];
         $expectedDocumentA['_formatted']['title'] = \str_replace(
@@ -157,12 +157,14 @@ abstract class AbstractSearcherTestCase extends TestCase
             '<mark>Blog</mark>',
             $expectedDocumentA['title'] ?? '',
         );
+        $expectedDocumentA['_formatted']['article'] = null; // normalize the highlight behaviour none matches returned as null for every engine
         $expectedDocumentB = $documents[1];
         $expectedDocumentB['_formatted']['title'] = \str_replace(
             'Blog',
             '<mark>Blog</mark>',
             $expectedDocumentB['title'] ?? '',
         );
+        $expectedDocumentB['_formatted']['article'] = null; // normalize the highlight behaviour none matches returned as null for every engine
 
         $expectedDocumentsVariantA = [
             $expectedDocumentA,
@@ -174,6 +176,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         ];
 
         $loadedDocuments = [...$search->getResult()];
+
         $this->assertCount(2, $loadedDocuments);
 
         $this->assertTrue(


### PR DESCRIPTION
There is inconsistent between how the result is if there are multiple "highlight" fields and the a highlight field does not have a match.

 - Elasticsearch, Opensearch, Solr: Do return nothing if the field has no match and so no highlighting is applied
 - Meilisearch, Algolia, Loupe: Returns the fields value
 
To be consistent I decided to go with the Elasticsearch behaviour because it seems my point of view easier for enduser to write: `$document['_formatted']['description'] ?? $document['description']`.  
As the other way `\str_contains($document['_formatted']['description'], $search->highlightPreTag) ? $document['_formatted']['description'] : null`.

@Toflar what do you think?

Another issue appeared which is #524 that none existing fields did throw an error on elastic and opensearch, we can not be as structure strict as I thought we can here.

## BC Break

Some engines in the past did automatically fallback in the highlighted fields to the original value even if there was no match and nothing to highlight. To normalize this behaviour this mechanic is now in control of you. If you did use Loupe, Meilisearch and Algolia and want the previous behaviour back add fallback yourself:

```diff
$title = $document['_formatted']['title']
+            ?? $document['title']
             ?? '';
```