### PR TITLE
Fix that tests wait for finishing cleanup tasks

### DIFF
--- a/packages/seal/src/Testing/AbstractAdapterTestCase.php
+++ b/packages/seal/src/Testing/AbstractAdapterTestCase.php
@@ -35,7 +35,7 @@ abstract class AbstractAdapterTestCase extends TestCase
         self::$taskHelper = new TaskHelper();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         self::$taskHelper->waitForAll();
     }

--- a/packages/seal/src/Testing/AbstractAdapterTestCase.php
+++ b/packages/seal/src/Testing/AbstractAdapterTestCase.php
@@ -35,6 +35,11 @@ abstract class AbstractAdapterTestCase extends TestCase
         self::$taskHelper = new TaskHelper();
     }
 
+    public function tearDown(): void
+    {
+        self::$taskHelper->waitForAll();
+    }
+
     protected static function getEngine(): EngineInterface
     {
         if (!isset(self::$engine)) {

--- a/packages/seal/src/Testing/AbstractIndexerTestCase.php
+++ b/packages/seal/src/Testing/AbstractIndexerTestCase.php
@@ -41,6 +41,11 @@ abstract class AbstractIndexerTestCase extends TestCase
         self::$taskHelper = new TaskHelper();
     }
 
+    public function tearDown(): void
+    {
+        self::$taskHelper->waitForAll();
+    }
+
     public static function setUpBeforeClass(): void
     {
         self::$schemaManager = self::$adapter->getSchemaManager();

--- a/packages/seal/src/Testing/AbstractIndexerTestCase.php
+++ b/packages/seal/src/Testing/AbstractIndexerTestCase.php
@@ -41,7 +41,7 @@ abstract class AbstractIndexerTestCase extends TestCase
         self::$taskHelper = new TaskHelper();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         self::$taskHelper->waitForAll();
     }

--- a/packages/seal/src/Testing/AbstractSearcherTestCase.php
+++ b/packages/seal/src/Testing/AbstractSearcherTestCase.php
@@ -70,7 +70,7 @@ abstract class AbstractSearcherTestCase extends TestCase
         self::$taskHelper->waitForAll();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         self::$taskHelper->waitForAll();
     }

--- a/packages/seal/src/Testing/AbstractSearcherTestCase.php
+++ b/packages/seal/src/Testing/AbstractSearcherTestCase.php
@@ -70,6 +70,11 @@ abstract class AbstractSearcherTestCase extends TestCase
         self::$taskHelper->waitForAll();
     }
 
+    public function tearDown(): void
+    {
+        self::$taskHelper->waitForAll();
+    }
+
     protected static function getSchema(): Schema
     {
         if (!isset(self::$schema)) {


### PR DESCRIPTION
Catch by @Toflar in https://github.com/PHP-CMSIG/search/pull/561.

The deletion in algolia and meilisearch are asynchron and so previous documents are not correctly waited to be cleanup before running the next tests. This way it should work again.

This bug effects only our internal tests not users of the library.