### PR TITLE
Add retry handling for github ci docker compose up command

### DIFF
--- a/.github/workflows/callable-test.yml
+++ b/.github/workflows/callable-test.yml
@@ -50,7 +50,8 @@ jobs:
               if: ${{ inputs.docker }}
               working-directory: ${{ inputs.directory }}
               run: |
-                  docker compose up --wait
+                  # try a few times to start the docker services, if it may fails on the first tries
+                  docker compose up --wait || docker compose up --wait || docker compose up --wait
 
             - name: Install and configure PHP
               uses: shivammathur/setup-php@v2


### PR DESCRIPTION
If docker compose up fails it mostly just an issue on network connection or something else. So just try it 3 times before it fails. No retry script, such keep it simple with `||`.