### PR TITLE
Keep ux-search alternative engines uptodate

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The following projects in the past target a similar problem:
 - [https://github.com/nresni/Ariadne](https://github.com/nresni/Ariadne) (Solr, Elasticsearch, Zendsearch: outdated 12 years ago)
 - [https://github.com/massiveart/MassiveSearchBundle](https://github.com/massiveart/MassiveSearchBundle) (ZendSearch, Elasticsearch)
 - [https://github.com/laravel/scout](https://github.com/laravel/scout) (Algolia, Meilisearch, Typesense)
-- [https://github.com/Mezcalito/ux-search/](https://github.com/Mezcalito/ux-search/) (Doctrine, Meilisearch)
+- [https://github.com/Mezcalito/ux-search/](https://github.com/Mezcalito/ux-search/) (Doctrine, Meilisearch, Algolia)
 
 ## 📩 Authors
 

--- a/docs/research/index.rst
+++ b/docs/research/index.rst
@@ -375,4 +375,4 @@ Following projects in the past target similar problem:
 - `https://github.com/nresni/Ariadne <https://github.com/nresni/Ariadne>`__  (Solr, Elasticsearch, Zendsearch: outdated 12 years ago)
 - `https://github.com/massiveart/MassiveSearchBundle <https://github.com/massiveart/MassiveSearchBundle>`__ (ZendSearch, Elasticsearch)
 - `https://github.com/laravel/scout <https://github.com/laravel/scout>`__  (Algolia, Meilisearch, Typesense)
-- `https://github.com/Mezcalito/ux-search/ <https://github.com/Mezcalito/ux-search/>`__  (Doctrine, Meilisearch)
+- `https://github.com/Mezcalito/ux-search/ <https://github.com/Mezcalito/ux-search/>`__  (Doctrine, Meilisearch, Algolia)


### PR DESCRIPTION
@AlexandrePetrone added algolia support to there symfony ux search bundle, we should keep the list of alernatives uptodate. https://github.com/Mezcalito/ux-search/pull/7