### PR TITLE
Fix issues with filters by Date Fields

### DIFF
--- a/docs/schema/index.rst
+++ b/docs/schema/index.rst
@@ -259,7 +259,10 @@ DateTimeField
 
 The ``DateTime`` field type is used to store dates. Unlike the text field type it is
 **not** ``searchable``, but the field can be marked as ``filterable`` and ``sortable``.
-It uses the PHP ``string`` type and represents the date a date in the ``ISO 8601`` format.
+It uses the PHP ``string`` type and represents the date in the ``ISO 8601`` (``'c'``) format.
+Depending on the used search engine it maybe is stored as a Unix timestamp. If the data
+is read from the index it will be converted back to ``ISO 8601`` format in the current configured
+timezone of your ``php.ini``.
 
 Lets have a look at the following example fields:
 

--- a/packages/seal-algolia-adapter/src/AlgoliaIndexer.php
+++ b/packages/seal-algolia-adapter/src/AlgoliaIndexer.php
@@ -29,6 +29,7 @@ final class AlgoliaIndexer implements IndexerInterface
         private readonly SearchClient $client,
     ) {
         $this->marshaller = new Marshaller(
+            dateFormat: 'U',
             geoPointFieldConfig: [
                 'name' => '_geoloc',
                 'latitude' => 'lat',

--- a/packages/seal-algolia-adapter/src/AlgoliaSearcher.php
+++ b/packages/seal-algolia-adapter/src/AlgoliaSearcher.php
@@ -34,6 +34,7 @@ final class AlgoliaSearcher implements SearcherInterface
         private readonly SearchClient $client,
     ) {
         $this->marshaller = new Marshaller(
+            dateFormat: 'U',
             geoPointFieldConfig: [
                 'name' => '_geoloc',
                 'latitude' => 'lat',
@@ -223,12 +224,12 @@ final class AlgoliaSearcher implements SearcherInterface
             match (true) {
                 $filter instanceof Condition\IdentifierCondition => $filters[] = $index->getIdentifierField()->name . ':' . $this->escapeFilterValue($filter->identifier),
                 $filter instanceof Condition\SearchCondition => $query = $filter->query,
-                $filter instanceof Condition\EqualCondition => $filters[] = $this->getFilterField($index, $filter->field) . ':' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\NotEqualCondition => $filters[] = 'NOT ' . $this->getFilterField($index, $filter->field) . ':' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\GreaterThanCondition => $filters[] = $this->getFilterField($index, $filter->field) . ' > ' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\GreaterThanEqualCondition => $filters[] = $this->getFilterField($index, $filter->field) . ' >= ' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\LessThanCondition => $filters[] = $this->getFilterField($index, $filter->field) . ' < ' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\LessThanEqualCondition => $filters[] = $this->getFilterField($index, $filter->field) . ' <= ' . $this->escapeFilterValue($filter->value),
+                $filter instanceof Condition\EqualCondition => $filters[] = $this->getFilterField($index, $filter->field) . ':' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)),
+                $filter instanceof Condition\NotEqualCondition => $filters[] = 'NOT ' . $this->getFilterField($index, $filter->field) . ':' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)),
+                $filter instanceof Condition\GreaterThanCondition => $filters[] = $this->getFilterField($index, $filter->field) . ' > ' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)),
+                $filter instanceof Condition\GreaterThanEqualCondition => $filters[] = $this->getFilterField($index, $filter->field) . ' >= ' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)),
+                $filter instanceof Condition\LessThanCondition => $filters[] = $this->getFilterField($index, $filter->field) . ' < ' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)),
+                $filter instanceof Condition\LessThanEqualCondition => $filters[] = $this->getFilterField($index, $filter->field) . ' <= ' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)),
                 $filter instanceof Condition\GeoDistanceCondition => $geoFilters = [
                     'aroundLatLng' => \sprintf(
                         '%s, %s',
@@ -262,6 +263,23 @@ final class AlgoliaSearcher implements SearcherInterface
         }
 
         return $name;
+    }
+
+    /**
+     * @template T
+     *
+     * @param T $value
+     *
+     * @return T|int
+     */
+    private function convertValue(Index $index, string $field, mixed $value): mixed
+    {
+        $field = $index->findFieldByPath($field);
+
+        return match (true) {
+            $field instanceof \CmsIg\Seal\Schema\Field\DateTimeField && \is_string($value) => \strtotime($value) ?: $value,
+            default => $value,
+        };
     }
 
     /**

--- a/packages/seal-loupe-adapter/src/LoupeIndexer.php
+++ b/packages/seal-loupe-adapter/src/LoupeIndexer.php
@@ -28,7 +28,7 @@ final class LoupeIndexer implements IndexerInterface
         private readonly LoupeHelper $loupeHelper,
     ) {
         $this->marshaller = new FlattenMarshaller(
-            dateAsInteger: true,
+            dateFormat: 'U',
             geoPointFieldConfig: [
                 'latitude' => 'lat',
                 'longitude' => 'lng',

--- a/packages/seal-loupe-adapter/src/LoupeSearcher.php
+++ b/packages/seal-loupe-adapter/src/LoupeSearcher.php
@@ -191,14 +191,14 @@ final class LoupeSearcher implements SearcherInterface
             match (true) {
                 $filter instanceof Condition\IdentifierCondition => $filters[] = $index->getIdentifierField()->name . ' = ' . $this->escapeFilterValue($filter->identifier),
                 $filter instanceof Condition\SearchCondition => $query = $filter->query,
-                $filter instanceof Condition\EqualCondition => $filters[] = $this->loupeHelper->formatField($filter->field) . ' = ' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\NotEqualCondition => $filters[] = $this->loupeHelper->formatField($filter->field) . ' != ' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\GreaterThanCondition => $filters[] = $this->loupeHelper->formatField($filter->field) . ' > ' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\GreaterThanEqualCondition => $filters[] = $this->loupeHelper->formatField($filter->field) . ' >= ' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\LessThanCondition => $filters[] = $this->loupeHelper->formatField($filter->field) . ' < ' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\LessThanEqualCondition => $filters[] = $this->loupeHelper->formatField($filter->field) . ' <= ' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\InCondition => $filters[] = $this->loupeHelper->formatField($filter->field) . ' IN (' . \implode(', ', \array_map(fn ($value) => $this->escapeFilterValue($value), $filter->values)) . ')',
-                $filter instanceof Condition\NotInCondition => $filters[] = $this->loupeHelper->formatField($filter->field) . ' NOT IN (' . \implode(', ', \array_map(fn ($value) => $this->escapeFilterValue($value), $filter->values)) . ')',
+                $filter instanceof Condition\EqualCondition => $filters[] = $this->loupeHelper->formatField($filter->field) . ' = ' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)),
+                $filter instanceof Condition\NotEqualCondition => $filters[] = $this->loupeHelper->formatField($filter->field) . ' != ' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)),
+                $filter instanceof Condition\GreaterThanCondition => $filters[] = $this->loupeHelper->formatField($filter->field) . ' > ' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)),
+                $filter instanceof Condition\GreaterThanEqualCondition => $filters[] = $this->loupeHelper->formatField($filter->field) . ' >= ' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)),
+                $filter instanceof Condition\LessThanCondition => $filters[] = $this->loupeHelper->formatField($filter->field) . ' < ' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)),
+                $filter instanceof Condition\LessThanEqualCondition => $filters[] = $this->loupeHelper->formatField($filter->field) . ' <= ' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)),
+                $filter instanceof Condition\InCondition => $filters[] = $this->loupeHelper->formatField($filter->field) . ' IN (' . \implode(', ', \array_map(fn ($value) => $this->escapeFilterValue($this->convertValue($index, $filter->field, $value)), $filter->values)) . ')',
+                $filter instanceof Condition\NotInCondition => $filters[] = $this->loupeHelper->formatField($filter->field) . ' NOT IN (' . \implode(', ', \array_map(fn ($value) => $this->escapeFilterValue($this->convertValue($index, $filter->field, $value)), $filter->values)) . ')',
                 $filter instanceof Condition\GeoDistanceCondition => $filters[] = \sprintf(
                     '_geoRadius(%s, %s, %s, %s)',
                     $this->loupeHelper->formatField($filter->field),
@@ -225,6 +225,23 @@ final class LoupeSearcher implements SearcherInterface
         }
 
         return \implode($conjunctive ? ' AND ' : ' OR ', $filters);
+    }
+
+    /**
+     * @template T
+     *
+     * @param T $value
+     *
+     * @return T|int
+     */
+    private function convertValue(Index $index, string $field, mixed $value): mixed
+    {
+        $field = $index->findFieldByPath($field);
+
+        return match(true) {
+            $field instanceof \CmsIg\Seal\Schema\Field\DateTimeField => \strtotime($value),
+            default => $value,
+        };
     }
 
     /**

--- a/packages/seal-loupe-adapter/src/LoupeSearcher.php
+++ b/packages/seal-loupe-adapter/src/LoupeSearcher.php
@@ -32,7 +32,7 @@ final class LoupeSearcher implements SearcherInterface
         private readonly LoupeHelper $loupeHelper,
     ) {
         $this->marshaller = new FlattenMarshaller(
-            dateAsInteger: true,
+            dateFormat: 'U',
             geoPointFieldConfig: [
                 'latitude' => 'lat',
                 'longitude' => 'lng',

--- a/packages/seal-loupe-adapter/src/LoupeSearcher.php
+++ b/packages/seal-loupe-adapter/src/LoupeSearcher.php
@@ -238,8 +238,8 @@ final class LoupeSearcher implements SearcherInterface
     {
         $field = $index->findFieldByPath($field);
 
-        return match(true) {
-            $field instanceof \CmsIg\Seal\Schema\Field\DateTimeField => \strtotime($value),
+        return match (true) {
+            $field instanceof \CmsIg\Seal\Schema\Field\DateTimeField && \is_string($value) => \strtotime($value) ?: $value,
             default => $value,
         };
     }

--- a/packages/seal-meilisearch-adapter/src/MeilisearchIndexer.php
+++ b/packages/seal-meilisearch-adapter/src/MeilisearchIndexer.php
@@ -29,7 +29,7 @@ final class MeilisearchIndexer implements IndexerInterface
         private readonly Client $client,
     ) {
         $this->marshaller = new Marshaller(
-            dateAsInteger: true,
+            dateFormat: 'U',
             geoPointFieldConfig: [
                 'name' => '_geo',
                 'latitude' => 'lat',

--- a/packages/seal-meilisearch-adapter/src/MeilisearchIndexer.php
+++ b/packages/seal-meilisearch-adapter/src/MeilisearchIndexer.php
@@ -29,6 +29,7 @@ final class MeilisearchIndexer implements IndexerInterface
         private readonly Client $client,
     ) {
         $this->marshaller = new Marshaller(
+            dateAsInteger: true,
             geoPointFieldConfig: [
                 'name' => '_geo',
                 'latitude' => 'lat',

--- a/packages/seal-meilisearch-adapter/src/MeilisearchSearcher.php
+++ b/packages/seal-meilisearch-adapter/src/MeilisearchSearcher.php
@@ -250,8 +250,8 @@ final class MeilisearchSearcher implements SearcherInterface
     {
         $field = $index->findFieldByPath($field);
 
-        return match(true) {
-            $field instanceof \CmsIg\Seal\Schema\Field\DateTimeField => \strtotime($value),
+        return match (true) {
+            $field instanceof \CmsIg\Seal\Schema\Field\DateTimeField && \is_string($value) => \strtotime($value) ?: $value,
             default => $value,
         };
     }

--- a/packages/seal-meilisearch-adapter/src/MeilisearchSearcher.php
+++ b/packages/seal-meilisearch-adapter/src/MeilisearchSearcher.php
@@ -33,6 +33,7 @@ final class MeilisearchSearcher implements SearcherInterface
         private readonly Client $client,
     ) {
         $this->marshaller = new Marshaller(
+            dateAsInteger: true,
             geoPointFieldConfig: [
                 'name' => '_geo',
                 'latitude' => 'lat',
@@ -205,13 +206,13 @@ final class MeilisearchSearcher implements SearcherInterface
             match (true) {
                 $filter instanceof Condition\IdentifierCondition => $filters[] = $index->getIdentifierField()->name . ' = ' . $this->escapeFilterValue($filter->identifier),
                 $filter instanceof Condition\SearchCondition => $query = $filter->query,
-                $filter instanceof Condition\EqualCondition => $filters[] = $filter->field . ' = ' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\NotEqualCondition => $filters[] = $filter->field . ' != ' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\NotInCondition => $filters[] = $filter->field . ' NOT IN [' . $this->escapeArrayFilterValues($filter->values) . ']',
-                $filter instanceof Condition\GreaterThanCondition => $filters[] = $filter->field . ' > ' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\GreaterThanEqualCondition => $filters[] = $filter->field . ' >= ' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\LessThanCondition => $filters[] = $filter->field . ' < ' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\LessThanEqualCondition => $filters[] = $filter->field . ' <= ' . $this->escapeFilterValue($filter->value),
+                $filter instanceof Condition\EqualCondition => $filters[] = $filter->field . ' = ' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)),
+                $filter instanceof Condition\NotEqualCondition => $filters[] = $filter->field . ' != ' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)),
+                $filter instanceof Condition\NotInCondition => $filters[] = $filter->field . ' NOT IN [' . $this->escapeArrayFilterValues(\array_map(fn ($value) => $this->convertValue($index, $filter->field, $value), $filter->values)) . ']',
+                $filter instanceof Condition\GreaterThanCondition => $filters[] = $filter->field . ' > ' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)),
+                $filter instanceof Condition\GreaterThanEqualCondition => $filters[] = $filter->field . ' >= ' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)),
+                $filter instanceof Condition\LessThanCondition => $filters[] = $filter->field . ' < ' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)),
+                $filter instanceof Condition\LessThanEqualCondition => $filters[] = $filter->field . ' <= ' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)),
                 $filter instanceof Condition\GeoDistanceCondition => $filters[] = \sprintf(
                     '_geoRadius(%s, %s, %s)',
                     $filter->latitude,
@@ -236,6 +237,23 @@ final class MeilisearchSearcher implements SearcherInterface
         }
 
         return \implode($conjunctive ? ' AND ' : ' OR ', $filters);
+    }
+
+    /**
+     * @template T
+     *
+     * @param T $value
+     *
+     * @return T|int
+     */
+    private function convertValue(Index $index, string $field, mixed $value): mixed
+    {
+        $field = $index->findFieldByPath($field);
+
+        return match(true) {
+            $field instanceof \CmsIg\Seal\Schema\Field\DateTimeField => \strtotime($value),
+            default => $value,
+        };
     }
 
     /**

--- a/packages/seal-meilisearch-adapter/src/MeilisearchSearcher.php
+++ b/packages/seal-meilisearch-adapter/src/MeilisearchSearcher.php
@@ -33,7 +33,7 @@ final class MeilisearchSearcher implements SearcherInterface
         private readonly Client $client,
     ) {
         $this->marshaller = new Marshaller(
-            dateAsInteger: true,
+            dateFormat: 'U',
             geoPointFieldConfig: [
                 'name' => '_geo',
                 'latitude' => 'lat',

--- a/packages/seal-redisearch-adapter/src/RediSearchIndexer.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchIndexer.php
@@ -28,7 +28,7 @@ final class RediSearchIndexer implements IndexerInterface
         private readonly \Redis $client,
     ) {
         $this->marshaller = new Marshaller(
-            dateAsInteger: true,
+            dateFormat: 'U',
             addRawFilterTextField: true,
             geoPointFieldConfig: [
                 'latitude' => 1,

--- a/packages/seal-redisearch-adapter/src/RediSearchIndexer.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchIndexer.php
@@ -28,6 +28,7 @@ final class RediSearchIndexer implements IndexerInterface
         private readonly \Redis $client,
     ) {
         $this->marshaller = new Marshaller(
+            dateAsInteger: true,
             addRawFilterTextField: true,
             geoPointFieldConfig: [
                 'latitude' => 1,

--- a/packages/seal-redisearch-adapter/src/RediSearchSchemaManager.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchSchemaManager.php
@@ -137,7 +137,7 @@ final class RediSearchSchemaManager implements SchemaManagerInterface
                     'sortable' => $field->sortable,
                     'filterable' => $field->filterable || $field->facet, // @phpstan-ignore-line
                 ],
-                $field instanceof Field\TextField, $field instanceof Field\DateTimeField => $indexFields = \array_replace($indexFields, $field->searchable ? [
+                $field instanceof Field\TextField => $indexFields = \array_replace($indexFields, $field->searchable ? [
                     $name => [
                         'jsonPath' => $jsonPath,
                         'type' => 'TEXT',
@@ -161,7 +161,7 @@ final class RediSearchSchemaManager implements SchemaManagerInterface
                     'sortable' => $field->sortable,
                     'filterable' => $field->filterable || $field->facet,
                 ],
-                $field instanceof Field\IntegerField, $field instanceof Field\FloatField => $indexFields[$name] = [
+                $field instanceof Field\IntegerField, $field instanceof Field\FloatField, $field instanceof Field\DateTimeField => $indexFields[$name] = [
                     'jsonPath' => $jsonPath,
                     'type' => 'NUMERIC',
                     'searchable' => $field->searchable,

--- a/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
@@ -31,7 +31,7 @@ final class RediSearchSearcher implements SearcherInterface
         private readonly \Redis $client,
     ) {
         $this->marshaller = new Marshaller(
-            dateAsInteger: true,
+            dateFormat: 'U',
             addRawFilterTextField: true,
             geoPointFieldConfig: [
                 'latitude' => 1,

--- a/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
@@ -31,6 +31,7 @@ final class RediSearchSearcher implements SearcherInterface
         private readonly \Redis $client,
     ) {
         $this->marshaller = new Marshaller(
+            dateAsInteger: true,
             addRawFilterTextField: true,
             geoPointFieldConfig: [
                 'latitude' => 1,
@@ -267,12 +268,12 @@ final class RediSearchSearcher implements SearcherInterface
             match (true) {
                 $filter instanceof Condition\SearchCondition => $filters[] = '%%' . \implode('%% ', \explode(' ', $this->escapeFilterValue($filter->query))) . '%%', // levenshtein of 2 per word
                 $filter instanceof Condition\IdentifierCondition => $filters[] = '@' . $index->getIdentifierField()->name . ':{' . $this->escapeFilterValue($filter->identifier) . '}',
-                $filter instanceof Condition\EqualCondition => $filters[] = '@' . $this->getFilterField($index, $filter->field) . ':{' . $this->escapeFilterValue($filter->value) . '}',
-                $filter instanceof Condition\NotEqualCondition => $filters[] = '-@' . $this->getFilterField($index, $filter->field) . ':{' . $this->escapeFilterValue($filter->value) . '}',
-                $filter instanceof Condition\GreaterThanCondition => $filters[] = '@' . $this->getFilterField($index, $filter->field) . ':[(' . $this->escapeFilterValue($filter->value) . ' inf]',
-                $filter instanceof Condition\GreaterThanEqualCondition => $filters[] = '@' . $this->getFilterField($index, $filter->field) . ':[' . $this->escapeFilterValue($filter->value) . ' inf]',
-                $filter instanceof Condition\LessThanCondition => $filters[] = '@' . $this->getFilterField($index, $filter->field) . ':[-inf (' . $this->escapeFilterValue($filter->value) . ']',
-                $filter instanceof Condition\LessThanEqualCondition => $filters[] = '@' . $this->getFilterField($index, $filter->field) . ':[-inf ' . $this->escapeFilterValue($filter->value) . ']',
+                $filter instanceof Condition\EqualCondition => $filters[] = '@' . $this->getFilterField($index, $filter->field) . ':{' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)) . '}',
+                $filter instanceof Condition\NotEqualCondition => $filters[] = '-@' . $this->getFilterField($index, $filter->field) . ':{' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)) . '}',
+                $filter instanceof Condition\GreaterThanCondition => $filters[] = '@' . $this->getFilterField($index, $filter->field) . ':[(' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)) . ' inf]',
+                $filter instanceof Condition\GreaterThanEqualCondition => $filters[] = '@' . $this->getFilterField($index, $filter->field) . ':[' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)) . ' inf]',
+                $filter instanceof Condition\LessThanCondition => $filters[] = '@' . $this->getFilterField($index, $filter->field) . ':[-inf (' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)) . ']',
+                $filter instanceof Condition\LessThanEqualCondition => $filters[] = '@' . $this->getFilterField($index, $filter->field) . ':[-inf ' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)) . ']',
                 $filter instanceof Condition\GeoDistanceCondition => $filters[] = \sprintf(
                     '@%s:[%s %s %s]',
                     $this->getFilterField($index, $filter->field),
@@ -311,6 +312,23 @@ final class RediSearchSearcher implements SearcherInterface
         }
 
         return \implode($conjunctive ? ' ' : ' | ', $filters);
+    }
+
+    /**
+     * @template T
+     *
+     * @param T $value
+     *
+     * @return T|int
+     */
+    private function convertValue(Index $index, string $field, mixed $value): mixed
+    {
+        $field = $index->findFieldByPath($field);
+
+        return match(true) {
+            $field instanceof \CmsIg\Seal\Schema\Field\DateTimeField => \strtotime($value),
+            default => $value,
+        };
     }
 
     /**

--- a/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
@@ -325,8 +325,8 @@ final class RediSearchSearcher implements SearcherInterface
     {
         $field = $index->findFieldByPath($field);
 
-        return match(true) {
-            $field instanceof \CmsIg\Seal\Schema\Field\DateTimeField => \strtotime($value),
+        return match (true) {
+            $field instanceof \CmsIg\Seal\Schema\Field\DateTimeField && \is_string($value) => \strtotime($value) ?: $value,
             default => $value,
         };
     }

--- a/packages/seal-solr-adapter/src/SolrIndexer.php
+++ b/packages/seal-solr-adapter/src/SolrIndexer.php
@@ -29,6 +29,7 @@ final class SolrIndexer implements IndexerInterface
         private readonly Client $client,
     ) {
         $this->marshaller = new FlattenMarshaller(
+            dateFormat: 'Y-m-d\TH:i:s\Z',
             addRawFilterTextField: true,
             geoPointFieldConfig: [
                 'latitude' => 0,

--- a/packages/seal-solr-adapter/src/SolrSearcher.php
+++ b/packages/seal-solr-adapter/src/SolrSearcher.php
@@ -38,6 +38,7 @@ final class SolrSearcher implements SearcherInterface
         private readonly Client $client,
     ) {
         $this->marshaller = new FlattenMarshaller(
+            dateFormat: 'Y-m-d\TH:i:s\Z',
             addRawFilterTextField: true,
             geoPointFieldConfig: [
                 'latitude' => 0,
@@ -247,12 +248,12 @@ final class SolrSearcher implements SearcherInterface
             match (true) {
                 $filter instanceof Condition\SearchCondition => $queryText = $filter->query,
                 $filter instanceof Condition\IdentifierCondition => $filters[] = $index->getIdentifierField()->name . ':' . $this->escapeFilterValue($filter->identifier),
-                $filter instanceof Condition\EqualCondition => $filters[] = $this->getFilterField($index, $filter->field) . ':' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\NotEqualCondition => $filters[] = '-' . $this->getFilterField($index, $filter->field) . ':' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\GreaterThanCondition => $filters[] = $this->getFilterField($index, $filter->field) . ':{' . $this->escapeFilterValue($filter->value) . ' TO *}',
-                $filter instanceof Condition\GreaterThanEqualCondition => $filters[] = $this->getFilterField($index, $filter->field) . ':[' . $this->escapeFilterValue($filter->value) . ' TO *]',
-                $filter instanceof Condition\LessThanCondition => $filters[] = $this->getFilterField($index, $filter->field) . ':{* TO ' . $this->escapeFilterValue($filter->value) . '}',
-                $filter instanceof Condition\LessThanEqualCondition => $filters[] = $this->getFilterField($index, $filter->field) . ':[* TO ' . $this->escapeFilterValue($filter->value) . ']',
+                $filter instanceof Condition\EqualCondition => $filters[] = $this->getFilterField($index, $filter->field) . ':' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)),
+                $filter instanceof Condition\NotEqualCondition => $filters[] = '-' . $this->getFilterField($index, $filter->field) . ':' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)),
+                $filter instanceof Condition\GreaterThanCondition => $filters[] = $this->getFilterField($index, $filter->field) . ':{' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)) . ' TO *}',
+                $filter instanceof Condition\GreaterThanEqualCondition => $filters[] = $this->getFilterField($index, $filter->field) . ':[' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)) . ' TO *]',
+                $filter instanceof Condition\LessThanCondition => $filters[] = $this->getFilterField($index, $filter->field) . ':{* TO ' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)) . '}',
+                $filter instanceof Condition\LessThanEqualCondition => $filters[] = $this->getFilterField($index, $filter->field) . ':[* TO ' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)) . ']',
                 $filter instanceof Condition\GeoDistanceCondition => $filters[] = \sprintf(
                     '{!geofilt sfield=%s pt=%s,%s d=%s}',
                     $this->getFilterField($index, $filter->field),
@@ -279,6 +280,25 @@ final class SolrSearcher implements SearcherInterface
         }
 
         return \implode($conjunctive ? ' AND ' : ' OR ', $filters);
+    }
+
+    /**
+     * @template T
+     *
+     * @param T $value
+     *
+     * @return T|int
+     */
+    private function convertValue(Index $index, string $field, mixed $value): mixed
+    {
+        $field = $index->findFieldByPath($field);
+
+        $dateTime = new \DateTimeImmutable($value, new \DateTimeZone('UTC'));
+
+        return match(true) {
+            $field instanceof \CmsIg\Seal\Schema\Field\DateTimeField => $dateTime->format('Y-m-d\TH:i:s\Z'),
+            default => $value,
+        };
     }
 
     /**

--- a/packages/seal-solr-adapter/src/SolrSearcher.php
+++ b/packages/seal-solr-adapter/src/SolrSearcher.php
@@ -287,16 +287,14 @@ final class SolrSearcher implements SearcherInterface
      *
      * @param T $value
      *
-     * @return T|int
+     * @return T|string
      */
     private function convertValue(Index $index, string $field, mixed $value): mixed
     {
         $field = $index->findFieldByPath($field);
 
-        $dateTime = new \DateTimeImmutable($value, new \DateTimeZone('UTC'));
-
         return match(true) {
-            $field instanceof \CmsIg\Seal\Schema\Field\DateTimeField => $dateTime->format('Y-m-d\TH:i:s\Z'),
+            $field instanceof \CmsIg\Seal\Schema\Field\DateTimeField && \is_string($value) => (new \DateTimeImmutable($value, new \DateTimeZone('UTC')))->format('Y-m-d\TH:i:s\Z'),
             default => $value,
         };
     }

--- a/packages/seal-solr-adapter/src/SolrSearcher.php
+++ b/packages/seal-solr-adapter/src/SolrSearcher.php
@@ -293,7 +293,7 @@ final class SolrSearcher implements SearcherInterface
     {
         $field = $index->findFieldByPath($field);
 
-        return match(true) {
+        return match (true) {
             $field instanceof \CmsIg\Seal\Schema\Field\DateTimeField && \is_string($value) => (new \DateTimeImmutable($value, new \DateTimeZone('UTC')))->format('Y-m-d\TH:i:s\Z'),
             default => $value,
         };

--- a/packages/seal-typesense-adapter/src/TypesenseIndexer.php
+++ b/packages/seal-typesense-adapter/src/TypesenseIndexer.php
@@ -29,7 +29,7 @@ final class TypesenseIndexer implements IndexerInterface
         private readonly Client $client,
     ) {
         $this->marshaller = new Marshaller(
-            dateAsInteger: true,
+            dateFormat: 'U',
             geoPointFieldConfig: [
                 'latitude' => 0,
                 'longitude' => 1,

--- a/packages/seal-typesense-adapter/src/TypesenseSearcher.php
+++ b/packages/seal-typesense-adapter/src/TypesenseSearcher.php
@@ -33,7 +33,7 @@ final class TypesenseSearcher implements SearcherInterface
         private readonly Client $client,
     ) {
         $this->marshaller = new Marshaller(
-            dateAsInteger: true,
+            dateFormat: 'U',
             geoPointFieldConfig: [
                 'latitude' => 0,
                 'longitude' => 1,

--- a/packages/seal-typesense-adapter/src/TypesenseSearcher.php
+++ b/packages/seal-typesense-adapter/src/TypesenseSearcher.php
@@ -211,12 +211,12 @@ final class TypesenseSearcher implements SearcherInterface
             match (true) {
                 $filter instanceof Condition\IdentifierCondition => $filters[] = 'id:=' . $this->escapeFilterValue($filter->identifier),
                 $filter instanceof Condition\SearchCondition => $query = $filter->query,
-                $filter instanceof Condition\EqualCondition => $filters[] = $filter->field . ':=' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\NotEqualCondition => $filters[] = $filter->field . ':!=' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\GreaterThanCondition => $filters[] = $filter->field . ':>' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\GreaterThanEqualCondition => $filters[] = $filter->field . ':>=' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\LessThanCondition => $filters[] = $filter->field . ':<' . $this->escapeFilterValue($filter->value),
-                $filter instanceof Condition\LessThanEqualCondition => $filters[] = $filter->field . ':<=' . $this->escapeFilterValue($filter->value),
+                $filter instanceof Condition\EqualCondition => $filters[] = $filter->field . ':=' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)),
+                $filter instanceof Condition\NotEqualCondition => $filters[] = $filter->field . ':!=' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)),
+                $filter instanceof Condition\GreaterThanCondition => $filters[] = $filter->field . ':>' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)),
+                $filter instanceof Condition\GreaterThanEqualCondition => $filters[] = $filter->field . ':>=' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)),
+                $filter instanceof Condition\LessThanCondition => $filters[] = $filter->field . ':<' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)),
+                $filter instanceof Condition\LessThanEqualCondition => $filters[] = $filter->field . ':<=' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)),
                 $filter instanceof Condition\GeoDistanceCondition => $filters[] = \sprintf(
                     '%s:(%s, %s, %s)',
                     $filter->field,
@@ -248,6 +248,23 @@ final class TypesenseSearcher implements SearcherInterface
         }
 
         return \implode($conjunctive ? ' && ' : ' || ', $filters);
+    }
+
+    /**
+     * @template T
+     *
+     * @param T $value
+     *
+     * @return T|int
+     */
+    private function convertValue(Index $index, string $field, mixed $value): mixed
+    {
+        $field = $index->findFieldByPath($field);
+
+        return match(true) {
+            $field instanceof \CmsIg\Seal\Schema\Field\DateTimeField => \strtotime($value),
+            default => $value,
+        };
     }
 
     /**

--- a/packages/seal-typesense-adapter/src/TypesenseSearcher.php
+++ b/packages/seal-typesense-adapter/src/TypesenseSearcher.php
@@ -261,8 +261,8 @@ final class TypesenseSearcher implements SearcherInterface
     {
         $field = $index->findFieldByPath($field);
 
-        return match(true) {
-            $field instanceof \CmsIg\Seal\Schema\Field\DateTimeField => \strtotime($value),
+        return match (true) {
+            $field instanceof \CmsIg\Seal\Schema\Field\DateTimeField && \is_string($value) => \strtotime($value) ?: $value,
             default => $value,
         };
     }

--- a/packages/seal/src/Marshaller/FlattenMarshaller.php
+++ b/packages/seal/src/Marshaller/FlattenMarshaller.php
@@ -39,13 +39,13 @@ final class FlattenMarshaller
      * @param non-empty-string $fieldSeparator
      */
     public function __construct(
-        private readonly bool $dateAsInteger = false,
+        private readonly string $dateFormat = 'c',
         private readonly bool $addRawFilterTextField = false,
         private readonly array|null $geoPointFieldConfig = null,
         private readonly string $fieldSeparator = '.',
     ) {
         $this->marshaller = new Marshaller(
-            $this->dateAsInteger,
+            $this->dateFormat,
             $this->addRawFilterTextField,
             $this->geoPointFieldConfig,
         );

--- a/packages/seal/src/Marshaller/Marshaller.php
+++ b/packages/seal/src/Marshaller/Marshaller.php
@@ -32,7 +32,7 @@ final class Marshaller
      * }|null $geoPointFieldConfig
      */
     public function __construct(
-        private readonly bool $dateAsInteger = false,
+        private readonly string $dateFormat = 'c',
         private readonly bool $addRawFilterTextField = false,
         private readonly array|null $geoPointFieldConfig = null,
     ) {
@@ -118,23 +118,31 @@ final class Marshaller
         if ($field->multiple) {
             /** @var string[]|null $value */
 
-            return \array_map(function ($value) {
-                if (null !== $value && $this->dateAsInteger) {
-                    /** @var int */
-                    return \strtotime($value);
-                }
-
-                return $value;
-            }, (array) $value);
+            return \array_map(fn (string $value): int|string => $this->marshallDateTimeFieldValue($value), (array) $value);
         }
 
-        /** @var string|null $value */
-        if (null !== $value && $this->dateAsInteger) {
+        if (null === $value) {
+            return null;
+        }
+
+        /** @var string $value */
+
+        return $this->marshallDateTimeFieldValue($value);
+    }
+
+    private function marshallDateTimeFieldValue(string $value): int|string
+    {
+        if ('U' === $this->dateFormat) {
             /** @var int */
             return \strtotime($value);
         }
 
-        return $value;
+        $timestamp = \strtotime($value);
+
+        \assert(false !== $timestamp, 'Invalid date format: ' . $value);
+
+        /** @var string */
+        return \date($this->dateFormat, $timestamp);
     }
 
     /**
@@ -296,45 +304,43 @@ final class Marshaller
     /**
      * @param string|int|string[]|int[]|null $value
      *
-     * @return string|string[]
+     * @return string|string[]|null
      */
     private function unmarshallDateTimeField(string|int|array|null $value, Field\DateTimeField $field): string|array|null
     {
         if ($field->multiple) {
-            return \array_map(function ($value) {
-                if (null !== $value && $this->dateAsInteger) {
-                    /** @var int $value */
+            /** @var string[]|int[]|null $value */
 
-                    return \date('c', $value);
-                }
-
-                if (\is_string($value) && \str_ends_with($value, 'Z')) {
-                    /** @var int $time */
-                    $time = \strtotime($value);
-
-                    return \date('c', $time);
-                }
-
-                /** @var string */
-                return $value;
-            }, (array) $value);
+            return \array_map(fn (string|int $value): string => $this->unmarshallDateTimeFieldValue($value), (array) $value);
         }
 
-        if (null !== $value && $this->dateAsInteger) {
-            /** @var int $value */
+        /** @var string|int|null $value */
+        if (null === $value) {
+            return null;
+        }
 
+        return $this->unmarshallDateTimeFieldValue($value);
+    }
+
+    private function unmarshallDateTimeFieldValue(string|int $value): string
+    {
+        if ('U' === $this->dateFormat) {
+            /** @var int $value */
             return \date('c', $value);
         }
 
-        if (\is_string($value) && \str_ends_with($value, 'Z')) {
-            /** @var int $time */
-            $time = \strtotime($value);
+        /** @var string $value */
+        $dateTime = match ($this->dateFormat) {
+            'c' => new \DateTimeImmutable($value),
+            default => \DateTimeImmutable::createFromFormat($this->dateFormat, $value),
+        };
 
-            return \date('c', $time);
+        if (false === $dateTime) {
+            throw new \RuntimeException('Invalid date format: ' . \json_encode(\DateTimeImmutable::getLastErrors()));
         }
 
-        /** @var string|null */
-        return $value;
+        /** @var string */
+        return $dateTime->format('c');
     }
 
     /**

--- a/packages/seal/src/Schema/Index.php
+++ b/packages/seal/src/Schema/Index.php
@@ -92,7 +92,7 @@ final class Index
         return null;
     }
 
-    public function getFieldByPath(string $path): AbstractField
+    public function findFieldByPath(string $path): ?AbstractField
     {
         $pathParts = \explode('.', $path);
         $fields = $this->fields;
@@ -109,9 +109,20 @@ final class Index
             } elseif ($field instanceof AbstractField) {
                 return $field;
             } else {
-                throw new FieldByPathNotFoundException($this->name, $path);
+                return null;
             }
         }
+    }
+
+    public function getFieldByPath(string $path): AbstractField
+    {
+        $field = $this->findFieldByPath($path);
+
+        if (!$field instanceof AbstractField) {
+            throw new FieldByPathNotFoundException($this->name, $path);
+        }
+
+        return $field;
     }
 
     /**

--- a/packages/seal/src/Schema/Index.php
+++ b/packages/seal/src/Schema/Index.php
@@ -92,7 +92,7 @@ final class Index
         return null;
     }
 
-    public function findFieldByPath(string $path): ?AbstractField
+    public function findFieldByPath(string $path): AbstractField|null
     {
         $pathParts = \explode('.', $path);
         $fields = $this->fields;

--- a/packages/seal/src/Testing/AbstractSearcherTestCase.php
+++ b/packages/seal/src/Testing/AbstractSearcherTestCase.php
@@ -839,7 +839,9 @@ abstract class AbstractSearcherTestCase extends TestCase
         $this->assertGreaterThanOrEqual(1, \count($loadedDocuments));
 
         foreach ($loadedDocuments as $loadedDocument) {
-            $this->assertGreaterThan(\strtotime('2022-12-26T12:00:00+01:00'), \strtotime($loadedDocument['created'] ?? '1970-01-01T00:00:00+00:00'));
+            $created = $loadedDocument['created'] ?? '1970-01-01T00:00:00+00:00';
+            $this->assertIsString($created);
+            $this->assertGreaterThan(\strtotime('2022-12-26T12:00:00+01:00'), \strtotime($created));
         }
 
         foreach ($documents as $document) {
@@ -914,7 +916,9 @@ abstract class AbstractSearcherTestCase extends TestCase
         $this->assertGreaterThanOrEqual(2, \count($loadedDocuments));
 
         foreach ($loadedDocuments as $loadedDocument) {
-            $this->assertGreaterThanOrEqual(\strtotime('2022-12-26T12:00:00+01:00'), \strtotime($loadedDocument['created'] ?? '1970-01-01T00:00:00+00:00'));
+            $created = $loadedDocument['created'] ?? '1970-01-01T00:00:00+00:00';
+            $this->assertIsString($created);
+            $this->assertGreaterThanOrEqual(\strtotime('2022-12-26T12:00:00+01:00'), \strtotime($created));
         }
 
         foreach ($documents as $document) {

--- a/packages/seal/src/Testing/AbstractSearcherTestCase.php
+++ b/packages/seal/src/Testing/AbstractSearcherTestCase.php
@@ -816,6 +816,41 @@ abstract class AbstractSearcherTestCase extends TestCase
         }
     }
 
+    public function testGreaterThanConditionWithDateField(): void
+    {
+        $documents = TestingHelper::createComplexFixtures();
+
+        $schema = self::getSchema();
+
+        foreach ($documents as $document) {
+            self::$taskHelper->tasks[] = self::$indexer->save(
+                $schema->indexes[TestingHelper::INDEX_COMPLEX],
+                $document,
+                ['return_slow_promise_result' => true],
+            );
+        }
+        self::$taskHelper->waitForAll();
+
+        $search = new SearchBuilder($schema, self::$searcher);
+        $search->index(TestingHelper::INDEX_COMPLEX);
+        $search->addFilter(new Condition\GreaterThanCondition('created', '2022-12-26T12:00:00+01:00'));
+
+        $loadedDocuments = [...$search->getResult()];
+        $this->assertGreaterThanOrEqual(1, \count($loadedDocuments));
+
+        foreach ($loadedDocuments as $loadedDocument) {
+            $this->assertGreaterThan(\strtotime('2022-12-26T12:00:00+01:00'), \strtotime($loadedDocument['created'] ?? '1970-01-01T00:00:00+00:00'));
+        }
+
+        foreach ($documents as $document) {
+            self::$taskHelper->tasks[] = self::$indexer->delete(
+                $schema->indexes[TestingHelper::INDEX_COMPLEX],
+                $document['uuid'],
+                ['return_slow_promise_result' => true],
+            );
+        }
+    }
+
     public function testGreaterThanEqualCondition(): void
     {
         $documents = TestingHelper::createComplexFixtures();
@@ -845,6 +880,41 @@ abstract class AbstractSearcherTestCase extends TestCase
             );
 
             $this->assertGreaterThanOrEqual(2.5, $loadedDocument['rating']);
+        }
+
+        foreach ($documents as $document) {
+            self::$taskHelper->tasks[] = self::$indexer->delete(
+                $schema->indexes[TestingHelper::INDEX_COMPLEX],
+                $document['uuid'],
+                ['return_slow_promise_result' => true],
+            );
+        }
+    }
+
+    public function testGreaterThanOrEqualConditionWithDateField(): void
+    {
+        $documents = TestingHelper::createComplexFixtures();
+
+        $schema = self::getSchema();
+
+        foreach ($documents as $document) {
+            self::$taskHelper->tasks[] = self::$indexer->save(
+                $schema->indexes[TestingHelper::INDEX_COMPLEX],
+                $document,
+                ['return_slow_promise_result' => true],
+            );
+        }
+        self::$taskHelper->waitForAll();
+
+        $search = new SearchBuilder($schema, self::$searcher);
+        $search->index(TestingHelper::INDEX_COMPLEX);
+        $search->addFilter(new Condition\GreaterThanEqualCondition('created', '2022-12-26T12:00:00+01:00'));
+
+        $loadedDocuments = [...$search->getResult()];
+        $this->assertGreaterThanOrEqual(2, \count($loadedDocuments));
+
+        foreach ($loadedDocuments as $loadedDocument) {
+            $this->assertGreaterThanOrEqual(\strtotime('2022-12-26T12:00:00+01:00'), \strtotime($loadedDocument['created'] ?? '1970-01-01T00:00:00+00:00'));
         }
 
         foreach ($documents as $document) {

--- a/packages/seal/tests/Marshaller/MarshallerTest.php
+++ b/packages/seal/tests/Marshaller/MarshallerTest.php
@@ -45,21 +45,21 @@ class MarshallerTest extends TestCase
 
     public function testMarshallDateAsInt(): void
     {
-        $marshaller = new Marshaller(dateAsInteger: true);
+        $marshaller = new Marshaller(dateFormat: 'U');
         $complexIndex = TestingHelper::createSchema()->indexes[TestingHelper::INDEX_COMPLEX];
         $documents = TestingHelper::createComplexFixtures();
 
         $rawDocument = $marshaller->marshall($complexIndex->fields, $documents[0]);
 
-        $this->assertSame($this->getRawDocument(dateAsInteger: true), $rawDocument);
+        $this->assertSame($this->getRawDocument(dateFormat: 'U'), $rawDocument);
     }
 
     public function testUnmarshallDateAsInt(): void
     {
-        $marshaller = new Marshaller(dateAsInteger: true);
+        $marshaller = new Marshaller(dateFormat: 'U');
         $complexIndex = TestingHelper::createSchema()->indexes[TestingHelper::INDEX_COMPLEX];
 
-        $document = $marshaller->unmarshall($complexIndex->fields, $this->getRawDocument(dateAsInteger: true));
+        $document = $marshaller->unmarshall($complexIndex->fields, $this->getRawDocument(dateFormat: 'U'));
 
         $documents = TestingHelper::createComplexFixtures();
         $this->assertSame($documents[0], $document);
@@ -68,7 +68,7 @@ class MarshallerTest extends TestCase
     /**
      * @return array<string, mixed>
      */
-    private function getRawDocument(bool $dateAsInteger = false): array
+    private function getRawDocument(string $dateFormat = 'c'): array
     {
         return [
             'uuid' => '23b30f01-d8fd-4dca-b36a-4710e360a965',
@@ -109,7 +109,7 @@ class MarshallerTest extends TestCase
             'footer' => [
                 'title' => 'New Footer',
             ],
-            'created' => $dateAsInteger ? 1_643_022_000 : '2022-01-24T12:00:00+01:00',
+            'created' => 'U' === $dateFormat ? 1_643_022_000 : '2022-01-24T12:00:00+01:00',
             'commentsCount' => 2,
             'rating' => 3.5,
             'isSpecial' => true,


### PR DESCRIPTION
Filters based on `datetime` fields seems currently not work correctly in:

 - [x] Loupe (expect integer in filter)
 - [x] Typesense (expect integer in filter)
 - [x] Meilisearch (expect integer in filter, and schema as integer) (requires drop reindex)
 - [x] Algolia (expect integer in filter, and schema as integer) (requires drop reindex)
 - [x] RediSearch (expect integer in filter, and schema as integer) (requires drop reindex)
 - [x] Solr (expect specific format in filters, and in indexing) (requires drop reindex)

⚠️ `Marshaller` and `Flattenmarshaller` services also changed the `dateAsInteger: true` was removed in favor of `dateFormat: 'U'`. To allow different date formats for Example for Solr which requires a specific format. As they are still `@internal` there are no issues with BC Break here. But still a reindex is required for Solr, Redisearch and 

fixes #587

### BC Breaks

For `Meilisearch`, `Algolia`, `RediSearch` and `Solr` the saving of the date time type changed and requires a drop reindex. `cmsig:seal:reindex --drop`.