### PR TITLE
Add support for Redis 8

### DIFF
--- a/.examples/laravel/docker-compose.yml
+++ b/.examples/laravel/docker-compose.yml
@@ -47,14 +47,20 @@ services:
       - opensearch-data:/usr/share/opensearch/data
 
   redis:
-    image: redis/redis-stack:7.4.0-v1
+    image: redis:8
     ports:
-      - 6379:6379 # redis server
-      - 8001:8001 # redis insight
-    environment:
-      REDIS_ARGS: --requirepass supersecure
+      - 6379:6379
+    command: >
+      --requirepass supersecure
     volumes:
-        - redisearch-data:/data
+     - redisearch-data:/data
+
+  redisinsight: # optional for debug and visualize redis data
+    image: redis/redisinsight:latest
+    ports:
+      - 5540:5540 # redis insight: to connect use "redis://default:supersecure@redis:6379"
+    depends_on:
+      - "redis"
 
   typesense:
     image: typesense/typesense:28.0

--- a/.examples/mezzio/docker-compose.yml
+++ b/.examples/mezzio/docker-compose.yml
@@ -47,14 +47,20 @@ services:
       - opensearch-data:/usr/share/opensearch/data
 
   redis:
-    image: redis/redis-stack:7.4.0-v1
+    image: redis:8
     ports:
-      - 6379:6379 # redis server
-      - 8001:8001 # redis insight
-    environment:
-      REDIS_ARGS: --requirepass supersecure
+      - 6379:6379
+    command: >
+      --requirepass supersecure
     volumes:
-      - redisearch-data:/data
+     - redisearch-data:/data
+
+  redisinsight: # optional for debug and visualize redis data
+    image: redis/redisinsight:latest
+    ports:
+      - 5540:5540 # redis insight: to connect use "redis://default:supersecure@redis:6379"
+    depends_on:
+      - "redis"
 
   typesense:
     image: typesense/typesense:28.0

--- a/.examples/spiral/docker-compose.yml
+++ b/.examples/spiral/docker-compose.yml
@@ -47,14 +47,20 @@ services:
       - opensearch-data:/usr/share/opensearch/data
 
   redis:
-    image: redis/redis-stack:7.4.0-v1
+    image: redis:8
     ports:
-      - 6379:6379 # redis server
-      - 8001:8001 # redis insight
-    environment:
-      REDIS_ARGS: --requirepass supersecure
+      - 6379:6379
+    command: >
+      --requirepass supersecure
     volumes:
-      - redisearch-data:/data
+     - redisearch-data:/data
+
+  redisinsight: # optional for debug and visualize redis data
+    image: redis/redisinsight:latest
+    ports:
+      - 5540:5540 # redis insight: to connect use "redis://default:supersecure@redis:6379"
+    depends_on:
+      - "redis"
 
   typesense:
     image: typesense/typesense:28.0

--- a/.examples/symfony/docker-compose.yml
+++ b/.examples/symfony/docker-compose.yml
@@ -47,14 +47,20 @@ services:
       - opensearch-data:/usr/share/opensearch/data
 
   redis:
-    image: redis/redis-stack:7.4.0-v1
+    image: redis:8
     ports:
-      - 6379:6379 # redis server
-      - 8001:8001 # redis insight
-    environment:
-      REDIS_ARGS: --requirepass supersecure
+      - 6379:6379
+    command: >
+      --requirepass supersecure
     volumes:
-      - redisearch-data:/data
+     - redisearch-data:/data
+
+  redisinsight: # optional for debug and visualize redis data
+    image: redis/redisinsight:latest
+    ports:
+      - 5540:5540 # redis insight: to connect use "redis://default:supersecure@redis:6379"
+    depends_on:
+      - "redis"
 
   typesense:
     image: typesense/typesense:28.0

--- a/.examples/yii/docker-compose.yml
+++ b/.examples/yii/docker-compose.yml
@@ -47,14 +47,20 @@ services:
       - opensearch-data:/usr/share/opensearch/data
 
   redis:
-    image: redis/redis-stack:7.4.0-v1
+    image: redis:8
     ports:
-      - 6379:6379 # redis server
-      - 8001:8001 # redis insight
-    environment:
-      REDIS_ARGS: --requirepass supersecure
+      - 6379:6379
+    command: >
+      --requirepass supersecure
     volumes:
-      - redisearch-data:/data
+     - redisearch-data:/data
+
+  redisinsight: # optional for debug and visualize redis data
+    image: redis/redisinsight:latest
+    ports:
+      - 5540:5540 # redis insight: to connect use "redis://default:supersecure@redis:6379"
+    depends_on:
+      - "redis"
 
   typesense:
     image: typesense/typesense:28.0

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -1582,14 +1582,20 @@ search engine.
 
             services:
               redis:
-                image: redis/redis-stack:7.4.0-v1
+                image: redis:8
                 ports:
-                  - 6379:6379 # redis server
-                  - 8001:8001 # redis insight
-                environment:
-                  REDIS_ARGS: --requirepass supersecure
+                  - 6379:6379
+                command: >
+                  --requirepass supersecure
                 volumes:
-                    - redisearch-data:/data
+                 - redisearch-data:/data
+
+              redisinsight: # optional for debug and visualize redis data
+                image: redis/redisinsight:latest
+                ports:
+                  - 5540:5540 # redis insight: to connect use "redis://default:supersecure@redis:6379"
+                depends_on:
+                  - "redis"
 
             volumes:
               redisearch-data:

--- a/packages/seal-redisearch-adapter/docker-compose.yml
+++ b/packages/seal-redisearch-adapter/docker-compose.yml
@@ -1,13 +1,19 @@
 services:
   redis:
-    image: redis/redis-stack:7.4.0-v1
+    image: redis:8
     ports:
-      - 6379:6379 # redis server
-      - 8001:8001 # redis insight
-    environment:
-      REDIS_ARGS: --requirepass supersecure
+      - 6379:6379
+    command: >
+      --requirepass supersecure
     volumes:
-        - redisearch-data:/data
+     - redisearch-data:/data
+
+  redisinsight: # optional for debug and visualize redis data
+    image: redis/redisinsight:latest
+    ports:
+      - 5540:5540 # redis insight: to connect use "redis://default:supersecure@redis:6379"
+    depends_on:
+      - "redis"
 
 volumes:
   redisearch-data:

--- a/packages/seal-redisearch-adapter/src/RediSearchSchemaManager.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchSchemaManager.php
@@ -31,7 +31,9 @@ final class RediSearchSchemaManager implements SchemaManagerInterface
         try {
             $indexInfo = $this->client->rawCommand('FT.INFO', $index->name);
         } catch (\RedisException $e) {
-            if ('unknown index name' !== \strtolower($e->getMessage())) {
+            if ('unknown index name' !== \strtolower($e->getMessage()) // redis 7
+                && \str_ends_with('no such index', \strtolower($e->getMessage())) // redis 8
+            ) {
                 throw $e;
             }
 

--- a/packages/seal-redisearch-adapter/tests/ClientHelper.php
+++ b/packages/seal-redisearch-adapter/tests/ClientHelper.php
@@ -24,7 +24,11 @@ final class ClientHelper
 
             self::$client = new \Redis();
             self::$client->pconnect($host, (int) $port);
-            self::$client->auth($_ENV['REDIS_PASSWORD'] ?? 'supersecure');
+
+            $redisPassword = $_ENV['REDIS_PASSWORD'] ?? null;
+            if ($redisPassword) {
+                self::$client->auth($redisPassword);
+            }
         }
 
         return self::$client;


### PR DESCRIPTION
This add support for the Redis 8 https://github.com/redis/redis/releases/tag/8.0.0.
As redis stack is now replaced, we need install redisinsight seperatly as it is not yet included into redis itself, its only here for debugging.