### PR TITLE
Add support for Opensearch 3

### DIFF
--- a/packages/seal-opensearch-adapter/docker-compose.yml
+++ b/packages/seal-opensearch-adapter/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   opensearch:
-    image: opensearchproject/opensearch:2
+    image: opensearchproject/opensearch:3
     environment:
       discovery.type: single-node
       cluster.routing.allocation.disk.threshold_enabled: 'false'


### PR DESCRIPTION
This update the docker image of opensearch to 3 to test against the latest version of Opensearch.

See also:

 - https://github.com/opensearch-project/OpenSearch/releases/tag/3.0.0
 
Not sure yet if there will be a major release of the PHP SDK also or not: https://github.com/opensearch-project/opensearch-php/issues/331#issuecomment-2857132130