### PR TITLE
Refactor FlattenMarshaller to not duplicate original document (BC Break)

### DIFF
--- a/packages/seal-loupe-adapter/composer.lock
+++ b/packages/seal-loupe-adapter/composer.lock
@@ -1349,12 +1349,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "fea728f03454f7a119d607e318c8e4c058d20294"
+                "reference": "275d3b5bd1d89dcaa328f38f8af0af32e13f86c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/fea728f03454f7a119d607e318c8e4c058d20294",
-                "reference": "fea728f03454f7a119d607e318c8e4c058d20294",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/275d3b5bd1d89dcaa328f38f8af0af32e13f86c6",
+                "reference": "275d3b5bd1d89dcaa328f38f8af0af32e13f86c6",
                 "shasum": ""
             },
             "require": {
@@ -1399,7 +1399,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-18T21:24:56+00:00"
+            "time": "2025-05-20T14:56:56+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/packages/seal-loupe-adapter/src/LoupeHelper.php
+++ b/packages/seal-loupe-adapter/src/LoupeHelper.php
@@ -24,7 +24,6 @@ use Loupe\Loupe\LoupeFactory;
 final class LoupeHelper
 {
     public const SEPARATOR = '_';
-    public const SOURCE_FIELD = 'l_source'; // fields are not allowed to begin with `_`
 
     /**
      * @var Loupe[]

--- a/packages/seal-loupe-adapter/src/LoupeIndexer.php
+++ b/packages/seal-loupe-adapter/src/LoupeIndexer.php
@@ -29,12 +29,11 @@ final class LoupeIndexer implements IndexerInterface
     ) {
         $this->marshaller = new FlattenMarshaller(
             dateAsInteger: true,
-            separator: LoupeHelper::SEPARATOR,
-            sourceField: LoupeHelper::SOURCE_FIELD,
             geoPointFieldConfig: [
                 'latitude' => 'lat',
                 'longitude' => 'lng',
             ],
+            fieldSeparator: LoupeHelper::SEPARATOR,
         );
     }
 

--- a/packages/seal-loupe-adapter/src/LoupeSearcher.php
+++ b/packages/seal-loupe-adapter/src/LoupeSearcher.php
@@ -30,12 +30,11 @@ final class LoupeSearcher implements SearcherInterface
     ) {
         $this->marshaller = new FlattenMarshaller(
             dateAsInteger: true,
-            separator: LoupeHelper::SEPARATOR,
-            sourceField: LoupeHelper::SOURCE_FIELD,
             geoPointFieldConfig: [
                 'latitude' => 'lat',
                 'longitude' => 'lng',
             ],
+            fieldSeparator: LoupeHelper::SEPARATOR,
         );
     }
 

--- a/packages/seal-solr-adapter/src/SolrSchemaManager.php
+++ b/packages/seal-solr-adapter/src/SolrSchemaManager.php
@@ -148,7 +148,7 @@ final class SolrSchemaManager implements SchemaManagerInterface
                     'type' => $field->searchable ? 'text_general' : 'string',
                     'indexed' => $field->searchable,
                     'docValues' => $field->filterable || $field->sortable,
-                    'stored' => true, // required to be set to stored for highlighting
+                    'stored' => true,
                     'useDocValuesAsStored' => false,
                     'multiValued' => $isMultiple,
                 ],
@@ -157,7 +157,7 @@ final class SolrSchemaManager implements SchemaManagerInterface
                     'type' => 'boolean',
                     'indexed' => $field->searchable,
                     'docValues' => $field->filterable || $field->sortable,
-                    'stored' => false,
+                    'stored' => true,
                     'useDocValuesAsStored' => false,
                     'multiValued' => $isMultiple,
                 ],
@@ -166,7 +166,7 @@ final class SolrSchemaManager implements SchemaManagerInterface
                     'type' => 'pdate',
                     'indexed' => $field->searchable,
                     'docValues' => $field->filterable || $field->sortable,
-                    'stored' => false,
+                    'stored' => true,
                     'useDocValuesAsStored' => false,
                     'multiValued' => $isMultiple,
                 ],
@@ -175,7 +175,7 @@ final class SolrSchemaManager implements SchemaManagerInterface
                     'type' => 'pint',
                     'indexed' => $field->searchable,
                     'docValues' => $field->filterable || $field->sortable,
-                    'stored' => false,
+                    'stored' => true,
                     'useDocValuesAsStored' => false,
                     'multiValued' => $isMultiple,
                 ],
@@ -184,7 +184,7 @@ final class SolrSchemaManager implements SchemaManagerInterface
                     'type' => 'pfloat',
                     'indexed' => $field->searchable,
                     'docValues' => $field->filterable || $field->sortable,
-                    'stored' => false,
+                    'stored' => true,
                     'useDocValuesAsStored' => false,
                     'multiValued' => $isMultiple,
                 ],
@@ -193,13 +193,25 @@ final class SolrSchemaManager implements SchemaManagerInterface
                     'type' => 'location',
                     'indexed' => $field->searchable,
                     'docValues' => $field->filterable || $field->sortable,
-                    'stored' => false,
+                    'stored' => true,
                     'useDocValuesAsStored' => false,
                     'multiValued' => $isMultiple,
                 ],
                 $field instanceof Field\ObjectField => $indexFields = \array_replace($indexFields, $this->createIndexFields($field->fields, $name . '.', $isMultiple)),
                 $field instanceof Field\TypedField => \array_map(function ($fields, $type) use ($name, &$indexFields, $isMultiple) {
                     $indexFields = \array_replace($indexFields, $this->createIndexFields($fields, $name . '.' . $type . '.', $isMultiple));
+
+                    if ($isMultiple) {
+                        $indexFields[$name . '.' . $type . '._originalIndex'] = [
+                            'name' => $name . '.' . $type . '._originalIndex',
+                            'type' => 'pint',
+                            'indexed' => false,
+                            'docValues' => false,
+                            'stored' => true,
+                            'useDocValuesAsStored' => false,
+                            'multiValued' => true,
+                        ];
+                    }
                 }, $field->types, \array_keys($field->types)),
                 default => throw new \RuntimeException(\sprintf('Field type "%s" is not supported.', $field::class)),
             };

--- a/packages/seal-solr-adapter/src/SolrSchemaManager.php
+++ b/packages/seal-solr-adapter/src/SolrSchemaManager.php
@@ -217,8 +217,8 @@ final class SolrSchemaManager implements SchemaManagerInterface
         }
 
         if ('' === $prefix) {
-            $indexFields['_source'] = [
-                'name' => '_source',
+            $indexFields['s_metadata'] = [
+                'name' => 's_metadata',
                 'type' => 'string',
                 'indexed' => false,
                 'docValues' => false,

--- a/packages/seal/src/Marshaller/FlattenMarshaller.php
+++ b/packages/seal/src/Marshaller/FlattenMarshaller.php
@@ -24,6 +24,10 @@ use CmsIg\Seal\Schema\Field;
  */
 final class FlattenMarshaller
 {
+    private readonly Marshaller $marshaller;
+
+    private readonly Flattener $flattener;
+
     /**
      * @param array{
      *     name?: string,
@@ -32,14 +36,24 @@ final class FlattenMarshaller
      *     separator?: string,
      *     multiple?: bool,
      * }|null $geoPointFieldConfig
+     * @param non-empty-string $fieldSeparator
      */
     public function __construct(
         private readonly bool $dateAsInteger = false,
         private readonly bool $addRawFilterTextField = false,
-        private readonly string $separator = '.',
-        private readonly string $sourceField = '_source',
         private readonly array|null $geoPointFieldConfig = null,
+        private readonly string $fieldSeparator = '.',
     ) {
+        $this->marshaller = new Marshaller(
+            $this->dateAsInteger,
+            $this->addRawFilterTextField,
+            $this->geoPointFieldConfig,
+        );
+
+        $this->flattener = new Flattener(
+            metadataKey: 's_metadata',
+            fieldSeparator: $this->fieldSeparator,
+        );
     }
 
     /**
@@ -50,8 +64,20 @@ final class FlattenMarshaller
      */
     public function marshall(array $fields, array $document): array
     {
-        $flattenDocument = $this->flatten($fields, $document);
-        $flattenDocument[$this->sourceField] = \json_encode($document, \JSON_THROW_ON_ERROR);
+        $marshalledDocument = $this->marshaller->marshall($fields, $document);
+
+        $geoFieldName = $this->findGeoFieldName($fields);
+        $geoFieldValue = null;
+        if (null !== $geoFieldName && \array_key_exists($geoFieldName, $marshalledDocument)) {
+            $geoFieldValue = $marshalledDocument[$geoFieldName];
+            unset($marshalledDocument[$geoFieldName]);
+        }
+
+        $flattenDocument = $this->flattener->flatten($marshalledDocument);
+
+        if (null !== $geoFieldName) {
+            $flattenDocument[$geoFieldName] = $geoFieldValue;
+        }
 
         return $flattenDocument;
     }
@@ -64,224 +90,42 @@ final class FlattenMarshaller
      */
     public function unmarshall(array $fields, array $raw): array
     {
-        /** @var array<string, mixed> */
-        return \json_decode($raw[$this->sourceField], true, flags: \JSON_THROW_ON_ERROR); // @phpstan-ignore-line
+        $raw = \array_filter($raw, static fn ($value) => null !== $value);
+
+        $geoFieldName = $this->findGeoFieldName($fields);
+        $geoFieldValue = null;
+        if (null !== $geoFieldName && \array_key_exists($geoFieldName, $raw)) {
+            $geoFieldValue = $raw[$geoFieldName];
+            unset($raw[$geoFieldName]);
+        }
+
+        $unflattenDocument = $this->flattener->unflatten($raw);
+
+        if (null !== $geoFieldName && null !== $geoFieldValue) {
+            $unflattenDocument[$geoFieldName] = $geoFieldValue;
+        }
+
+        $unmarshalledDocument = $this->marshaller->unmarshall($fields, $unflattenDocument);
+
+        return $unmarshalledDocument;
     }
 
     /**
      * @param Field\AbstractField[] $fields
-     * @param array<string, mixed> $raw
-     *
-     * @return array<string, mixed>
      */
-    private function flatten(array $fields, array $raw, bool $rootIsParentMultiple = false)
+    private function findGeoFieldName(array $fields): string|null
     {
-        foreach ($fields as $name => $field) {
-            if (!\array_key_exists($name, $raw)) {
-                continue;
-            }
-
-            match (true) {
-                $field instanceof Field\DateTimeField => $raw[$name] = $this->flattenDateTime($raw[$field->name], $field), // @phpstan-ignore-line
-                $field instanceof Field\GeoPointField => $raw[$name] = $this->flattenGeoPointField($raw[$field->name], $field), // @phpstan-ignore-line
-                $field instanceof Field\ObjectField => $raw = $this->flattenObject($name, $raw, $field, $rootIsParentMultiple),
-                $field instanceof Field\TypedField => $raw = $this->flattenTyped($name, $raw, $field, $rootIsParentMultiple),
-                default => null,
-            };
-
-            if ($this->addRawFilterTextField
-                && $field instanceof Field\TextField && $field->searchable && ($field->sortable || $field->filterable)
-            ) {
-                $raw[$name . '.raw'] = $raw[$name];
-            }
+        $geoFieldName = $this->geoPointFieldConfig['name'] ?? null;
+        if (null !== $geoFieldName) {
+            return $geoFieldName;
         }
 
-        return $raw;
-    }
-
-    /**
-     * @param string|string[]|null $value
-     *
-     * @return int|string|string[]|int[]|null
-     */
-    private function flattenDateTime(string|array|null $value, Field\DateTimeField $field): int|string|array|null
-    {
-        if ($field->multiple) {
-            /** @var string[]|null $value */
-
-            return \array_map(function ($value) {
-                if (null !== $value && $this->dateAsInteger) {
-                    /** @var int */
-                    return \strtotime($value);
-                }
-
-                return $value;
-            }, (array) $value);
-        }
-
-        /** @var string|null $value */
-        if (null !== $value && $this->dateAsInteger) {
-            /** @var int */
-            return \strtotime($value);
-        }
-
-        return $value;
-    }
-
-    /**
-     * @param array{latitude: float, longitude: float}|null $value
-     *
-     * @return array<int|string, array<int|string, float>|float|string>|string|null
-     */
-    private function flattenGeoPointField(array|null $value, Field\GeoPointField $field): array|string|null
-    {
-        if ($field->multiple) {
-            throw new \LogicException('GeoPointField currently does not support multiple values.');
-        }
-
-        if ($value) {
-            $value = [
-                $this->geoPointFieldConfig['latitude'] ?? 'latitude' => $value['latitude'],
-                $this->geoPointFieldConfig['longitude'] ?? 'longitude' => $value['longitude'],
-            ];
-
-            \ksort($value); // consistent to the Marshaller where we need this for the redisearch
-
-            if ($this->geoPointFieldConfig['separator'] ?? false) {
-                $value = \implode($this->geoPointFieldConfig['separator'], $value);
+        foreach ($fields as $field) {
+            if ($field instanceof Field\GeoPointField) {
+                return $field->name;
             }
-
-            if ($this->geoPointFieldConfig['multiple'] ?? false) {
-                $value = [$value];
-            }
-
-            return $value;
         }
 
         return null;
-    }
-
-    /**
-     * @param array<string, mixed> $raw
-     *
-     * @return array<string, mixed>
-     */
-    private function flattenObject(string $name, array $raw, Field\ObjectField $field, bool $rootIsParentMultiple)
-    {
-        /** @var array<array<string, mixed>> $objects */
-        $objects = $field->multiple ? $raw[$name] : [$raw[$name]];
-
-        $newRawData = [];
-        foreach ($objects as $object) {
-            $isParentMultiple = $rootIsParentMultiple || $field->multiple;
-            $flattenedObject = $this->flatten($field->fields, $object, $isParentMultiple);
-
-            foreach ($flattenedObject as $key => $value) {
-                $flattenKey = $name . $this->separator . $key;
-
-                if (!$isParentMultiple) {
-                    $newRawData[$flattenKey] = $value;
-
-                    continue;
-                }
-
-                if (!isset($newRawData[$flattenKey])) {
-                    $newRawData[$flattenKey] = [];
-                }
-
-                if (!\is_array($value)) {
-                    $newRawData[$flattenKey][] = $value; // @phpstan-ignore-line
-
-                    continue;
-                }
-
-                foreach ($value as $valuePart) {
-                    $newRawData[$flattenKey][] = $valuePart; // @phpstan-ignore-line
-                }
-            }
-        }
-
-        $keepOrderRaw = [];
-        foreach ($raw as $key => $value) {
-            if ($key === $name) {
-                foreach ($newRawData as $key2 => $value2) {
-                    $keepOrderRaw[$key2] = $value2;
-                }
-
-                continue;
-            }
-
-            $keepOrderRaw[$key] = $value;
-        }
-
-        return $keepOrderRaw;
-    }
-
-    /**
-     * @param array<string, mixed> $raw
-     *
-     * @return array<string, mixed>
-     */
-    private function flattenTyped(string $name, array $raw, Field\TypedField $field, bool $rootIsParentMultiple)
-    {
-        /** @var array<array<string, mixed>> $objects */
-        $objects = $field->multiple ? $raw[$name] : [$raw[$name]];
-
-        $newRawData = [];
-        foreach ($objects as $object) {
-            /** @var string $type */
-            $type = $object[$field->typeField];
-            unset($object[$field->typeField]);
-
-            $isParentMultiple = $rootIsParentMultiple || $field->multiple;
-
-            if (!isset($field->types[$type])) {
-                throw new \RuntimeException(\sprintf(
-                    'Type "%s" not found. Existing types are "%s"',
-                    $type,
-                    \implode('", "', \array_keys($field->types)),
-                ));
-            }
-
-            $flattenedObject = $this->flatten($field->types[$type], $object, $isParentMultiple);
-            foreach ($flattenedObject as $key => $value) {
-                $flattenKey = $name . $this->separator . $type . $this->separator . $key;
-
-                if (!$isParentMultiple) {
-                    $newRawData[$flattenKey] = $value;
-
-                    continue;
-                }
-
-                if (!isset($newRawData[$flattenKey])) {
-                    $newRawData[$flattenKey] = [];
-                }
-
-                if (!\is_array($value)) {
-                    $newRawData[$flattenKey][] = $value; // @phpstan-ignore-line
-
-                    continue;
-                }
-
-                foreach ($value as $valuePart) {
-                    $newRawData[$flattenKey][] = $valuePart; // @phpstan-ignore-line
-                }
-            }
-        }
-
-        $keepOrderRaw = [];
-        foreach ($raw as $key => $value) {
-            if ($key === $name) {
-                foreach ($newRawData as $key2 => $value2) {
-                    $keepOrderRaw[$key2] = $value2;
-                }
-
-                continue;
-            }
-
-            $keepOrderRaw[$key] = $value;
-        }
-
-        return $keepOrderRaw;
     }
 }

--- a/packages/seal/src/Marshaller/Flattener.php
+++ b/packages/seal/src/Marshaller/Flattener.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS-IG SEAL project.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CmsIg\Seal\Marshaller;
+
+/**
+ * @internal this class currently can be modified or removed at any time
+ */
+final class Flattener
+{
+    /**
+     * @param non-empty-string $metadataKey
+     * @param non-empty-string $fieldSeparator
+     * @param non-empty-string $metadataSeparator
+     * @param non-empty-string $metadataPlaceholder
+     */
+    public function __construct(
+        private readonly string $metadataKey = 's_metadata',
+        private readonly string $fieldSeparator = '.',
+        private readonly string $metadataSeparator = '/',
+        private readonly string $metadataPlaceholder = '*',
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return array<string, mixed>
+     */
+    public function flatten(array $data): array
+    {
+        $flattenData = $this->doFlatten($data);
+
+        $newData = [];
+        $metadata = [];
+        foreach ($flattenData as $key => $value) {
+            unset($flattenData[$key]);
+
+            /** @var string $metadataKey */
+            $metadataKey = \preg_replace('/' . \preg_quote($this->metadataSeparator, '/') . '(\d+)' . \preg_quote($this->metadataSeparator, '/') . '/', $this->metadataSeparator, $key, -1);
+            /** @var string $metadataKey */
+            $metadataKey = \preg_replace('/' . \preg_quote($this->metadataSeparator, '/') . '(\d+)$/', '', $metadataKey, -1);
+            $newKey = \str_replace($this->metadataSeparator, $this->fieldSeparator, $metadataKey);
+
+            if ($newKey === $key) {
+                $newData[$newKey] = $value;
+
+                continue;
+            }
+
+            if ($metadataKey === $key) {
+                $newData[$newKey] = $value;
+                $newValue = [$value];
+            } else {
+                $newValue = \is_array($value) ? $value : [$value];
+                $oldValue = ($newData[$newKey] ?? []);
+
+                \assert(\is_array($oldValue), 'Expected old value of key "' . $newKey . '" to be an array got "' . \get_debug_type($oldValue) . '".');
+
+                $newData[$newKey] = [
+                    ...$oldValue,
+                    ...$newValue,
+                ];
+            }
+
+            if (\str_contains($metadataKey, $this->metadataSeparator)) {
+                foreach ($newValue as $v) {
+                    $metadata[$metadataKey][] = \preg_replace_callback('/[^' . \preg_quote($this->metadataSeparator, '/') . ']+/', fn ($matches) => \is_numeric($matches[0]) ? $matches[0] : $this->metadataPlaceholder, $key);
+                }
+            }
+        }
+
+        if ([] !== $metadata) {
+            $newData[$this->metadataKey] = \json_encode($metadata, \JSON_THROW_ON_ERROR);
+        }
+
+        return $newData;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return array<string, mixed>
+     */
+    private function doFlatten(array $data, string $prefix = ''): array
+    {
+        $newData = [];
+        foreach ($data as $key => $value) {
+            if (!\is_array($value)
+                || [] === $value
+            ) {
+                $newData[$prefix . $key] = $value;
+
+                continue;
+            }
+
+            $flattened = $this->doFlatten($value, $key . $this->metadataSeparator);
+            foreach ($flattened as $subKey => $subValue) {
+                $newData[$prefix . $subKey] = $subValue;
+            }
+        }
+
+        return $newData;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return array<string, mixed>
+     */
+    public function unflatten(array $data): array
+    {
+        $newData = [];
+        /** @var array<string, array<string>> $metadata */
+        $metadata = [];
+        $metadataKeyMapping = [];
+        if (\array_key_exists($this->metadataKey, $data)) {
+            \assert(\is_string($data[$this->metadataKey]), 'Expected metadata to be a string.');
+
+            /** @var array<string, array<string>> $metadata */
+            $metadata = \json_decode($data[$this->metadataKey], true, flags: \JSON_THROW_ON_ERROR);
+
+            foreach (\array_keys($metadata) as $subMetadataKey) {
+                $metadataKeyMapping[\str_replace($this->metadataSeparator, $this->fieldSeparator, $subMetadataKey)] = $subMetadataKey;
+            }
+
+            unset($data[$this->metadataKey]);
+        }
+
+        foreach ($data as $key => $value) {
+            $metadataKey = $metadataKeyMapping[$key] ?? null;
+            if (null === $metadataKey) {
+                $newData[$key] = $value;
+
+                continue;
+            }
+
+            $keyParts = \explode($this->metadataSeparator, $metadataKey);
+            if (!\is_array($value)) {
+                $value = [$value];
+            }
+
+            foreach ($value as $subKey => $subValue) {
+                \assert(\array_key_exists($subKey, $metadata[$metadataKey]), 'Expected key "' . $subKey . '" to exist in "' . $key . '".');
+
+                $keyPartsReplacements = $keyParts;
+
+                /** @var string $newKeyPath */
+                $newKeyPath = \preg_replace_callback('/' . \preg_quote($this->metadataPlaceholder, '/') . '/', function () use (&$keyPartsReplacements) {
+                    return \array_shift($keyPartsReplacements);
+                }, $metadata[$metadataKey][$subKey]);
+
+                $newSubData = &$newData;
+                foreach (\explode($this->metadataSeparator, $newKeyPath) as $newKeyPart) {
+                    $newSubData = &$newSubData[$newKeyPart]; // @phpstan-ignore-line
+                }
+
+                $newSubData = $subValue;
+            }
+        }
+
+        return $newData;
+    }
+}

--- a/packages/seal/src/Marshaller/Marshaller.php
+++ b/packages/seal/src/Marshaller/Marshaller.php
@@ -309,7 +309,10 @@ final class Marshaller
                 }
 
                 if (\is_string($value) && \str_ends_with($value, 'Z')) {
-                    return \date('c', \strtotime($value));
+                    /** @var int $time */
+                    $time = \strtotime($value);
+
+                    return \date('c', $time);
                 }
 
                 /** @var string */
@@ -324,7 +327,10 @@ final class Marshaller
         }
 
         if (\is_string($value) && \str_ends_with($value, 'Z')) {
-            return \date('c', \strtotime($value));
+            /** @var int $time */
+            $time = \strtotime($value);
+
+            return \date('c', $time);
         }
 
         /** @var string|null */

--- a/packages/seal/src/Marshaller/Marshaller.php
+++ b/packages/seal/src/Marshaller/Marshaller.php
@@ -308,6 +308,10 @@ final class Marshaller
                     return \date('c', $value);
                 }
 
+                if (\is_string($value) && \str_ends_with($value, 'Z')) {
+                    return \date('c', \strtotime($value));
+                }
+
                 /** @var string */
                 return $value;
             }, (array) $value);
@@ -317,6 +321,10 @@ final class Marshaller
             /** @var int $value */
 
             return \date('c', $value);
+        }
+
+        if (\is_string($value) && \str_ends_with($value, 'Z')) {
+            return \date('c', \strtotime($value));
         }
 
         /** @var string|null */

--- a/packages/seal/src/Testing/AbstractAdapterTestCase.php
+++ b/packages/seal/src/Testing/AbstractAdapterTestCase.php
@@ -114,7 +114,7 @@ abstract class AbstractAdapterTestCase extends TestCase
         foreach ($loadedDocuments as $key => $loadedDocument) {
             $expectedDocument = $documents[$key];
 
-            $this->assertSame($expectedDocument, $loadedDocument);
+            $this->assertSame($expectedDocument, $loadedDocument, 'Expected the loaded document to be the same as the saved document (' . $expectedDocument['uuid'] . ').');
         }
 
         foreach ($documents as $document) {

--- a/packages/seal/src/Testing/TestingHelper.php
+++ b/packages/seal/src/Testing/TestingHelper.php
@@ -189,7 +189,6 @@ final class TestingHelper
                 'commentsCount' => 0,
                 'rating' => 2.5,
                 'isSpecial' => false,
-                'comments' => [],
                 'tags' => ['UI', 'UX'],
                 'categoryIds' => [2, 3],
                 'location' => [
@@ -207,7 +206,6 @@ final class TestingHelper
                 ],
                 'created' => '2023-02-03T12:00:00+01:00',
                 'commentsCount' => 0,
-                'comments' => [],
                 'tags' => ['Tech', 'UX'],
                 'categoryIds' => [3, 4],
                 'location' => [

--- a/packages/seal/tests/Marshaller/FlattenMarshallerTest.php
+++ b/packages/seal/tests/Marshaller/FlattenMarshallerTest.php
@@ -33,8 +33,9 @@ class FlattenMarshallerTest extends TestCase
         $marshaller = new FlattenMarshaller(addRawFilterTextField: true);
 
         $marshalledDocument = $marshaller->marshall($fields, $document);
+        unset($marshalledDocument['s_metadata']);
 
-        $this->assertSame([...$flattenDocument, '_source' => \json_encode($document, \JSON_THROW_ON_ERROR)], $marshalledDocument);
+        $this->assertSame($flattenDocument, $marshalledDocument);
     }
 
     /**
@@ -47,7 +48,11 @@ class FlattenMarshallerTest extends TestCase
     {
         $marshaller = new FlattenMarshaller(addRawFilterTextField: true);
 
-        $flattenDocument['_source'] = \json_encode($document, \JSON_THROW_ON_ERROR);
+        $marshalledDocument = $marshaller->marshall($fields, $document);
+        $metadata = $marshalledDocument['s_metadata'] ?? null;
+        if (null !== $metadata) {
+            $flattenDocument['s_metadata'] = $metadata;
+        }
         $unmarshalledDocument = $marshaller->unmarshall($fields, $flattenDocument);
 
         $this->assertSame($document, $unmarshalledDocument);
@@ -124,9 +129,11 @@ class FlattenMarshallerTest extends TestCase
                 'title' => 'New Blog',
                 'header.image.media' => 1,
                 'article' => '<article><h2>New Subtitle</h2><p>A html field with some content</p></article>',
+                'blocks.text._originalIndex' => [0, 1, 3],
                 'blocks.text.title' => ['Title', 'Title 2', 'Title 4'],
                 'blocks.text.description' => ['<p>Description</p>', null, '<p>Description 4</p>'],
                 'blocks.text.media' => [3, 4, 3, 4],
+                'blocks.embed._originalIndex' => [2],
                 'blocks.embed.title' => ['Video'],
                 'blocks.embed.media' => ['https://www.youtube.com/watch?v=iYM2zFP3Zn0'],
                 'footer.title' => 'New Footer',
@@ -137,12 +144,12 @@ class FlattenMarshallerTest extends TestCase
                 'comments.email' => ['admin.nonesearchablefield@localhost', 'example.nonesearchablefield@localhost'],
                 'comments.text' => ['Awesome blog!', 'Like this blog!'],
                 'tags' => ['Tech', 'UI'],
+                'tags.raw' => ['Tech', 'UI'],
                 'categoryIds' => [1, 2],
                 'location' => [
                     'latitude' => 40.7128,
                     'longitude' => -74.006,
                 ],
-                'tags.raw' => ['Tech', 'UI'],
             ],
             [
                 'uuid' => new Field\IdentifierField('uuid'),
@@ -173,7 +180,7 @@ class FlattenMarshallerTest extends TestCase
                 'created' => new Field\DateTimeField('created', filterable: true, sortable: true),
                 'commentsCount' => new Field\IntegerField('commentsCount', searchable: false, filterable: true, sortable: true),
                 'rating' => new Field\FloatField('rating', searchable: false, filterable: true, sortable: true),
-                'isSpecial' => new Field\BooleanField('rating', searchable: false, filterable: true),
+                'isSpecial' => new Field\BooleanField('isSpecial', searchable: false, filterable: true),
                 'comments' => new Field\ObjectField('comments', [
                     'email' => new Field\TextField('email', searchable: false),
                     'text' => new Field\TextField('text'),
@@ -376,14 +383,18 @@ class FlattenMarshallerTest extends TestCase
             ],
             [
                 'uuid' => '23b30f01-d8fd-4dca-b36a-4710e360a965',
+                'blocks.text._originalIndex' => [0, 1, 3],
                 'blocks.text.title' => ['Title', 'Title 2', 'Title 4'],
                 'blocks.text.description' => ['<p>Description</p>', null, '<p>Description 4</p>'],
                 'blocks.text.media' => [3, 4, 3, 4],
+                'blocks.text.secondaryBlocks.text._originalIndex' => [0, 1, 3, 0, 1, 3],
                 'blocks.text.secondaryBlocks.text.title' => ['Title', 'Title 2', 'Title 4', 'Title', 'Title 2', 'Title 4'],
                 'blocks.text.secondaryBlocks.text.description' => ['<p>Description</p>', null, '<p>Description 4</p>', '<p>Description</p>', null, '<p>Description 4</p>'],
                 'blocks.text.secondaryBlocks.text.media' => [3, 4, 3, 4, 3, 4, 3, 4],
+                'blocks.text.secondaryBlocks.embed._originalIndex' => [2, 2],
                 'blocks.text.secondaryBlocks.embed.title' => ['Video', 'Video'],
                 'blocks.text.secondaryBlocks.embed.media' => ['https://www.youtube.com/watch?v=iYM2zFP3Zn0', 'https://www.youtube.com/watch?v=iYM2zFP3Zn0'],
+                'blocks.embed._originalIndex' => [2],
                 'blocks.embed.title' => ['Video'],
                 'blocks.embed.media' => ['https://www.youtube.com/watch?v=iYM2zFP3Zn0'],
             ],

--- a/packages/seal/tests/Marshaller/FlattenerTest.php
+++ b/packages/seal/tests/Marshaller/FlattenerTest.php
@@ -1,0 +1,312 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS-IG SEAL project.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CmsIg\Seal\Tests\Marshaller;
+
+use CmsIg\Seal\Marshaller\Flattener;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Flattener::class)]
+class FlattenerTest extends TestCase
+{
+    /**
+     * @param array<string, mixed> $unflatten
+     * @param array<string, mixed> $flatten
+     */
+    #[DataProvider('flattenDataProvider')]
+    public function testFlatten(array $unflatten, array $flatten): void
+    {
+        $marshaller = new Flattener();
+
+        $this->assertSame($flatten, $marshaller->flatten($unflatten));
+    }
+
+    /**
+     * @param array<string, mixed> $unflatten
+     * @param array<string, mixed> $flatten
+     */
+    #[DataProvider('flattenDataProvider')]
+    public function testUnflatten(array $unflatten, array $flatten): void
+    {
+        $marshaller = new Flattener();
+
+        $this->assertSame($unflatten, $marshaller->unflatten($flatten));
+    }
+
+    /**
+     * @return \Generator<array{
+     *     flatten: array<string, mixed>,
+     *     unflatten: array<string, mixed>,
+     * }>
+     */
+    public static function flattenDataProvider(): \Generator
+    {
+        yield 'nested_one_level' => [
+            'unflatten' => [
+                'id' => 1,
+                'title' => 'Title',
+                'blocks' => [
+                    [
+                        'title' => 'Title 1',
+                        'tags' => ['UI', 'UX'],
+                    ],
+                    [
+                        'title' => 'Title 2',
+                        'tags' => ['Tech'],
+                    ],
+                ],
+            ],
+            'flatten' => [
+                'id' => 1,
+                'title' => 'Title',
+                'blocks.title' => ['Title 1', 'Title 2'],
+                'blocks.tags' => ['UI', 'UX', 'Tech'],
+                's_metadata' => \json_encode([
+                    'blocks/title' => ['*/0/*', '*/1/*'],
+                    'blocks/tags' => ['*/0/*/0', '*/0/*/1', '*/1/*/0'],
+                ], \JSON_THROW_ON_ERROR),
+            ],
+        ];
+
+        yield 'object' => [
+            'unflatten' => [
+                'uuid' => '23b30f01-d8fd-4dca-b36a-4710e360a965',
+                'title' => 'New Blog',
+                'header' => [
+                    'type' => 'image',
+                    'media' => 1,
+                ],
+            ],
+            'flatten' => [
+                'uuid' => '23b30f01-d8fd-4dca-b36a-4710e360a965',
+                'title' => 'New Blog',
+                'header.type' => 'image',
+                'header.media' => 1,
+                's_metadata' => \json_encode([
+                    'header/type' => ['*/*'],
+                    'header/media' => ['*/*'],
+                ], \JSON_THROW_ON_ERROR),
+            ],
+        ];
+
+        yield 'object_array' => [
+            'unflatten' => [
+                'uuid' => '23b30f01-d8fd-4dca-b36a-4710e360a965',
+                'title' => 'New Blog',
+                'comments' => [
+                    [
+                        'email' => 'admin.nonesearchablefield@localhost',
+                        'text' => 'Awesome blog!',
+                    ],
+                    [
+                        'email' => 'example.nonesearchablefield@localhost',
+                        'text' => 'Like this blog!',
+                    ],
+                ],
+            ],
+            'flatten' => [
+                'uuid' => '23b30f01-d8fd-4dca-b36a-4710e360a965',
+                'title' => 'New Blog',
+                'comments.email' => ['admin.nonesearchablefield@localhost', 'example.nonesearchablefield@localhost'],
+                'comments.text' => ['Awesome blog!', 'Like this blog!'],
+                's_metadata' => \json_encode([
+                    'comments/email' => ['*/0/*', '*/1/*'],
+                    'comments/text' => ['*/0/*', '*/1/*'],
+                ], \JSON_THROW_ON_ERROR),
+            ],
+        ];
+
+        yield 'complex_object' => [
+            'unflatten' => [
+                'uuid' => '23b30f01-d8fd-4dca-b36a-4710e360a965',
+                'title' => 'New Blog',
+                'header' => [
+                    'image' => [
+                        'media' => 1,
+                    ],
+                ],
+                'article' => '<article><h2>New Subtitle</h2><p>A html field with some content</p></article>',
+                'blocks' => [
+                    'text' => [
+                        [
+                            '_originalIndex' => 0,
+                            'title' => 'Title',
+                            'description' => '<p>Description</p>',
+                            'media' => [
+                                0 => 3,
+                                1 => 4,
+                            ],
+                        ],
+                        [
+                            '_originalIndex' => 1,
+                            'title' => 'Title 2',
+                        ],
+                        [
+                            '_originalIndex' => 3,
+                            'title' => 'Title 4',
+                            'description' => '<p>Description 4</p>',
+                            'media' => [
+                                0 => 3,
+                                1 => 4,
+                            ],
+                        ],
+                    ],
+                    'embed' => [
+                        [
+                            '_originalIndex' => 2,
+                            'title' => 'Video',
+                            'media' => 'https://www.youtube.com/watch?v=iYM2zFP3Zn0',
+                        ],
+                    ],
+                ],
+                'footer' => [
+                    'title' => 'New Footer',
+                ],
+                'created' => 1643022000,
+                'commentsCount' => 2,
+                'rating' => 3.5,
+                'isSpecial' => true,
+                'comments' => [
+                    [
+                        'email' => 'admin.nonesearchablefield@localhost',
+                        'text' => 'Awesome blog!',
+                    ],
+                    [
+                        'email' => 'example.nonesearchablefield@localhost',
+                        'text' => 'Like this blog!',
+                    ],
+                ],
+                'tags' => [
+                    'Tech',
+                    'UI',
+                ],
+                'categoryIds' => [
+                    1,
+                    2,
+                ],
+                'location' => [
+                    'lat' => 40.7128,
+                    'lng' => -74.006,
+                ],
+            ],
+            'flatten' => [
+                'uuid' => '23b30f01-d8fd-4dca-b36a-4710e360a965',
+                'title' => 'New Blog',
+                'header.image.media' => 1,
+                'article' => '<article><h2>New Subtitle</h2><p>A html field with some content</p></article>',
+                'blocks.text._originalIndex' => [0, 1, 3],
+                'blocks.text.title' => [
+                    'Title',
+                    'Title 2',
+                    'Title 4',
+                ],
+                'blocks.text.description' => [
+                    '<p>Description</p>',
+                    '<p>Description 4</p>',
+                ],
+                'blocks.text.media' => [3, 4, 3, 4],
+                'blocks.embed._originalIndex' => [2],
+                'blocks.embed.title' => ['Video'],
+                'blocks.embed.media' => ['https://www.youtube.com/watch?v=iYM2zFP3Zn0'],
+                'footer.title' => 'New Footer',
+                'created' => 1643022000,
+                'commentsCount' => 2,
+                'rating' => 3.5,
+                'isSpecial' => true,
+                'comments.email' => ['admin.nonesearchablefield@localhost', 'example.nonesearchablefield@localhost'],
+                'comments.text' => ['Awesome blog!', 'Like this blog!'],
+                'tags' => [
+                    'Tech',
+                    'UI',
+                ],
+                'categoryIds' => [
+                    1,
+                    2,
+                ],
+                'location.lat' => 40.7128,
+                'location.lng' => -74.006,
+                's_metadata' => '{"header\/image\/media":["*\/*\/*"],"blocks\/text\/_originalIndex":["*\/*\/0\/*","*\/*\/1\/*","*\/*\/2\/*"],"blocks\/text\/title":["*\/*\/0\/*","*\/*\/1\/*","*\/*\/2\/*"],"blocks\/text\/description":["*\/*\/0\/*","*\/*\/2\/*"],"blocks\/text\/media":["*\/*\/0\/*\/0","*\/*\/0\/*\/1","*\/*\/2\/*\/0","*\/*\/2\/*\/1"],"blocks\/embed\/_originalIndex":["*\/*\/0\/*"],"blocks\/embed\/title":["*\/*\/0\/*"],"blocks\/embed\/media":["*\/*\/0\/*"],"footer\/title":["*\/*"],"comments\/email":["*\/0\/*","*\/1\/*"],"comments\/text":["*\/0\/*","*\/1\/*"],"location\/lat":["*\/*"],"location\/lng":["*\/*"]}',
+            ],
+        ];
+
+        yield 'simple' => [
+            'unflatten' => [
+                'id' => 1,
+                'title' => 'Title',
+            ],
+            'flatten' => [
+                'id' => 1,
+                'title' => 'Title',
+            ],
+        ];
+
+        yield 'empty_values' => [
+            'unflatten' => [
+                'id' => 1,
+                'title' => 'Title',
+                'comments' => [],
+                'rating' => null,
+                'isSpecial' => null,
+            ],
+            'flatten' => [
+                'id' => 1,
+                'title' => 'Title',
+                'comments' => [],
+                'rating' => null,
+                'isSpecial' => null,
+            ],
+        ];
+
+        yield 'simple_with_multiple' => [
+            'unflatten' => [
+                'id' => 1,
+                'title' => 'Title',
+                'tags' => ['UI', 'UX'],
+            ],
+            'flatten' => [
+                'id' => 1,
+                'title' => 'Title',
+                'tags' => ['UI', 'UX'],
+            ],
+        ];
+
+        yield 'object_with_field_separator' => [
+            'unflatten' => [
+                'id' => 1,
+                'header.title' => 'Title',
+                'content.blocks' => [
+                    [
+                        'title' => 'Title 1',
+                        'tags' => ['UI', 'UX'],
+                    ],
+                    [
+                        'title' => 'Title 2',
+                        'tags' => ['Tech'],
+                    ],
+                ],
+            ],
+            'flatten' => [
+                'id' => 1,
+                'header.title' => 'Title',
+                'content.blocks.title' => ['Title 1', 'Title 2'],
+                'content.blocks.tags' => ['UI', 'UX', 'Tech'],
+                's_metadata' => \json_encode([
+                    'content.blocks/title' => ['*/0/*', '*/1/*'],
+                    'content.blocks/tags' => ['*/0/*/0', '*/0/*/1', '*/1/*/0'],
+                ], \JSON_THROW_ON_ERROR),
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
fixes #544 by converting:

```php
[
    'id' => 1,
    'title' => 'Title',
    'blocks' => [
        [
           'title' => 'Title 1',
           'tags' => ['UI', 'UX'],
        ],
        [
           'title' => 'Title 2',
           'tags' => ['Tech'],
        ],
    ],
]
```

instead of in:

```php
[
    'id' => 1,
    'title' => 'Title',
    'blocks.title' => ['Title 1', 'Title 2'],
    'blocks.tags' => ['UI', 'UX', 'Tech'],
    'l_source' => '{"id":1,"title":"Title","blocks":[{"title":"Title 1","tags":["UI","UX"]},{"title":"Title 2","tags":["Tech"]}]}',
]
```

in:

```php
[
    'id' => 1,
    'title' => 'Title',
    'blocks.title' => ['Title 1', 'Title 2'],
    'blocks.tags' => ['UI', 'UX', 'Tech'],
    's_metadata' => '{"blocks.title":["*.0.*","*.1.*"],"blocks.tags":["*.0.*.0","*.0.*.1","*.1.*.0"]}',
];
```

### Todo

 - [x] Implement Flattener
 - [x] Adopt GeoPoint handling (should not be flatten)
 - [x] Adopt Solr Typed Field Original Index handling

### BC Break

The Solr and Loupe adapter required to flatten complex objects. For still supporting nested objects in previous versions we did duplicate the original document into a own field raw field. With the new flattener algorithm we not require this duplication and just some metadata to recreate the data into its complex structure. For this change a `drop` + `reindex` is required for all which are using `Loupe` or `Solr` adapter. Run the:

```bash
# Symfony
bin/console cmsig:seal:reindex --drop

# Laravel
php artisan cmsig:seal:reindex --drop

# Spiral
php app.php cmsig:seal:reindex --drop

# Mezzio
vendor/bin/laminas cmsig:seal:reindex --drop

# Yii
./yii cmsig:seal:reindex --drop
```

or use the `$engine->reindex($reindexProviders, ReindexConfig::create()->withDropIndex(true));` method to drop and reindex all existing indexes.