### PR TITLE
Add LoaderProviderInterface so different loaders can be configured

### DIFF
--- a/integrations/mezzio/src/ConfigProvider.php
+++ b/integrations/mezzio/src/ConfigProvider.php
@@ -29,11 +29,27 @@ use CmsIg\Seal\Adapter\Typesense\TypesenseAdapterFactory;
 use CmsIg\Seal\EngineInterface;
 use CmsIg\Seal\EngineRegistry;
 use CmsIg\Seal\Integration\Mezzio\Service\CommandAbstractFactory;
+use CmsIg\Seal\Integration\Mezzio\Service\LoaderProviderInterface;
+use CmsIg\Seal\Integration\Mezzio\Service\PhpFileLoaderProvider;
 use CmsIg\Seal\Integration\Mezzio\Service\SealContainer;
 use CmsIg\Seal\Integration\Mezzio\Service\SealContainerFactory;
 use CmsIg\Seal\Integration\Mezzio\Service\SealContainerServiceAbstractFactory;
 use CmsIg\Seal\Schema\Schema;
 
+/**
+ * @phpstan-type TCmsSigSealConfig = array{
+ *      index_name_prefix: string,
+ *      schemas: array<string, array{
+ *          dir: string,
+ *          engine?: string,
+ *      }>,
+ *      engines: array<string, array{
+ *          adapter: string,
+ *      }>,
+ *      adapter_factories: array<class-string, class-string<AdapterFactoryInterface>>,
+ *      reindex_providers: string[],
+ *  }
+ */
 final class ConfigProvider
 {
     /**
@@ -87,6 +103,7 @@ final class ConfigProvider
             'factories' => [
                 EngineRegistry::class => SealContainerServiceAbstractFactory::class,
                 EngineInterface::class => SealContainerServiceAbstractFactory::class,
+                LoaderProviderInterface::class => PhpFileLoaderProvider::class,
                 Schema::class => SealContainerServiceAbstractFactory::class,
                 AdapterFactory::class => SealContainerServiceAbstractFactory::class,
                 SealContainer::class => SealContainerFactory::class,

--- a/integrations/mezzio/src/ConfigProvider.php
+++ b/integrations/mezzio/src/ConfigProvider.php
@@ -31,11 +31,11 @@ use CmsIg\Seal\EngineRegistry;
 use CmsIg\Seal\Integration\Mezzio\Service\CommandAbstractFactory;
 use CmsIg\Seal\Integration\Mezzio\Service\LoaderProviderInterface;
 use CmsIg\Seal\Integration\Mezzio\Service\PhpFileLoaderProvider;
+use CmsIg\Seal\Integration\Mezzio\Service\PhpFileLoaderProviderFactory;
 use CmsIg\Seal\Integration\Mezzio\Service\SealContainer;
 use CmsIg\Seal\Integration\Mezzio\Service\SealContainerFactory;
 use CmsIg\Seal\Integration\Mezzio\Service\SealContainerServiceAbstractFactory;
 use CmsIg\Seal\Schema\Schema;
-use Laminas\ServiceManager\Factory\InvokableFactory;
 
 /**
  * @phpstan-type TCmsSigSealConfig = array{
@@ -104,7 +104,7 @@ final class ConfigProvider
             'factories' => [
                 EngineRegistry::class => SealContainerServiceAbstractFactory::class,
                 EngineInterface::class => SealContainerServiceAbstractFactory::class,
-                PhpFileLoaderProvider::class => InvokableFactory::class,
+                PhpFileLoaderProvider::class => PhpFileLoaderProviderFactory::class,
                 Schema::class => SealContainerServiceAbstractFactory::class,
                 AdapterFactory::class => SealContainerServiceAbstractFactory::class,
                 SealContainer::class => SealContainerFactory::class,

--- a/integrations/mezzio/src/ConfigProvider.php
+++ b/integrations/mezzio/src/ConfigProvider.php
@@ -35,6 +35,7 @@ use CmsIg\Seal\Integration\Mezzio\Service\SealContainer;
 use CmsIg\Seal\Integration\Mezzio\Service\SealContainerFactory;
 use CmsIg\Seal\Integration\Mezzio\Service\SealContainerServiceAbstractFactory;
 use CmsIg\Seal\Schema\Schema;
+use Laminas\ServiceManager\Factory\InvokableFactory;
 
 /**
  * @phpstan-type TCmsSigSealConfig = array{
@@ -103,7 +104,7 @@ final class ConfigProvider
             'factories' => [
                 EngineRegistry::class => SealContainerServiceAbstractFactory::class,
                 EngineInterface::class => SealContainerServiceAbstractFactory::class,
-                LoaderProviderInterface::class => PhpFileLoaderProvider::class,
+                PhpFileLoaderProvider::class => InvokableFactory::class,
                 Schema::class => SealContainerServiceAbstractFactory::class,
                 AdapterFactory::class => SealContainerServiceAbstractFactory::class,
                 SealContainer::class => SealContainerFactory::class,
@@ -112,6 +113,9 @@ final class ConfigProvider
                 Command\ReindexCommand::class => CommandAbstractFactory::class,
                 ...$adapterFactories,
             ],
+            'aliases' => [
+                LoaderProviderInterface::class => PhpFileLoaderProvider::class,
+            ]
         ];
     }
 

--- a/integrations/mezzio/src/ConfigProvider.php
+++ b/integrations/mezzio/src/ConfigProvider.php
@@ -115,7 +115,7 @@ final class ConfigProvider
             ],
             'aliases' => [
                 LoaderProviderInterface::class => PhpFileLoaderProvider::class,
-            ]
+            ],
         ];
     }
 

--- a/integrations/mezzio/src/Service/LoaderProviderInterface.php
+++ b/integrations/mezzio/src/Service/LoaderProviderInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS-IG SEAL project.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CmsIg\Seal\Integration\Mezzio\Service;
+
+use CmsIg\Seal\Integration\Mezzio\ConfigProvider;
+use CmsIg\Seal\Schema\Loader\LoaderInterface;
+
+/**
+ * @psalm-import-type TCmsSigSealConfig from ConfigProvider
+ */
+interface LoaderProviderInterface
+{
+    /**
+     * @param TCmsSigSealConfig $config
+     */
+    public function getLoader(string $engineName, array $config): LoaderInterface;
+}

--- a/integrations/mezzio/src/Service/PhpFileLoaderProvider.php
+++ b/integrations/mezzio/src/Service/PhpFileLoaderProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS-IG SEAL project.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CmsIg\Seal\Integration\Mezzio\Service;
+
+use CmsIg\Seal\Schema\Loader\LoaderInterface;
+use CmsIg\Seal\Schema\Loader\PhpFileLoader;
+
+final class PhpFileLoaderProvider implements LoaderProviderInterface
+{
+    public function getLoader(string $engineName, array $config): LoaderInterface
+    {
+        $indexNamePrefix = $config['index_name_prefix'];
+
+        $engineSchemaDirs = [];
+        foreach ($config['schemas'] as $options) {
+            $engineSchemaDirs[$options['engine'] ?? 'default'][] = $options['dir'];
+        }
+
+        $dirs = $engineSchemaDirs[$engineName] ?? [];
+
+        return new PhpFileLoader($dirs, $indexNamePrefix);
+    }
+}

--- a/integrations/mezzio/src/Service/PhpFileLoaderProviderFactory.php
+++ b/integrations/mezzio/src/Service/PhpFileLoaderProviderFactory.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the CMS-IG SEAL project.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace CmsIg\Seal\Integration\Mezzio\Service;
 
 use Psr\Container\ContainerInterface;

--- a/integrations/mezzio/src/Service/PhpFileLoaderProviderFactory.php
+++ b/integrations/mezzio/src/Service/PhpFileLoaderProviderFactory.php
@@ -6,7 +6,7 @@ namespace CmsIg\Seal\Integration\Mezzio\Service;
 
 use Psr\Container\ContainerInterface;
 
-final readonly class PhpFileLoaderProviderFactory
+final class PhpFileLoaderProviderFactory
 {
     public function __invoke(ContainerInterface $container): PhpFileLoaderProvider
     {

--- a/integrations/mezzio/src/Service/PhpFileLoaderProviderFactory.php
+++ b/integrations/mezzio/src/Service/PhpFileLoaderProviderFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CmsIg\Seal\Integration\Mezzio\Service;
+
+use Psr\Container\ContainerInterface;
+
+final readonly class PhpFileLoaderProviderFactory
+{
+    public function __invoke(ContainerInterface $container): PhpFileLoaderProvider
+    {
+        return new PhpFileLoaderProvider();
+    }
+}

--- a/integrations/mezzio/src/Service/SealContainerFactory.php
+++ b/integrations/mezzio/src/Service/SealContainerFactory.php
@@ -14,49 +14,30 @@ declare(strict_types=1);
 namespace CmsIg\Seal\Integration\Mezzio\Service;
 
 use CmsIg\Seal\Adapter\AdapterFactory;
-use CmsIg\Seal\Adapter\AdapterFactoryInterface;
 use CmsIg\Seal\Adapter\Multi\MultiAdapterFactory;
 use CmsIg\Seal\Adapter\ReadWrite\ReadWriteAdapterFactory;
 use CmsIg\Seal\Engine;
 use CmsIg\Seal\EngineInterface;
 use CmsIg\Seal\EngineRegistry;
-use CmsIg\Seal\Schema\Loader\PhpFileLoader;
+use CmsIg\Seal\Integration\Mezzio\ConfigProvider;
 use Doctrine\DBAL\Schema\Schema;
 use Psr\Container\ContainerInterface;
 
 /**
  * @internal
+ *
+ * @phpstan-import-type TCmsSigSealConfig from ConfigProvider
  */
 final class SealContainerFactory
 {
     public function __invoke(ContainerInterface $container): SealContainer
     {
-        /** @var array{cmsig_seal: mixed[]} $config */
+        /** @var array{cmsig_seal: TCmsSigSealConfig} $config */
         $config = $container->get('config');
 
-        /**
-         * @var array{
-         *     index_name_prefix: string,
-         *     schemas: array<string, array{
-         *         dir: string,
-         *         engine?: string,
-         *     }>,
-         *     engines: array<string, array{
-         *         adapter: string,
-         *     }>,
-         *     adapter_factories: array<class-string, class-string<AdapterFactoryInterface>>,
-         *     reindex_providers: string[],
-         * } $config
-         */
         $config = $config['cmsig_seal'];
 
-        $indexNamePrefix = $config['index_name_prefix'];
         $adapterFactoriesConfig = $config['adapter_factories'];
-
-        $engineSchemaDirs = [];
-        foreach ($config['schemas'] as $options) {
-            $engineSchemaDirs[$options['engine'] ?? 'default'][] = $options['dir'];
-        }
 
         $sealContainer = new SealContainer($container);
 
@@ -90,10 +71,11 @@ final class SealContainerFactory
 
             /** @var string $adapterDsn */
             $adapterDsn = $engineConfig['adapter'];
-            $dirs = $engineSchemaDirs[$name] ?? [];
-
             $adapter = $adapterFactory->createAdapter($adapterDsn);
-            $loader = new PhpFileLoader($dirs, $indexNamePrefix);
+
+            $loaderProvider = $container->get(LoaderProviderInterface::class);
+            \assert($loaderProvider instanceof LoaderProviderInterface);
+            $loader = $loaderProvider->getLoader($name, $config);
             $schema = $loader->load();
 
             $engine = new Engine($adapter, $schema);


### PR DESCRIPTION
I'm implementing SEAL in a multi-tenant environment with identical indexes prefixed with the tenant name. Following on from the suggestion at https://github.com/PHP-CMSIG/search/discussions/266 I plan to write a custom `LoaderInterface` implementation to handle this. However, with the Mezzio integration `PhpFileLoader` is hard-coded in the `@internal` `SealContainerFactory`.

This PR adds a `LoaderProviderInterface` and by default maps it to a `PhpFileLoaderProvider`, which follows the same logic as before. Now weirdos like me can override it if needed 😁  