### PR TITLE
Switch redis query dialect from deprecated 3 to 2

### DIFF
--- a/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
@@ -97,7 +97,7 @@ final class RediSearchSearcher implements SearcherInterface
         }
 
         $arguments[] = 'DIALECT';
-        $arguments[] = '3';
+        $arguments[] = '2';
 
         /** @var mixed[]|false $result */
         $result = $this->client->rawCommand(
@@ -124,7 +124,7 @@ final class RediSearchSearcher implements SearcherInterface
             foreach ($item as $value) {
                 if ('$' === $previousValue) {
                     /** @var array<string, mixed> $document */
-                    $document = \json_decode($value, true, flags: \JSON_THROW_ON_ERROR)[0]; // @phpstan-ignore-line
+                    $document = \json_decode($value, true, flags: \JSON_THROW_ON_ERROR);
 
                     $documents[] = $document;
                 }


### PR DESCRIPTION
At current state there exist 4 redis query dialects. Redis 8 deprecated the dialects 1, 3, 4. We used Dialect 3 because of some issues.

See the different dialects usage in: https://github.com/PHP-CMSIG/search/issues/131

Redis Dialects documentation: https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/dialects/

# TODO

 - [x] Check Redis 7 compatibility else it is a breaking change
 - [ ] Check filtering by list of uuids (https://github.com/RediSearch/RediSearch/issues/1304
https://github.com/RediSearch/RediSearch/issues/1148) think this was also one of the cases why we did go with dialect 3 instead of 1 or 2