### PR TITLE
Add possibility that an Index can have options

### DIFF
--- a/packages/seal/src/Schema/Index.php
+++ b/packages/seal/src/Schema/Index.php
@@ -44,10 +44,12 @@ final class Index
 
     /**
      * @param array<string, AbstractField> $fields
+     * @param array<string, mixed> $options
      */
     public function __construct(
         public readonly string $name,
         public readonly array $fields,
+        public readonly array $options = [],
     ) {
         $attributes = $this->getAttributes($fields);
         $this->searchableFields = $attributes['searchableFields'];

--- a/packages/seal/src/Schema/Loader/PhpFileLoader.php
+++ b/packages/seal/src/Schema/Loader/PhpFileLoader.php
@@ -63,9 +63,9 @@ final class PhpFileLoader implements LoaderInterface
             foreach ($pathIndexes as $index) {
                 $name = $index->name;
                 if (isset($indexes[$name])) {
-                    $index = new Index($this->indexNamePrefix . $name, $this->mergeFields($indexes[$index->name]->fields, $index->fields));
+                    $index = new Index($this->indexNamePrefix . $name, $this->mergeFields($indexes[$index->name]->fields, $index->fields), $this->mergeOptions($indexes[$index->name]->options, $index->options));
                 } else {
-                    $index = new Index($this->indexNamePrefix . $name, $index->fields);
+                    $index = new Index($this->indexNamePrefix . $name, $index->fields, $index->options);
                 }
 
                 $indexes[$name] = $index;
@@ -96,6 +96,17 @@ final class PhpFileLoader implements LoaderInterface
         }
 
         return $fields;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     * @param array<string, mixed> $newOptions
+     *
+     * @return array<string, mixed>
+     */
+    private function mergeOptions(array $options, array $newOptions): array
+    {
+        return \array_replace_recursive($options, $newOptions);
     }
 
     /**

--- a/packages/seal/tests/Schema/IndexTest.php
+++ b/packages/seal/tests/Schema/IndexTest.php
@@ -139,6 +139,19 @@ class IndexTest extends TestCase
         $this->assertSame('media', $field->name);
     }
 
+    public function testGetOptions(): void
+    {
+        $index = new Index('test', [
+            'uuid' => new Field\IdentifierField('uuid'),
+        ], [
+            'key' => 'value',
+        ]);
+
+        $this->assertSame([
+            'key' => 'value',
+        ], $index->options);
+    }
+
     /**
      * @return \Generator<array{
      *     0: string,

--- a/packages/seal/tests/Schema/Loader/PhpFileLoaderTest.php
+++ b/packages/seal/tests/Schema/Loader/PhpFileLoaderTest.php
@@ -73,6 +73,16 @@ class PhpFileLoaderTest extends TestCase
         $this->assertTrue(
             $schema->indexes['blog']->fields['blocks']->types['gallery']['media']->multiple,
         );
+
+        $this->assertSame([
+            'keepOption' => 'keepValue',
+            'simpleOption' => 'simpleOption-overwrite',
+            'nestedOption' => [
+                'key1' => 'value1-overwrite',
+                'key2' => 'value2',
+                'key3' => 'value3-new',
+            ],
+        ], $schema->indexes['blog']->options);
     }
 
     public function testMergeWithPrefix(): void

--- a/packages/seal/tests/Schema/Loader/fixtures/basic/news.php
+++ b/packages/seal/tests/Schema/Loader/fixtures/basic/news.php
@@ -49,4 +49,9 @@ return new Index('news', [
     ], multiple: true),
     'tags' => new Field\TextField('tags', multiple: true),
     'categoryIds' => new Field\IntegerField('categoryIds', multiple: true),
+], [
+    'simpleOption' => 'value',
+    'nestedOption' => [
+        'key1' => 'value1',
+    ],
 ]);

--- a/packages/seal/tests/Schema/Loader/fixtures/basic/subdirectory/blog.php
+++ b/packages/seal/tests/Schema/Loader/fixtures/basic/subdirectory/blog.php
@@ -18,4 +18,9 @@ return new Index('blog', [
     'id' => new Field\IdentifierField('id'),
     'title' => new Field\TextField('title'),
     'description' => new Field\TextField('description'),
+], [
+    'simpleOption' => 'value',
+    'nestedOption' => [
+        'key1' => 'value1',
+    ],
 ]);

--- a/packages/seal/tests/Schema/Loader/fixtures/merge/blog_merge_1.php
+++ b/packages/seal/tests/Schema/Loader/fixtures/merge/blog_merge_1.php
@@ -29,4 +29,11 @@ return new Index('blog', [
             'media' => new Field\TextField('media'),
         ],
     ], multiple: true),
+], [
+    'keepOption' => 'keepValue',
+    'simpleOption' => 'simpleValue',
+    'nestedOption' => [
+        'key1' => 'value1',
+        'key2' => 'value2',
+    ],
 ]);

--- a/packages/seal/tests/Schema/Loader/fixtures/merge/blog_merge_2.php
+++ b/packages/seal/tests/Schema/Loader/fixtures/merge/blog_merge_2.php
@@ -22,4 +22,10 @@ return new Index('blog', [
         ],
     ], multiple: true),
     'footerText' => new Field\TextField('footerText'),
+], [
+    'simpleOption' => 'simpleOption-overwrite',
+    'nestedOption' => [
+        'key1' => 'value1-overwrite',
+        'key3' => 'value3-new',
+    ],
 ]);


### PR DESCRIPTION
Maybe there are adapter specific options for an index. Like we have already `options` array for `fields` we add here it for Index. So the `SchemaManager` of adapters like `Loupe` can example configure a `TypoTolerance` or other options.

fixes part of #540

Target of this PR is only add possibility to have options not yet any
adapter specific implementation for it. It can be used for projects to add additonal infos like a label  like in #539.

