### PR TITLE
Fix sort by text fields for elasticsearch, opensearch, typesense and solr

### DIFF
--- a/packages/seal-algolia-adapter/src/AlgoliaSearcher.php
+++ b/packages/seal-algolia-adapter/src/AlgoliaSearcher.php
@@ -17,6 +17,7 @@ use Algolia\AlgoliaSearch\Api\SearchClient;
 use Algolia\AlgoliaSearch\Exceptions\NotFoundException;
 use CmsIg\Seal\Adapter\SearcherInterface;
 use CmsIg\Seal\Marshaller\Marshaller;
+use CmsIg\Seal\Schema\Field;
 use CmsIg\Seal\Schema\Index;
 use CmsIg\Seal\Search\Condition;
 use CmsIg\Seal\Search\Result;
@@ -201,12 +202,12 @@ final class AlgoliaSearcher implements SearcherInterface
             match (true) {
                 $filter instanceof Condition\IdentifierCondition => $filters[] = $index->getIdentifierField()->name . ':' . $this->escapeFilterValue($filter->identifier),
                 $filter instanceof Condition\SearchCondition => $query = $filter->query,
-                $filter instanceof Condition\EqualCondition => $filters[] = $filter->field . ':' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\NotEqualCondition => $filters[] = 'NOT ' . $filter->field . ':' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\GreaterThanCondition => $filters[] = $filter->field . ' > ' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\GreaterThanEqualCondition => $filters[] = $filter->field . ' >= ' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\LessThanCondition => $filters[] = $filter->field . ' < ' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\LessThanEqualCondition => $filters[] = $filter->field . ' <= ' . $this->escapeFilterValue($filter->value),
+                $filter instanceof Condition\EqualCondition => $filters[] = $this->getFilterField($index, $filter->field) . ':' . $this->escapeFilterValue($filter->value),
+                $filter instanceof Condition\NotEqualCondition => $filters[] = 'NOT ' . $this->getFilterField($index, $filter->field) . ':' . $this->escapeFilterValue($filter->value),
+                $filter instanceof Condition\GreaterThanCondition => $filters[] = $this->getFilterField($index, $filter->field) . ' > ' . $this->escapeFilterValue($filter->value),
+                $filter instanceof Condition\GreaterThanEqualCondition => $filters[] = $this->getFilterField($index, $filter->field) . ' >= ' . $this->escapeFilterValue($filter->value),
+                $filter instanceof Condition\LessThanCondition => $filters[] = $this->getFilterField($index, $filter->field) . ' < ' . $this->escapeFilterValue($filter->value),
+                $filter instanceof Condition\LessThanEqualCondition => $filters[] = $this->getFilterField($index, $filter->field) . ' <= ' . $this->escapeFilterValue($filter->value),
                 $filter instanceof Condition\GeoDistanceCondition => $geoFilters = [
                     'aroundLatLng' => \sprintf(
                         '%s, %s',
@@ -229,5 +230,16 @@ final class AlgoliaSearcher implements SearcherInterface
         }
 
         return \implode($conjunctive ? ' AND ' : ' OR ', $filters);
+    }
+
+    private function getFilterField(Index $index, string $name): string
+    {
+        $field = $index->getFieldByPath($name);
+
+        if ($field instanceof Field\IdentifierField) {
+            return 'objectID';
+        }
+
+        return $name;
     }
 }

--- a/packages/seal-elasticsearch-adapter/src/ElasticsearchSearcher.php
+++ b/packages/seal-elasticsearch-adapter/src/ElasticsearchSearcher.php
@@ -83,7 +83,7 @@ final class ElasticsearchSearcher implements SearcherInterface
 
         $sort = [];
         foreach ($search->sortBys as $field => $direction) {
-            $sort[] = [$field => $direction];
+            $sort[] = [$this->getFilterField($search->index, $field) => $direction];
         }
 
         $body = [

--- a/packages/seal-elasticsearch-adapter/tests/ElasticsearchSchemaManagerTest.php
+++ b/packages/seal-elasticsearch-adapter/tests/ElasticsearchSchemaManagerTest.php
@@ -193,6 +193,11 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             ],
             'title' => [
                 'type' => 'text',
+                'fields' => [
+                    'raw' => [
+                        'type' => 'keyword',
+                    ],
+                ],
             ],
             'uuid' => [
                 'type' => 'keyword',

--- a/packages/seal-memory-adapter/src/MemorySearcher.php
+++ b/packages/seal-memory-adapter/src/MemorySearcher.php
@@ -140,10 +140,15 @@ final class MemorySearcher implements SearcherInterface
                 $terms = \explode(' ', $filter->query);
                 $searchTerms = \array_unique([...$searchTerms, ...$terms]);
 
+                $hasSomeMatch = false;
                 foreach ($terms as $term) {
-                    if (!\str_contains($text, $term)) {
-                        continue 2;
+                    if (\str_contains($text, $term)) {
+                        $hasSomeMatch = true;
                     }
+                }
+
+                if (!$hasSomeMatch) {
+                    continue;
                 }
             } elseif ($filter instanceof Condition\EqualCondition) {
                 if (\str_contains($filter->field, '.')) {

--- a/packages/seal-opensearch-adapter/src/OpensearchSchemaManager.php
+++ b/packages/seal-opensearch-adapter/src/OpensearchSchemaManager.php
@@ -82,7 +82,7 @@ final class OpensearchSchemaManager implements SchemaManagerInterface
                 $field instanceof Field\IdentifierField => $properties[$name] = [
                     'type' => 'keyword',
                     'index' => $field->searchable || $field->filterable, // @phpstan-ignore-line // TODO recheck doc_values https://github.com/php-cmsig/search/issues/65
-                    'doc_values' => $field->filterable,
+                    'doc_values' => $field->filterable || $field->sortable, // @phpstan-ignore-line
                 ],
                 $field instanceof Field\TextField => $properties[$name] = \array_replace([
                     'type' => 'text',
@@ -92,29 +92,29 @@ final class OpensearchSchemaManager implements SchemaManagerInterface
                         'raw' => [
                             'type' => 'keyword',
                             'index' => $field->searchable || $field->filterable, // TODO recheck doc_values https://github.com/php-cmsig/search/issues/65
-                            'doc_values' => $field->filterable,
+                            'doc_values' => $field->filterable || $field->sortable,
                         ],
                     ],
                 ] : []),
                 $field instanceof Field\BooleanField => $properties[$name] = [
                     'type' => 'boolean',
                     'index' => $field->searchable || $field->filterable, // @phpstan-ignore-line // TODO recheck doc_values https://github.com/php-cmsig/search/issues/65
-                    'doc_values' => $field->filterable,
+                    'doc_values' => $field->filterable || $field->sortable,
                 ],
                 $field instanceof Field\DateTimeField => $properties[$name] = [
                     'type' => 'date',
                     'index' => $field->searchable || $field->filterable, // @phpstan-ignore-line // TODO recheck doc_values https://github.com/php-cmsig/search/issues/65
-                    'doc_values' => $field->filterable,
+                    'doc_values' => $field->filterable || $field->sortable,
                 ],
                 $field instanceof Field\IntegerField => $properties[$name] = [
                     'type' => 'integer',
                     'index' => $field->searchable || $field->filterable, // @phpstan-ignore-line // TODO recheck doc_values https://github.com/php-cmsig/search/issues/65
-                    'doc_values' => $field->filterable,
+                    'doc_values' => $field->filterable || $field->sortable,
                 ],
                 $field instanceof Field\FloatField => $properties[$name] = [
                     'type' => 'float',
                     'index' => $field->searchable || $field->filterable, // @phpstan-ignore-line // TODO recheck doc_values https://github.com/php-cmsig/search/issues/65
-                    'doc_values' => $field->filterable,
+                    'doc_values' => $field->filterable || $field->sortable,
                 ],
                 $field instanceof Field\GeoPointField => $properties[$name] = [
                     'type' => 'geo_point',

--- a/packages/seal-opensearch-adapter/src/OpensearchSearcher.php
+++ b/packages/seal-opensearch-adapter/src/OpensearchSearcher.php
@@ -73,7 +73,7 @@ final class OpensearchSearcher implements SearcherInterface
 
         $sort = [];
         foreach ($search->sortBys as $field => $direction) {
-            $sort[] = [$field => $direction];
+            $sort[] = [$this->getFilterField($search->index, $field) => $direction];
         }
 
         $body = [

--- a/packages/seal-opensearch-adapter/tests/OpensearchSchemaManagerTest.php
+++ b/packages/seal-opensearch-adapter/tests/OpensearchSchemaManagerTest.php
@@ -179,6 +179,11 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             ],
             'title' => [
                 'type' => 'text',
+                'fields' => [
+                    'raw' => [
+                        'type' => 'keyword',
+                    ],
+                ],
             ],
             'uuid' => [
                 'type' => 'keyword',

--- a/packages/seal-solr-adapter/src/SolrSearcher.php
+++ b/packages/seal-solr-adapter/src/SolrSearcher.php
@@ -99,7 +99,7 @@ final class SolrSearcher implements SearcherInterface
         }
 
         foreach ($search->sortBys as $field => $direction) {
-            $query->addSort($field, $direction);
+            $query->addSort($this->getFilterField($search->index, $field), $direction);
         }
 
         if ([] !== $search->highlightFields) {

--- a/packages/seal-typesense-adapter/src/TypesenseSchemaManager.php
+++ b/packages/seal-typesense-adapter/src/TypesenseSchemaManager.php
@@ -96,6 +96,7 @@ final class TypesenseSchemaManager implements SchemaManagerInterface
                 $field instanceof Field\IdentifierField => $fields[] = [
                     'name' => $name,
                     'type' => 'string',
+                    'sort' => $field->sortable,
                     'index' => $field->searchable || $field->filterable, // @phpstan-ignore-line
                     'facet' => $field->filterable,
                 ],
@@ -103,6 +104,7 @@ final class TypesenseSchemaManager implements SchemaManagerInterface
                     'name' => $name,
                     'type' => $field->multiple ? 'string[]' : 'string',
                     'optional' => true,
+                    'sort' => $field->sortable,
                     'index' => $field->searchable || $field->filterable,
                     'facet' => $field->filterable,
                 ],
@@ -110,6 +112,7 @@ final class TypesenseSchemaManager implements SchemaManagerInterface
                     'name' => $name,
                     'type' => $field->multiple ? 'bool[]' : 'bool',
                     'optional' => true,
+                    'sort' => $field->sortable,
                     'index' => $field->searchable || $field->filterable, // @phpstan-ignore-line
                     'facet' => $field->filterable,
                 ],
@@ -117,6 +120,7 @@ final class TypesenseSchemaManager implements SchemaManagerInterface
                     'name' => $name,
                     'type' => $field->multiple ? 'int64[]' : 'int64',
                     'optional' => true,
+                    'sort' => $field->sortable,
                     'index' => $field->searchable || $field->filterable, // @phpstan-ignore-line
                     'facet' => $field->filterable,
                 ],
@@ -124,6 +128,7 @@ final class TypesenseSchemaManager implements SchemaManagerInterface
                     'name' => $name,
                     'type' => $field->multiple ? 'int64[]' : 'int64',
                     'optional' => true,
+                    'sort' => $field->sortable,
                     'index' => $field->searchable || $field->filterable, // @phpstan-ignore-line
                     'facet' => $field->filterable,
                 ],
@@ -131,6 +136,7 @@ final class TypesenseSchemaManager implements SchemaManagerInterface
                     'name' => $name,
                     'type' => $field->multiple ? 'float[]' : 'float',
                     'optional' => true,
+                    'sort' => $field->sortable,
                     'index' => $field->searchable || $field->filterable, // @phpstan-ignore-line
                     'facet' => $field->filterable,
                 ],
@@ -138,6 +144,7 @@ final class TypesenseSchemaManager implements SchemaManagerInterface
                     'name' => $name,
                     'type' => $field->multiple ? 'geopoint[]' : 'geopoint',
                     'optional' => true,
+                    'sort' => $field->sortable,
                     'index' => $field->searchable || $field->filterable, // @phpstan-ignore-line
                     'facet' => $field->filterable,
                 ],

--- a/packages/seal/src/Testing/AbstractSearcherTestCase.php
+++ b/packages/seal/src/Testing/AbstractSearcherTestCase.php
@@ -1083,6 +1083,84 @@ abstract class AbstractSearcherTestCase extends TestCase
         }
     }
 
+    public function testSortByTextFieldAsc(): void
+    {
+        $documents = TestingHelper::createComplexFixtures();
+
+        $schema = self::getSchema();
+
+        foreach ($documents as $document) {
+            self::$taskHelper->tasks[] = self::$indexer->save(
+                $schema->indexes[TestingHelper::INDEX_COMPLEX],
+                $document,
+                ['return_slow_promise_result' => true],
+            );
+        }
+        self::$taskHelper->waitForAll();
+
+        $search = new SearchBuilder($schema, self::$searcher);
+        $search->index(TestingHelper::INDEX_COMPLEX);
+        $search->addFilter(new Condition\NotEqualCondition('uuid', '97cd3e94-c17f-4c11-a22b-d9da2e5318cd'));
+        $search->addSortBy('title', 'asc');
+
+        $loadedDocuments = [...$search->getResult()];
+        $this->assertCount(3, $loadedDocuments);
+
+        foreach ($documents as $document) {
+            self::$taskHelper->tasks[] = self::$indexer->delete(
+                $schema->indexes[TestingHelper::INDEX_COMPLEX],
+                $document['uuid'],
+                ['return_slow_promise_result' => true],
+            );
+        }
+
+        $beforeTitle = null;
+        foreach ($loadedDocuments as $loadedDocument) {
+            $title = $loadedDocument['title'] ?? '';
+            $this->assertSame(-1, $beforeTitle <=> $title);
+            $beforeTitle = $title;
+        }
+    }
+
+    public function testSortByTextFieldDesc(): void
+    {
+        $documents = TestingHelper::createComplexFixtures();
+
+        $schema = self::getSchema();
+
+        foreach ($documents as $document) {
+            self::$taskHelper->tasks[] = self::$indexer->save(
+                $schema->indexes[TestingHelper::INDEX_COMPLEX],
+                $document,
+                ['return_slow_promise_result' => true],
+            );
+        }
+        self::$taskHelper->waitForAll();
+
+        $search = new SearchBuilder($schema, self::$searcher);
+        $search->index(TestingHelper::INDEX_COMPLEX);
+        $search->addFilter(new Condition\NotEqualCondition('uuid', '97cd3e94-c17f-4c11-a22b-d9da2e5318cd'));
+        $search->addSortBy('title', 'desc');
+
+        $loadedDocuments = [...$search->getResult()];
+        $this->assertCount(3, $loadedDocuments);
+
+        foreach ($documents as $document) {
+            self::$taskHelper->tasks[] = self::$indexer->delete(
+                $schema->indexes[TestingHelper::INDEX_COMPLEX],
+                $document['uuid'],
+                ['return_slow_promise_result' => true],
+            );
+        }
+
+        $beforeTitle = null;
+        foreach ($loadedDocuments as $loadedDocument) {
+            $title = $loadedDocument['title'] ?? '';
+            $this->assertSame(null === $beforeTitle ? -1 : 1, $beforeTitle <=> $title);
+            $beforeTitle = $title;
+        }
+    }
+
     public function testSearchingWithNestedAndOrConditions(): void
     {
         $expectedDocumentIds = [];

--- a/packages/seal/src/Testing/TestingHelper.php
+++ b/packages/seal/src/Testing/TestingHelper.php
@@ -33,7 +33,7 @@ final class TestingHelper
 
         $complexFields = [
             'uuid' => new Field\IdentifierField('uuid'),
-            'title' => new Field\TextField('title'),
+            'title' => new Field\TextField('title', sortable: true),
             'header' => new Field\TypedField('header', 'type', [
                 'image' => [
                     'media' => new Field\IntegerField('media'),


### PR DESCRIPTION
In elasticsearch and opensearch fields for filtering are postfixed with `.raw`, it looks the same is required when sorting on them we need to sort by the raw field which is a keyword instead the normal text field.

Typesense seems to have added sort by text fields in https://github.com/typesense/typesense/issues/117#issuecomment-1000857228. In Algolia we have an issue as the uuid needed to be mapped to objectId and so to filter by it we need change the behaviour.

fixes #523 