### PR TITLE
Add support for Typesense 28 and Typesense PHP SDK 5

### DIFF
--- a/.examples/laravel/composer.lock
+++ b/.examples/laravel/composer.lock
@@ -137,7 +137,7 @@
         },
         {
             "name": "cmsig/seal",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal",
@@ -234,7 +234,7 @@
         },
         {
             "name": "cmsig/seal-laravel-package",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../integrations/laravel",
@@ -6254,7 +6254,7 @@
         },
         {
             "name": "cmsig/seal-algolia-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-algolia-adapter",
@@ -6346,7 +6346,7 @@
         },
         {
             "name": "cmsig/seal-elasticsearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-elasticsearch-adapter",
@@ -6441,7 +6441,7 @@
         },
         {
             "name": "cmsig/seal-loupe-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
@@ -6533,7 +6533,7 @@
         },
         {
             "name": "cmsig/seal-meilisearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-meilisearch-adapter",
@@ -6627,7 +6627,7 @@
         },
         {
             "name": "cmsig/seal-memory-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-memory-adapter",
@@ -6716,7 +6716,7 @@
         },
         {
             "name": "cmsig/seal-multi-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-multi-adapter",
@@ -6806,7 +6806,7 @@
         },
         {
             "name": "cmsig/seal-opensearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-opensearch-adapter",
@@ -6902,7 +6902,7 @@
         },
         {
             "name": "cmsig/seal-read-write-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-read-write-adapter",
@@ -6992,7 +6992,7 @@
         },
         {
             "name": "cmsig/seal-redisearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-redisearch-adapter",
@@ -7086,7 +7086,7 @@
         },
         {
             "name": "cmsig/seal-solr-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-solr-adapter",
@@ -7183,18 +7183,18 @@
         },
         {
             "name": "cmsig/seal-typesense-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-typesense-adapter",
-                "reference": "657e4dbce8859464e20311e03d7c1a2fb22f1575"
+                "reference": "7d7da626ba02bd24b25334f9365468d6d22fcf2b"
             },
             "require": {
                 "cmsig/seal": "^0.8",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "symfony/http-client": "^5.4 || ^6.0 || ^7.0",
-                "typesense/typesense-php": "^4.8.1"
+                "typesense/typesense-php": "^4.8.1 || ^5.0"
             },
             "conflict": {
                 "monolog/monolog": "<2.0"
@@ -13086,16 +13086,16 @@
         },
         {
             "name": "typesense/typesense-php",
-            "version": "v4.9.3",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/typesense/typesense-php.git",
-                "reference": "50fc2089ff4829c8e0e11d8c674e9da085b49998"
+                "reference": "0e8dee542c05b201becf4734319075e6c4d540b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/typesense/typesense-php/zipball/50fc2089ff4829c8e0e11d8c674e9da085b49998",
-                "reference": "50fc2089ff4829c8e0e11d8c674e9da085b49998",
+                "url": "https://api.github.com/repos/typesense/typesense-php/zipball/0e8dee542c05b201becf4734319075e6c4d540b3",
+                "reference": "0e8dee542c05b201becf4734319075e6c4d540b3",
                 "shasum": ""
             },
             "require": {
@@ -13111,6 +13111,8 @@
                 "psr/http-message": "^1.0 || ^2.0"
             },
             "require-dev": {
+                "mockery/mockery": "^1.6",
+                "phpunit/phpunit": "^11.2",
                 "squizlabs/php_codesniffer": "3.*",
                 "symfony/http-client": "^5.2"
             },
@@ -13151,7 +13153,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-04-29T15:34:34+00:00"
+            "time": "2025-05-05T17:35:26+00:00"
         },
         {
             "name": "voku/portable-utf8",

--- a/.examples/laravel/docker-compose.yml
+++ b/.examples/laravel/docker-compose.yml
@@ -57,7 +57,7 @@ services:
         - redisearch-data:/data
 
   typesense:
-    image: typesense/typesense:27.1
+    image: typesense/typesense:28.0
     ports:
       - "8108:8108"
     environment:

--- a/.examples/mezzio/composer.lock
+++ b/.examples/mezzio/composer.lock
@@ -57,7 +57,7 @@
         },
         {
             "name": "cmsig/seal",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal",
@@ -154,7 +154,7 @@
         },
         {
             "name": "cmsig/seal-mezzio-module",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../integrations/mezzio",
@@ -2974,7 +2974,7 @@
         },
         {
             "name": "cmsig/seal-algolia-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-algolia-adapter",
@@ -3066,7 +3066,7 @@
         },
         {
             "name": "cmsig/seal-elasticsearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-elasticsearch-adapter",
@@ -3161,7 +3161,7 @@
         },
         {
             "name": "cmsig/seal-loupe-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
@@ -3253,7 +3253,7 @@
         },
         {
             "name": "cmsig/seal-meilisearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-meilisearch-adapter",
@@ -3347,7 +3347,7 @@
         },
         {
             "name": "cmsig/seal-memory-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-memory-adapter",
@@ -3436,7 +3436,7 @@
         },
         {
             "name": "cmsig/seal-multi-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-multi-adapter",
@@ -3526,7 +3526,7 @@
         },
         {
             "name": "cmsig/seal-opensearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-opensearch-adapter",
@@ -3622,7 +3622,7 @@
         },
         {
             "name": "cmsig/seal-read-write-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-read-write-adapter",
@@ -3712,7 +3712,7 @@
         },
         {
             "name": "cmsig/seal-redisearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-redisearch-adapter",
@@ -3806,7 +3806,7 @@
         },
         {
             "name": "cmsig/seal-solr-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-solr-adapter",
@@ -3903,18 +3903,18 @@
         },
         {
             "name": "cmsig/seal-typesense-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-typesense-adapter",
-                "reference": "657e4dbce8859464e20311e03d7c1a2fb22f1575"
+                "reference": "7d7da626ba02bd24b25334f9365468d6d22fcf2b"
             },
             "require": {
                 "cmsig/seal": "^0.8",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "symfony/http-client": "^5.4 || ^6.0 || ^7.0",
-                "typesense/typesense-php": "^4.8.1"
+                "typesense/typesense-php": "^4.8.1 || ^5.0"
             },
             "conflict": {
                 "monolog/monolog": "<2.0"
@@ -10168,16 +10168,16 @@
         },
         {
             "name": "typesense/typesense-php",
-            "version": "v4.9.3",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/typesense/typesense-php.git",
-                "reference": "50fc2089ff4829c8e0e11d8c674e9da085b49998"
+                "reference": "0e8dee542c05b201becf4734319075e6c4d540b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/typesense/typesense-php/zipball/50fc2089ff4829c8e0e11d8c674e9da085b49998",
-                "reference": "50fc2089ff4829c8e0e11d8c674e9da085b49998",
+                "url": "https://api.github.com/repos/typesense/typesense-php/zipball/0e8dee542c05b201becf4734319075e6c4d540b3",
+                "reference": "0e8dee542c05b201becf4734319075e6c4d540b3",
                 "shasum": ""
             },
             "require": {
@@ -10193,6 +10193,8 @@
                 "psr/http-message": "^1.0 || ^2.0"
             },
             "require-dev": {
+                "mockery/mockery": "^1.6",
+                "phpunit/phpunit": "^11.2",
                 "squizlabs/php_codesniffer": "3.*",
                 "symfony/http-client": "^5.2"
             },
@@ -10233,7 +10235,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-04-29T15:34:34+00:00"
+            "time": "2025-05-05T17:35:26+00:00"
         },
         {
             "name": "voku/portable-ascii",

--- a/.examples/mezzio/docker-compose.yml
+++ b/.examples/mezzio/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       - redisearch-data:/data
 
   typesense:
-    image: typesense/typesense:27.1
+    image: typesense/typesense:28.0
     ports:
       - "8108:8108"
     environment:

--- a/.examples/spiral/composer.lock
+++ b/.examples/spiral/composer.lock
@@ -179,7 +179,7 @@
         },
         {
             "name": "cmsig/seal",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal",
@@ -276,7 +276,7 @@
         },
         {
             "name": "cmsig/seal-spiral-bridge",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../integrations/spiral",
@@ -6949,7 +6949,7 @@
         },
         {
             "name": "cmsig/seal-algolia-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-algolia-adapter",
@@ -7041,7 +7041,7 @@
         },
         {
             "name": "cmsig/seal-elasticsearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-elasticsearch-adapter",
@@ -7136,7 +7136,7 @@
         },
         {
             "name": "cmsig/seal-loupe-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
@@ -7228,7 +7228,7 @@
         },
         {
             "name": "cmsig/seal-meilisearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-meilisearch-adapter",
@@ -7322,7 +7322,7 @@
         },
         {
             "name": "cmsig/seal-memory-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-memory-adapter",
@@ -7411,7 +7411,7 @@
         },
         {
             "name": "cmsig/seal-multi-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-multi-adapter",
@@ -7501,7 +7501,7 @@
         },
         {
             "name": "cmsig/seal-opensearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-opensearch-adapter",
@@ -7597,7 +7597,7 @@
         },
         {
             "name": "cmsig/seal-read-write-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-read-write-adapter",
@@ -7687,7 +7687,7 @@
         },
         {
             "name": "cmsig/seal-redisearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-redisearch-adapter",
@@ -7781,7 +7781,7 @@
         },
         {
             "name": "cmsig/seal-solr-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-solr-adapter",
@@ -7878,18 +7878,18 @@
         },
         {
             "name": "cmsig/seal-typesense-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-typesense-adapter",
-                "reference": "657e4dbce8859464e20311e03d7c1a2fb22f1575"
+                "reference": "7d7da626ba02bd24b25334f9365468d6d22fcf2b"
             },
             "require": {
                 "cmsig/seal": "^0.8",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "symfony/http-client": "^5.4 || ^6.0 || ^7.0",
-                "typesense/typesense-php": "^4.8.1"
+                "typesense/typesense-php": "^4.8.1 || ^5.0"
             },
             "conflict": {
                 "monolog/monolog": "<2.0"
@@ -13178,16 +13178,16 @@
         },
         {
             "name": "typesense/typesense-php",
-            "version": "v4.9.3",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/typesense/typesense-php.git",
-                "reference": "50fc2089ff4829c8e0e11d8c674e9da085b49998"
+                "reference": "0e8dee542c05b201becf4734319075e6c4d540b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/typesense/typesense-php/zipball/50fc2089ff4829c8e0e11d8c674e9da085b49998",
-                "reference": "50fc2089ff4829c8e0e11d8c674e9da085b49998",
+                "url": "https://api.github.com/repos/typesense/typesense-php/zipball/0e8dee542c05b201becf4734319075e6c4d540b3",
+                "reference": "0e8dee542c05b201becf4734319075e6c4d540b3",
                 "shasum": ""
             },
             "require": {
@@ -13203,6 +13203,8 @@
                 "psr/http-message": "^1.0 || ^2.0"
             },
             "require-dev": {
+                "mockery/mockery": "^1.6",
+                "phpunit/phpunit": "^11.2",
                 "squizlabs/php_codesniffer": "3.*",
                 "symfony/http-client": "^5.2"
             },
@@ -13243,7 +13245,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-04-29T15:34:34+00:00"
+            "time": "2025-05-05T17:35:26+00:00"
         },
         {
             "name": "vimeo/psalm",

--- a/.examples/spiral/docker-compose.yml
+++ b/.examples/spiral/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       - redisearch-data:/data
 
   typesense:
-    image: typesense/typesense:27.1
+    image: typesense/typesense:28.0
     ports:
       - "8108:8108"
     environment:

--- a/.examples/symfony/composer.lock
+++ b/.examples/symfony/composer.lock
@@ -8,7 +8,7 @@
     "packages": [
         {
             "name": "cmsig/seal",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal",
@@ -105,7 +105,7 @@
         },
         {
             "name": "cmsig/seal-symfony-bundle",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../integrations/symfony",
@@ -3262,7 +3262,7 @@
         },
         {
             "name": "cmsig/seal-algolia-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-algolia-adapter",
@@ -3354,7 +3354,7 @@
         },
         {
             "name": "cmsig/seal-elasticsearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-elasticsearch-adapter",
@@ -3449,7 +3449,7 @@
         },
         {
             "name": "cmsig/seal-loupe-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
@@ -3541,7 +3541,7 @@
         },
         {
             "name": "cmsig/seal-meilisearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-meilisearch-adapter",
@@ -3635,7 +3635,7 @@
         },
         {
             "name": "cmsig/seal-memory-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-memory-adapter",
@@ -3724,7 +3724,7 @@
         },
         {
             "name": "cmsig/seal-multi-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-multi-adapter",
@@ -3814,7 +3814,7 @@
         },
         {
             "name": "cmsig/seal-opensearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-opensearch-adapter",
@@ -3910,7 +3910,7 @@
         },
         {
             "name": "cmsig/seal-read-write-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-read-write-adapter",
@@ -4000,7 +4000,7 @@
         },
         {
             "name": "cmsig/seal-redisearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-redisearch-adapter",
@@ -4094,7 +4094,7 @@
         },
         {
             "name": "cmsig/seal-solr-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-solr-adapter",
@@ -4191,18 +4191,18 @@
         },
         {
             "name": "cmsig/seal-typesense-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-typesense-adapter",
-                "reference": "657e4dbce8859464e20311e03d7c1a2fb22f1575"
+                "reference": "7d7da626ba02bd24b25334f9365468d6d22fcf2b"
             },
             "require": {
                 "cmsig/seal": "^0.8",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "symfony/http-client": "^5.4 || ^6.0 || ^7.0",
-                "typesense/typesense-php": "^4.8.1"
+                "typesense/typesense-php": "^4.8.1 || ^5.0"
             },
             "conflict": {
                 "monolog/monolog": "<2.0"
@@ -8603,16 +8603,16 @@
         },
         {
             "name": "typesense/typesense-php",
-            "version": "v4.9.3",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/typesense/typesense-php.git",
-                "reference": "50fc2089ff4829c8e0e11d8c674e9da085b49998"
+                "reference": "0e8dee542c05b201becf4734319075e6c4d540b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/typesense/typesense-php/zipball/50fc2089ff4829c8e0e11d8c674e9da085b49998",
-                "reference": "50fc2089ff4829c8e0e11d8c674e9da085b49998",
+                "url": "https://api.github.com/repos/typesense/typesense-php/zipball/0e8dee542c05b201becf4734319075e6c4d540b3",
+                "reference": "0e8dee542c05b201becf4734319075e6c4d540b3",
                 "shasum": ""
             },
             "require": {
@@ -8628,6 +8628,8 @@
                 "psr/http-message": "^1.0 || ^2.0"
             },
             "require-dev": {
+                "mockery/mockery": "^1.6",
+                "phpunit/phpunit": "^11.2",
                 "squizlabs/php_codesniffer": "3.*",
                 "symfony/http-client": "^5.2"
             },
@@ -8668,7 +8670,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-04-29T15:34:34+00:00"
+            "time": "2025-05-05T17:35:26+00:00"
         },
         {
             "name": "voku/portable-ascii",

--- a/.examples/symfony/docker-compose.yml
+++ b/.examples/symfony/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       - redisearch-data:/data
 
   typesense:
-    image: typesense/typesense:27.1
+    image: typesense/typesense:28.0
     ports:
       - "8108:8108"
     environment:

--- a/.examples/yii/composer.lock
+++ b/.examples/yii/composer.lock
@@ -119,7 +119,7 @@
         },
         {
             "name": "cmsig/seal",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal",
@@ -216,7 +216,7 @@
         },
         {
             "name": "cmsig/seal-yii-module",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../integrations/yii",
@@ -5665,16 +5665,16 @@
         },
         {
             "name": "behat/gherkin",
-            "version": "v4.12.0",
+            "version": "v4.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Behat/Gherkin.git",
-                "reference": "cc3a7e224b36373be382b53ef02ede0f1807bb58"
+                "reference": "9294d26bb75f1718441b89f3a10e15ecb2c67f70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Behat/Gherkin/zipball/cc3a7e224b36373be382b53ef02ede0f1807bb58",
-                "reference": "cc3a7e224b36373be382b53ef02ede0f1807bb58",
+                "url": "https://api.github.com/repos/Behat/Gherkin/zipball/9294d26bb75f1718441b89f3a10e15ecb2c67f70",
+                "reference": "9294d26bb75f1718441b89f3a10e15ecb2c67f70",
                 "shasum": ""
             },
             "require": {
@@ -5682,13 +5682,12 @@
                 "php": "8.1.* || 8.2.* || 8.3.* || 8.4.*"
             },
             "require-dev": {
-                "cucumber/cucumber": "dev-gherkin-24.1.0",
+                "cucumber/gherkin-monorepo": "dev-gherkin-v32.1.1",
                 "friendsofphp/php-cs-fixer": "^3.65",
                 "phpstan/extension-installer": "^1",
                 "phpstan/phpstan": "^2",
                 "phpstan/phpstan-phpunit": "^2",
                 "phpunit/phpunit": "^10.5",
-                "symfony/filesystem": "^5.4 || ^6.4 || ^7.0",
                 "symfony/yaml": "^5.4 || ^6.4 || ^7.0"
             },
             "suggest": {
@@ -5701,8 +5700,8 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Behat\\Gherkin": "src/"
+                "psr-4": {
+                    "Behat\\Gherkin\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -5728,9 +5727,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Behat/Gherkin/issues",
-                "source": "https://github.com/Behat/Gherkin/tree/v4.12.0"
+                "source": "https://github.com/Behat/Gherkin/tree/v4.13.0"
             },
-            "time": "2025-02-26T14:28:23+00:00"
+            "time": "2025-05-06T15:26:21+00:00"
         },
         {
             "name": "clue/stdio-react",
@@ -6012,7 +6011,7 @@
         },
         {
             "name": "cmsig/seal-algolia-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-algolia-adapter",
@@ -6104,7 +6103,7 @@
         },
         {
             "name": "cmsig/seal-elasticsearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-elasticsearch-adapter",
@@ -6199,7 +6198,7 @@
         },
         {
             "name": "cmsig/seal-loupe-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
@@ -6291,7 +6290,7 @@
         },
         {
             "name": "cmsig/seal-meilisearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-meilisearch-adapter",
@@ -6385,7 +6384,7 @@
         },
         {
             "name": "cmsig/seal-memory-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-memory-adapter",
@@ -6474,7 +6473,7 @@
         },
         {
             "name": "cmsig/seal-multi-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-multi-adapter",
@@ -6564,7 +6563,7 @@
         },
         {
             "name": "cmsig/seal-opensearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-opensearch-adapter",
@@ -6660,7 +6659,7 @@
         },
         {
             "name": "cmsig/seal-read-write-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-read-write-adapter",
@@ -6750,7 +6749,7 @@
         },
         {
             "name": "cmsig/seal-redisearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-redisearch-adapter",
@@ -6844,7 +6843,7 @@
         },
         {
             "name": "cmsig/seal-solr-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-solr-adapter",
@@ -6941,18 +6940,18 @@
         },
         {
             "name": "cmsig/seal-typesense-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-typesense-adapter",
-                "reference": "657e4dbce8859464e20311e03d7c1a2fb22f1575"
+                "reference": "7d7da626ba02bd24b25334f9365468d6d22fcf2b"
             },
             "require": {
                 "cmsig/seal": "^0.8",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "symfony/http-client": "^5.4 || ^6.0 || ^7.0",
-                "typesense/typesense-php": "^4.8.1"
+                "typesense/typesense-php": "^4.8.1 || ^5.0"
             },
             "conflict": {
                 "monolog/monolog": "<2.0"
@@ -13987,16 +13986,16 @@
         },
         {
             "name": "typesense/typesense-php",
-            "version": "v4.9.3",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/typesense/typesense-php.git",
-                "reference": "50fc2089ff4829c8e0e11d8c674e9da085b49998"
+                "reference": "0e8dee542c05b201becf4734319075e6c4d540b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/typesense/typesense-php/zipball/50fc2089ff4829c8e0e11d8c674e9da085b49998",
-                "reference": "50fc2089ff4829c8e0e11d8c674e9da085b49998",
+                "url": "https://api.github.com/repos/typesense/typesense-php/zipball/0e8dee542c05b201becf4734319075e6c4d540b3",
+                "reference": "0e8dee542c05b201becf4734319075e6c4d540b3",
                 "shasum": ""
             },
             "require": {
@@ -14012,6 +14011,8 @@
                 "psr/http-message": "^1.0 || ^2.0"
             },
             "require-dev": {
+                "mockery/mockery": "^1.6",
+                "phpunit/phpunit": "^11.2",
                 "squizlabs/php_codesniffer": "3.*",
                 "symfony/http-client": "^5.2"
             },
@@ -14052,7 +14053,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-04-29T15:34:34+00:00"
+            "time": "2025-05-05T17:35:26+00:00"
         },
         {
             "name": "voku/portable-ascii",

--- a/.examples/yii/docker-compose.yml
+++ b/.examples/yii/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       - redisearch-data:/data
 
   typesense:
-    image: typesense/typesense:27.1
+    image: typesense/typesense:28.0
     ports:
       - "8108:8108"
     environment:

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -1667,7 +1667,7 @@ search engine.
 
             services:
               typesense:
-                image: typesense/typesense:27.1
+                image: typesense/typesense:28.0
                 ports:
                   - "8108:8108"
                 environment:

--- a/integrations/laravel/composer.lock
+++ b/integrations/laravel/composer.lock
@@ -77,7 +77,7 @@
         },
         {
             "name": "cmsig/seal",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal",
@@ -1420,12 +1420,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "d10b149020a8cec39fad6e34adf1295ffab768f8"
+                "reference": "fdbc4c32d108abf5d5b69502025b12fdc23f2f81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/d10b149020a8cec39fad6e34adf1295ffab768f8",
-                "reference": "d10b149020a8cec39fad6e34adf1295ffab768f8",
+                "url": "https://api.github.com/repos/symfony/console/zipball/fdbc4c32d108abf5d5b69502025b12fdc23f2f81",
+                "reference": "fdbc4c32d108abf5d5b69502025b12fdc23f2f81",
                 "shasum": ""
             },
             "require": {
@@ -1507,7 +1507,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-05T08:24:21+00:00"
+            "time": "2025-05-06T13:45:12+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2660,7 +2660,7 @@
         },
         {
             "name": "cmsig/seal-algolia-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-algolia-adapter",
@@ -2752,7 +2752,7 @@
         },
         {
             "name": "cmsig/seal-elasticsearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-elasticsearch-adapter",
@@ -2847,7 +2847,7 @@
         },
         {
             "name": "cmsig/seal-loupe-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
@@ -2939,7 +2939,7 @@
         },
         {
             "name": "cmsig/seal-meilisearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-meilisearch-adapter",
@@ -3033,7 +3033,7 @@
         },
         {
             "name": "cmsig/seal-memory-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-memory-adapter",
@@ -3122,7 +3122,7 @@
         },
         {
             "name": "cmsig/seal-multi-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-multi-adapter",
@@ -3212,7 +3212,7 @@
         },
         {
             "name": "cmsig/seal-opensearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-opensearch-adapter",
@@ -3308,7 +3308,7 @@
         },
         {
             "name": "cmsig/seal-read-write-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-read-write-adapter",
@@ -3398,7 +3398,7 @@
         },
         {
             "name": "cmsig/seal-redisearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-redisearch-adapter",
@@ -3492,7 +3492,7 @@
         },
         {
             "name": "cmsig/seal-solr-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-solr-adapter",
@@ -3589,18 +3589,18 @@
         },
         {
             "name": "cmsig/seal-typesense-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-typesense-adapter",
-                "reference": "657e4dbce8859464e20311e03d7c1a2fb22f1575"
+                "reference": "7d7da626ba02bd24b25334f9365468d6d22fcf2b"
             },
             "require": {
                 "cmsig/seal": "^0.8",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "symfony/http-client": "^5.4 || ^6.0 || ^7.0",
-                "typesense/typesense-php": "^4.8.1"
+                "typesense/typesense-php": "^4.8.1 || ^5.0"
             },
             "conflict": {
                 "monolog/monolog": "<2.0"
@@ -5659,12 +5659,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f"
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/36b3925046cf70ddb434566165c5fe01389a993f",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b7137d1a5be9f129daf5c3520e7b50f187194ded",
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded",
                 "shasum": ""
             },
             "require": {
@@ -5709,7 +5709,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-05T16:02:47+00:00"
+            "time": "2025-05-06T09:57:30+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -8474,16 +8474,16 @@
         },
         {
             "name": "typesense/typesense-php",
-            "version": "v4.10.0-RC1",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/typesense/typesense-php.git",
-                "reference": "9f333826a58c63d703373becd03afd10028eac60"
+                "reference": "0e8dee542c05b201becf4734319075e6c4d540b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/typesense/typesense-php/zipball/9f333826a58c63d703373becd03afd10028eac60",
-                "reference": "9f333826a58c63d703373becd03afd10028eac60",
+                "url": "https://api.github.com/repos/typesense/typesense-php/zipball/0e8dee542c05b201becf4734319075e6c4d540b3",
+                "reference": "0e8dee542c05b201becf4734319075e6c4d540b3",
                 "shasum": ""
             },
             "require": {
@@ -8541,7 +8541,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-05T16:31:56+00:00"
+            "time": "2025-05-05T17:35:26+00:00"
         },
         {
             "name": "voku/portable-utf8",

--- a/integrations/mezzio/composer.lock
+++ b/integrations/mezzio/composer.lock
@@ -8,7 +8,7 @@
     "packages": [
         {
             "name": "cmsig/seal",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal",
@@ -1290,7 +1290,7 @@
         },
         {
             "name": "cmsig/seal-algolia-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-algolia-adapter",
@@ -1382,7 +1382,7 @@
         },
         {
             "name": "cmsig/seal-elasticsearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-elasticsearch-adapter",
@@ -1477,7 +1477,7 @@
         },
         {
             "name": "cmsig/seal-loupe-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
@@ -1569,7 +1569,7 @@
         },
         {
             "name": "cmsig/seal-meilisearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-meilisearch-adapter",
@@ -1663,7 +1663,7 @@
         },
         {
             "name": "cmsig/seal-memory-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-memory-adapter",
@@ -1752,7 +1752,7 @@
         },
         {
             "name": "cmsig/seal-multi-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-multi-adapter",
@@ -1842,7 +1842,7 @@
         },
         {
             "name": "cmsig/seal-opensearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-opensearch-adapter",
@@ -1938,7 +1938,7 @@
         },
         {
             "name": "cmsig/seal-read-write-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-read-write-adapter",
@@ -2028,7 +2028,7 @@
         },
         {
             "name": "cmsig/seal-redisearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-redisearch-adapter",
@@ -2122,7 +2122,7 @@
         },
         {
             "name": "cmsig/seal-solr-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-solr-adapter",
@@ -2219,18 +2219,18 @@
         },
         {
             "name": "cmsig/seal-typesense-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-typesense-adapter",
-                "reference": "657e4dbce8859464e20311e03d7c1a2fb22f1575"
+                "reference": "7d7da626ba02bd24b25334f9365468d6d22fcf2b"
             },
             "require": {
                 "cmsig/seal": "^0.8",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "symfony/http-client": "^5.4 || ^6.0 || ^7.0",
-                "typesense/typesense-php": "^4.8.1"
+                "typesense/typesense-php": "^4.8.1 || ^5.0"
             },
             "conflict": {
                 "monolog/monolog": "<2.0"
@@ -4289,12 +4289,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f"
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/36b3925046cf70ddb434566165c5fe01389a993f",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b7137d1a5be9f129daf5c3520e7b50f187194ded",
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded",
                 "shasum": ""
             },
             "require": {
@@ -4339,7 +4339,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-05T16:02:47+00:00"
+            "time": "2025-05-06T09:57:30+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -7026,16 +7026,16 @@
         },
         {
             "name": "typesense/typesense-php",
-            "version": "v4.10.0-RC1",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/typesense/typesense-php.git",
-                "reference": "9f333826a58c63d703373becd03afd10028eac60"
+                "reference": "0e8dee542c05b201becf4734319075e6c4d540b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/typesense/typesense-php/zipball/9f333826a58c63d703373becd03afd10028eac60",
-                "reference": "9f333826a58c63d703373becd03afd10028eac60",
+                "url": "https://api.github.com/repos/typesense/typesense-php/zipball/0e8dee542c05b201becf4734319075e6c4d540b3",
+                "reference": "0e8dee542c05b201becf4734319075e6c4d540b3",
                 "shasum": ""
             },
             "require": {
@@ -7093,7 +7093,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-05T16:31:56+00:00"
+            "time": "2025-05-05T17:35:26+00:00"
         },
         {
             "name": "voku/portable-ascii",

--- a/integrations/spiral/composer.lock
+++ b/integrations/spiral/composer.lock
@@ -8,7 +8,7 @@
     "packages": [
         {
             "name": "cmsig/seal",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal",
@@ -1471,12 +1471,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "d10b149020a8cec39fad6e34adf1295ffab768f8"
+                "reference": "fdbc4c32d108abf5d5b69502025b12fdc23f2f81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/d10b149020a8cec39fad6e34adf1295ffab768f8",
-                "reference": "d10b149020a8cec39fad6e34adf1295ffab768f8",
+                "url": "https://api.github.com/repos/symfony/console/zipball/fdbc4c32d108abf5d5b69502025b12fdc23f2f81",
+                "reference": "fdbc4c32d108abf5d5b69502025b12fdc23f2f81",
                 "shasum": ""
             },
             "require": {
@@ -1558,7 +1558,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-05T08:24:21+00:00"
+            "time": "2025-05-06T13:45:12+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2324,7 +2324,7 @@
         },
         {
             "name": "cmsig/seal-algolia-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-algolia-adapter",
@@ -2416,7 +2416,7 @@
         },
         {
             "name": "cmsig/seal-elasticsearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-elasticsearch-adapter",
@@ -2511,7 +2511,7 @@
         },
         {
             "name": "cmsig/seal-loupe-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
@@ -2603,7 +2603,7 @@
         },
         {
             "name": "cmsig/seal-meilisearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-meilisearch-adapter",
@@ -2697,7 +2697,7 @@
         },
         {
             "name": "cmsig/seal-memory-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-memory-adapter",
@@ -2786,7 +2786,7 @@
         },
         {
             "name": "cmsig/seal-multi-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-multi-adapter",
@@ -2876,7 +2876,7 @@
         },
         {
             "name": "cmsig/seal-opensearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-opensearch-adapter",
@@ -2972,7 +2972,7 @@
         },
         {
             "name": "cmsig/seal-read-write-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-read-write-adapter",
@@ -3062,7 +3062,7 @@
         },
         {
             "name": "cmsig/seal-redisearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-redisearch-adapter",
@@ -3156,7 +3156,7 @@
         },
         {
             "name": "cmsig/seal-solr-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-solr-adapter",
@@ -3253,18 +3253,18 @@
         },
         {
             "name": "cmsig/seal-typesense-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-typesense-adapter",
-                "reference": "657e4dbce8859464e20311e03d7c1a2fb22f1575"
+                "reference": "7d7da626ba02bd24b25334f9365468d6d22fcf2b"
             },
             "require": {
                 "cmsig/seal": "^0.8",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "symfony/http-client": "^5.4 || ^6.0 || ^7.0",
-                "typesense/typesense-php": "^4.8.1"
+                "typesense/typesense-php": "^4.8.1 || ^5.0"
             },
             "conflict": {
                 "monolog/monolog": "<2.0"
@@ -5323,12 +5323,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f"
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/36b3925046cf70ddb434566165c5fe01389a993f",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b7137d1a5be9f129daf5c3520e7b50f187194ded",
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded",
                 "shasum": ""
             },
             "require": {
@@ -5373,7 +5373,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-05T16:02:47+00:00"
+            "time": "2025-05-06T09:57:30+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -7981,16 +7981,16 @@
         },
         {
             "name": "typesense/typesense-php",
-            "version": "v4.10.0-RC1",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/typesense/typesense-php.git",
-                "reference": "9f333826a58c63d703373becd03afd10028eac60"
+                "reference": "0e8dee542c05b201becf4734319075e6c4d540b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/typesense/typesense-php/zipball/9f333826a58c63d703373becd03afd10028eac60",
-                "reference": "9f333826a58c63d703373becd03afd10028eac60",
+                "url": "https://api.github.com/repos/typesense/typesense-php/zipball/0e8dee542c05b201becf4734319075e6c4d540b3",
+                "reference": "0e8dee542c05b201becf4734319075e6c4d540b3",
                 "shasum": ""
             },
             "require": {
@@ -8048,7 +8048,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-05T16:31:56+00:00"
+            "time": "2025-05-05T17:35:26+00:00"
         },
         {
             "name": "voku/portable-ascii",

--- a/integrations/symfony/composer.lock
+++ b/integrations/symfony/composer.lock
@@ -8,7 +8,7 @@
     "packages": [
         {
             "name": "cmsig/seal",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal",
@@ -342,12 +342,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "d10b149020a8cec39fad6e34adf1295ffab768f8"
+                "reference": "fdbc4c32d108abf5d5b69502025b12fdc23f2f81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/d10b149020a8cec39fad6e34adf1295ffab768f8",
-                "reference": "d10b149020a8cec39fad6e34adf1295ffab768f8",
+                "url": "https://api.github.com/repos/symfony/console/zipball/fdbc4c32d108abf5d5b69502025b12fdc23f2f81",
+                "reference": "fdbc4c32d108abf5d5b69502025b12fdc23f2f81",
                 "shasum": ""
             },
             "require": {
@@ -429,7 +429,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-05T08:24:21+00:00"
+            "time": "2025-05-06T13:45:12+00:00"
         },
         {
             "name": "symfony/dependency-injection",
@@ -1942,7 +1942,7 @@
         },
         {
             "name": "cmsig/seal-algolia-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-algolia-adapter",
@@ -2034,7 +2034,7 @@
         },
         {
             "name": "cmsig/seal-elasticsearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-elasticsearch-adapter",
@@ -2129,7 +2129,7 @@
         },
         {
             "name": "cmsig/seal-loupe-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
@@ -2221,7 +2221,7 @@
         },
         {
             "name": "cmsig/seal-meilisearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-meilisearch-adapter",
@@ -2315,7 +2315,7 @@
         },
         {
             "name": "cmsig/seal-memory-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-memory-adapter",
@@ -2404,7 +2404,7 @@
         },
         {
             "name": "cmsig/seal-multi-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-multi-adapter",
@@ -2494,7 +2494,7 @@
         },
         {
             "name": "cmsig/seal-opensearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-opensearch-adapter",
@@ -2590,7 +2590,7 @@
         },
         {
             "name": "cmsig/seal-read-write-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-read-write-adapter",
@@ -2680,7 +2680,7 @@
         },
         {
             "name": "cmsig/seal-redisearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-redisearch-adapter",
@@ -2774,7 +2774,7 @@
         },
         {
             "name": "cmsig/seal-solr-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-solr-adapter",
@@ -2871,18 +2871,18 @@
         },
         {
             "name": "cmsig/seal-typesense-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-typesense-adapter",
-                "reference": "657e4dbce8859464e20311e03d7c1a2fb22f1575"
+                "reference": "7d7da626ba02bd24b25334f9365468d6d22fcf2b"
             },
             "require": {
                 "cmsig/seal": "^0.8",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "symfony/http-client": "^5.4 || ^6.0 || ^7.0",
-                "typesense/typesense-php": "^4.8.1"
+                "typesense/typesense-php": "^4.8.1 || ^5.0"
             },
             "conflict": {
                 "monolog/monolog": "<2.0"
@@ -4941,12 +4941,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f"
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/36b3925046cf70ddb434566165c5fe01389a993f",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b7137d1a5be9f129daf5c3520e7b50f187194ded",
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded",
                 "shasum": ""
             },
             "require": {
@@ -4991,7 +4991,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-05T16:02:47+00:00"
+            "time": "2025-05-06T09:57:30+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -7627,16 +7627,16 @@
         },
         {
             "name": "typesense/typesense-php",
-            "version": "v4.10.0-RC1",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/typesense/typesense-php.git",
-                "reference": "9f333826a58c63d703373becd03afd10028eac60"
+                "reference": "0e8dee542c05b201becf4734319075e6c4d540b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/typesense/typesense-php/zipball/9f333826a58c63d703373becd03afd10028eac60",
-                "reference": "9f333826a58c63d703373becd03afd10028eac60",
+                "url": "https://api.github.com/repos/typesense/typesense-php/zipball/0e8dee542c05b201becf4734319075e6c4d540b3",
+                "reference": "0e8dee542c05b201becf4734319075e6c4d540b3",
                 "shasum": ""
             },
             "require": {
@@ -7694,7 +7694,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-05T16:31:56+00:00"
+            "time": "2025-05-05T17:35:26+00:00"
         },
         {
             "name": "voku/portable-ascii",

--- a/integrations/yii/composer.lock
+++ b/integrations/yii/composer.lock
@@ -8,7 +8,7 @@
     "packages": [
         {
             "name": "cmsig/seal",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal",
@@ -1415,7 +1415,7 @@
         },
         {
             "name": "cmsig/seal-algolia-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-algolia-adapter",
@@ -1507,7 +1507,7 @@
         },
         {
             "name": "cmsig/seal-elasticsearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-elasticsearch-adapter",
@@ -1602,7 +1602,7 @@
         },
         {
             "name": "cmsig/seal-loupe-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-loupe-adapter",
@@ -1694,7 +1694,7 @@
         },
         {
             "name": "cmsig/seal-meilisearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-meilisearch-adapter",
@@ -1788,7 +1788,7 @@
         },
         {
             "name": "cmsig/seal-memory-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-memory-adapter",
@@ -1877,7 +1877,7 @@
         },
         {
             "name": "cmsig/seal-multi-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-multi-adapter",
@@ -1967,7 +1967,7 @@
         },
         {
             "name": "cmsig/seal-opensearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-opensearch-adapter",
@@ -2063,7 +2063,7 @@
         },
         {
             "name": "cmsig/seal-read-write-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-read-write-adapter",
@@ -2153,7 +2153,7 @@
         },
         {
             "name": "cmsig/seal-redisearch-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-redisearch-adapter",
@@ -2247,7 +2247,7 @@
         },
         {
             "name": "cmsig/seal-solr-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-solr-adapter",
@@ -2344,18 +2344,18 @@
         },
         {
             "name": "cmsig/seal-typesense-adapter",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../../packages/seal-typesense-adapter",
-                "reference": "657e4dbce8859464e20311e03d7c1a2fb22f1575"
+                "reference": "7d7da626ba02bd24b25334f9365468d6d22fcf2b"
             },
             "require": {
                 "cmsig/seal": "^0.8",
                 "php": "^8.1",
                 "psr/container": "^1.0 || ^2.0",
                 "symfony/http-client": "^5.4 || ^6.0 || ^7.0",
-                "typesense/typesense-php": "^4.8.1"
+                "typesense/typesense-php": "^4.8.1 || ^5.0"
             },
             "conflict": {
                 "monolog/monolog": "<2.0"
@@ -4414,12 +4414,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f"
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/36b3925046cf70ddb434566165c5fe01389a993f",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b7137d1a5be9f129daf5c3520e7b50f187194ded",
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded",
                 "shasum": ""
             },
             "require": {
@@ -4464,7 +4464,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-05T16:02:47+00:00"
+            "time": "2025-05-06T09:57:30+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -7100,16 +7100,16 @@
         },
         {
             "name": "typesense/typesense-php",
-            "version": "v4.10.0-RC1",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/typesense/typesense-php.git",
-                "reference": "9f333826a58c63d703373becd03afd10028eac60"
+                "reference": "0e8dee542c05b201becf4734319075e6c4d540b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/typesense/typesense-php/zipball/9f333826a58c63d703373becd03afd10028eac60",
-                "reference": "9f333826a58c63d703373becd03afd10028eac60",
+                "url": "https://api.github.com/repos/typesense/typesense-php/zipball/0e8dee542c05b201becf4734319075e6c4d540b3",
+                "reference": "0e8dee542c05b201becf4734319075e6c4d540b3",
                 "shasum": ""
             },
             "require": {
@@ -7167,7 +7167,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-05T16:31:56+00:00"
+            "time": "2025-05-05T17:35:26+00:00"
         },
         {
             "name": "voku/portable-ascii",

--- a/packages/seal-algolia-adapter/composer.lock
+++ b/packages/seal-algolia-adapter/composer.lock
@@ -75,7 +75,7 @@
         },
         {
             "name": "cmsig/seal",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../seal",
@@ -944,12 +944,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f"
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/36b3925046cf70ddb434566165c5fe01389a993f",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b7137d1a5be9f129daf5c3520e7b50f187194ded",
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded",
                 "shasum": ""
             },
             "require": {
@@ -994,7 +994,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-05T16:02:47+00:00"
+            "time": "2025-05-06T09:57:30+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/packages/seal-elasticsearch-adapter/composer.lock
+++ b/packages/seal-elasticsearch-adapter/composer.lock
@@ -8,7 +8,7 @@
     "packages": [
         {
             "name": "cmsig/seal",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../seal",
@@ -1550,12 +1550,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f"
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/36b3925046cf70ddb434566165c5fe01389a993f",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b7137d1a5be9f129daf5c3520e7b50f187194ded",
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded",
                 "shasum": ""
             },
             "require": {
@@ -1600,7 +1600,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-05T16:02:47+00:00"
+            "time": "2025-05-06T09:57:30+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/packages/seal-loupe-adapter/composer.lock
+++ b/packages/seal-loupe-adapter/composer.lock
@@ -8,7 +8,7 @@
     "packages": [
         {
             "name": "cmsig/seal",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../seal",
@@ -1699,12 +1699,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f"
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/36b3925046cf70ddb434566165c5fe01389a993f",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b7137d1a5be9f129daf5c3520e7b50f187194ded",
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded",
                 "shasum": ""
             },
             "require": {
@@ -1749,7 +1749,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-05T16:02:47+00:00"
+            "time": "2025-05-06T09:57:30+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/packages/seal-meilisearch-adapter/composer.lock
+++ b/packages/seal-meilisearch-adapter/composer.lock
@@ -8,7 +8,7 @@
     "packages": [
         {
             "name": "cmsig/seal",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../seal",
@@ -1144,12 +1144,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f"
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/36b3925046cf70ddb434566165c5fe01389a993f",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b7137d1a5be9f129daf5c3520e7b50f187194ded",
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded",
                 "shasum": ""
             },
             "require": {
@@ -1194,7 +1194,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-05T16:02:47+00:00"
+            "time": "2025-05-06T09:57:30+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/packages/seal-memory-adapter/composer.lock
+++ b/packages/seal-memory-adapter/composer.lock
@@ -8,7 +8,7 @@
     "packages": [
         {
             "name": "cmsig/seal",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../seal",
@@ -450,12 +450,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f"
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/36b3925046cf70ddb434566165c5fe01389a993f",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b7137d1a5be9f129daf5c3520e7b50f187194ded",
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded",
                 "shasum": ""
             },
             "require": {
@@ -500,7 +500,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-05T16:02:47+00:00"
+            "time": "2025-05-06T09:57:30+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/packages/seal-multi-adapter/composer.lock
+++ b/packages/seal-multi-adapter/composer.lock
@@ -8,7 +8,7 @@
     "packages": [
         {
             "name": "cmsig/seal",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../seal",
@@ -504,12 +504,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f"
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/36b3925046cf70ddb434566165c5fe01389a993f",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b7137d1a5be9f129daf5c3520e7b50f187194ded",
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded",
                 "shasum": ""
             },
             "require": {
@@ -554,7 +554,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-05T16:02:47+00:00"
+            "time": "2025-05-06T09:57:30+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/packages/seal-opensearch-adapter/composer.lock
+++ b/packages/seal-opensearch-adapter/composer.lock
@@ -8,7 +8,7 @@
     "packages": [
         {
             "name": "cmsig/seal",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../seal",
@@ -1716,12 +1716,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f"
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/36b3925046cf70ddb434566165c5fe01389a993f",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b7137d1a5be9f129daf5c3520e7b50f187194ded",
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded",
                 "shasum": ""
             },
             "require": {
@@ -1766,7 +1766,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-05T16:02:47+00:00"
+            "time": "2025-05-06T09:57:30+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/packages/seal-read-write-adapter/composer.lock
+++ b/packages/seal-read-write-adapter/composer.lock
@@ -8,7 +8,7 @@
     "packages": [
         {
             "name": "cmsig/seal",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../seal",
@@ -504,12 +504,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f"
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/36b3925046cf70ddb434566165c5fe01389a993f",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b7137d1a5be9f129daf5c3520e7b50f187194ded",
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded",
                 "shasum": ""
             },
             "require": {
@@ -554,7 +554,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-05T16:02:47+00:00"
+            "time": "2025-05-06T09:57:30+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/packages/seal-redisearch-adapter/composer.lock
+++ b/packages/seal-redisearch-adapter/composer.lock
@@ -8,7 +8,7 @@
     "packages": [
         {
             "name": "cmsig/seal",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../seal",
@@ -504,12 +504,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f"
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/36b3925046cf70ddb434566165c5fe01389a993f",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b7137d1a5be9f129daf5c3520e7b50f187194ded",
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded",
                 "shasum": ""
             },
             "require": {
@@ -554,7 +554,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-05T16:02:47+00:00"
+            "time": "2025-05-06T09:57:30+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/packages/seal-solr-adapter/composer.lock
+++ b/packages/seal-solr-adapter/composer.lock
@@ -8,7 +8,7 @@
     "packages": [
         {
             "name": "cmsig/seal",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../seal",
@@ -926,12 +926,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f"
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/36b3925046cf70ddb434566165c5fe01389a993f",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b7137d1a5be9f129daf5c3520e7b50f187194ded",
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded",
                 "shasum": ""
             },
             "require": {
@@ -976,7 +976,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-05T16:02:47+00:00"
+            "time": "2025-05-06T09:57:30+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/packages/seal-typesense-adapter/composer.json
+++ b/packages/seal-typesense-adapter/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": "^8.1",
         "cmsig/seal": "^0.8",
-        "typesense/typesense-php": "^4.8.1",
+        "typesense/typesense-php": "^4.8.1 || ^5.0",
         "symfony/http-client": "^5.4 || ^6.0 || ^7.0",
         "psr/container": "^1.0 || ^2.0"
     },

--- a/packages/seal-typesense-adapter/composer.lock
+++ b/packages/seal-typesense-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1f74e2b6d72082174720e854b5235170",
+    "content-hash": "14d9588dd8bd3be59c71cc2570c8d6af",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -75,7 +75,7 @@
         },
         {
             "name": "cmsig/seal",
-            "version": "0.8.0",
+            "version": "0.8.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./../seal",
@@ -1427,16 +1427,16 @@
         },
         {
             "name": "typesense/typesense-php",
-            "version": "v4.10.0-RC1",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/typesense/typesense-php.git",
-                "reference": "9f333826a58c63d703373becd03afd10028eac60"
+                "reference": "0e8dee542c05b201becf4734319075e6c4d540b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/typesense/typesense-php/zipball/9f333826a58c63d703373becd03afd10028eac60",
-                "reference": "9f333826a58c63d703373becd03afd10028eac60",
+                "url": "https://api.github.com/repos/typesense/typesense-php/zipball/0e8dee542c05b201becf4734319075e6c4d540b3",
+                "reference": "0e8dee542c05b201becf4734319075e6c4d540b3",
                 "shasum": ""
             },
             "require": {
@@ -1494,7 +1494,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-05T16:31:56+00:00"
+            "time": "2025-05-05T17:35:26+00:00"
         }
     ],
     "packages-dev": [
@@ -1909,12 +1909,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f"
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/36b3925046cf70ddb434566165c5fe01389a993f",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b7137d1a5be9f129daf5c3520e7b50f187194ded",
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded",
                 "shasum": ""
             },
             "require": {
@@ -1959,7 +1959,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-05T16:02:47+00:00"
+            "time": "2025-05-06T09:57:30+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/packages/seal-typesense-adapter/docker-compose.yml
+++ b/packages/seal-typesense-adapter/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   typesense:
-    image: typesense/typesense:27.1
+    image: typesense/typesense:28.0
     ports:
       - "8108:8108"
     environment:

--- a/packages/seal/composer.lock
+++ b/packages/seal/composer.lock
@@ -352,12 +352,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f"
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/36b3925046cf70ddb434566165c5fe01389a993f",
-                "reference": "36b3925046cf70ddb434566165c5fe01389a993f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b7137d1a5be9f129daf5c3520e7b50f187194ded",
+                "reference": "b7137d1a5be9f129daf5c3520e7b50f187194ded",
                 "shasum": ""
             },
             "require": {
@@ -402,7 +402,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-05T16:02:47+00:00"
+            "time": "2025-05-06T09:57:30+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",


### PR DESCRIPTION
A new version of Typesense and the Typesense PHP SDK was released some time ago this update the SDK and tests against the new version.

See also:

 - https://github.com/typesense/typesense-php/releases/tag/v5.0.0
 - https://github.com/typesense/typesense/releases/tag/v28.0

From our perspective no changes are required yet.