### PR TITLE
Add Support for Typesense 29

### DIFF
--- a/.examples/laravel/docker-compose.yml
+++ b/.examples/laravel/docker-compose.yml
@@ -63,7 +63,7 @@ services:
       - "redis"
 
   typesense:
-    image: typesense/typesense:28.0
+    image: typesense/typesense:29.0
     ports:
       - "8108:8108"
     environment:

--- a/.examples/mezzio/docker-compose.yml
+++ b/.examples/mezzio/docker-compose.yml
@@ -63,7 +63,7 @@ services:
       - "redis"
 
   typesense:
-    image: typesense/typesense:28.0
+    image: typesense/typesense:29.0
     ports:
       - "8108:8108"
     environment:

--- a/.examples/spiral/docker-compose.yml
+++ b/.examples/spiral/docker-compose.yml
@@ -63,7 +63,7 @@ services:
       - "redis"
 
   typesense:
-    image: typesense/typesense:28.0
+    image: typesense/typesense:29.0
     ports:
       - "8108:8108"
     environment:

--- a/.examples/symfony/docker-compose.yml
+++ b/.examples/symfony/docker-compose.yml
@@ -63,7 +63,7 @@ services:
       - "redis"
 
   typesense:
-    image: typesense/typesense:28.0
+    image: typesense/typesense:29.0
     ports:
       - "8108:8108"
     environment:

--- a/.examples/yii/docker-compose.yml
+++ b/.examples/yii/docker-compose.yml
@@ -63,7 +63,7 @@ services:
       - "redis"
 
   typesense:
-    image: typesense/typesense:28.0
+    image: typesense/typesense:29.0
     ports:
       - "8108:8108"
     environment:

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -1673,7 +1673,7 @@ search engine.
 
             services:
               typesense:
-                image: typesense/typesense:28.0
+                image: typesense/typesense:29.0
                 ports:
                   - "8108:8108"
                 environment:

--- a/packages/seal-typesense-adapter/docker-compose.yml
+++ b/packages/seal-typesense-adapter/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   typesense:
-    image: typesense/typesense:28.0
+    image: typesense/typesense:29.0
     ports:
       - "8108:8108"
     environment:


### PR DESCRIPTION
This will change all docker compose files to use the current latest [Typesense Version 29](https://github.com/typesense/typesense/releases/tag/v29.0). There are no required changes to support Typesense 29. The [php Typesense client](https://github.com/typesense/typesense-php) version stays also currently the same.