### PR TITLE
Split documentation build and deploy into own jobs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,9 +5,10 @@ on:
     push:
         branches:
             - '[0-9]+.[0-9]+'
+    workflow_dispatch:
 
 permissions:
-    contents: write
+    contents: read
 
 jobs:
     docs:
@@ -42,8 +43,30 @@ jobs:
               run: |
                   sphinx-build docs docs/_build
 
+            - name: Upload build artifact
+              id: upload
+              uses: actions/upload-artifact@v4
+              with:
+                  name: docs-build
+                  path: docs/_build/
+
+    docs-deploy:
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/0.10' }}
+        needs: docs-build
+        runs-on: ubuntu-latest
+
+        permissions:
+            contents: write
+
+        steps:
+            - name: Download built docs
+              uses: actions/download-artifact@v4
+              with:
+                  name: docs-build
+                  path: docs/_build/
+
             - name: Deploy
-              uses: peaceiris/actions-gh-pages@v3
+              uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
               if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/0.10' }}
               with:
                   publish_branch: gh-pages

--- a/.github/workflows/publish-subsplits.yml
+++ b/.github/workflows/publish-subsplits.yml
@@ -21,7 +21,7 @@ jobs:
                   fetch-depth: '0'
                   persist-credentials: 'false'
 
-            - uses: frankdejonge/use-github-token@1.0.1
+            - uses: frankdejonge/use-github-token@0001015147267203898034927e8cccad3a7a9aa7 # as 1.1.0
               with:
                   authentication: 'alexander-schranz:${{ secrets.PERSONAL_ACCESS_TOKEN }}'
                   user_name: 'Alexander Schranz'
@@ -34,7 +34,7 @@ jobs:
                   path: './.splitsh'
                   key: '${{ runner.os }}-splitsh'
 
-            - uses: frankdejonge/use-subsplit-publish@1.0.0
+            - uses: frankdejonge/use-subsplit-publish@0001015147267203898034927e8cccad3a7a9aa7 # as 1.1.0
               with:
                   source-branch: '${{ github.ref_name }}'
                   config-path: './config.subsplit-publish.json'


### PR DESCRIPTION
As reported by @AlbertoPellitteri the build process with `pull_request_target` should only have read permissions. Only the deploy part should be available to write something.