### PR TITLE
Add Static Factory methods for Conditions and Facets

### DIFF
--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -1851,7 +1851,7 @@ many exists in the given index.
         public function someMethod()
         {
             $result = $this->engine->createSearchBuilder('blog')
-                ->addFilter(new \CmsIg\Seal\Search\Condition\SearchCondition('first'))
+                ->addFilter(\CmsIg\Seal\Search\Condition\Condition::search('first'))
                 ->getResult();
 
             foreach ($result as $document) {
@@ -1883,7 +1883,7 @@ we will filter by the ``tags`` field and get all documents which have the tag ``
         public function someMethod()
         {
             $result = $this->engine->createSearchBuilder('blog')
-                ->addFilter(new \CmsIg\Seal\Search\Condition\EqualCondition('tags', 'UI'));
+                ->addFilter(\CmsIg\Seal\Search\Condition\Condition::equal('tags', 'UI'));
                 ->getResult();
 
             foreach ($result as $document) {

--- a/docs/search-and-filters/index.rst
+++ b/docs/search-and-filters/index.rst
@@ -14,7 +14,7 @@ The following shows the basic usage as already shown in the "Getting Started" do
 
     <?php
 
-    use CmsIg\Seal\Search\Condition;
+    use CmsIg\Seal\Search\Condition\Condition;
 
     $result = $this->engine->createSearchBuilder('blog')
         ->addFilter(/* ... */)
@@ -42,10 +42,10 @@ The ``SearchCondition`` is the most basic condition and can be used to search fo
 
     <?php
 
-    use CmsIg\Seal\Search\Condition;
+    use CmsIg\Seal\Search\Condition\Condition;
 
     $result = $this->engine->createSearchBuilder('blog')
-        ->addFilter(new Condition\SearchCondition('Search Term'))
+        ->addFilter(Condition::search('Search Term'))
         ->getResult();
 
 The condition does only search on fields which are marked as ``searchable`` in the index configuration.
@@ -59,10 +59,10 @@ The ``EqualCondition`` is used to filter the result by a specific field value ma
 
     <?php
 
-    use CmsIg\Seal\Search\Condition;
+    use CmsIg\Seal\Search\Condition\Condition;
 
     $result = $this->engine->createSearchBuilder('blog')
-        ->addFilter(new Condition\EqualCondition('tags', 'UI'))
+        ->addFilter(Condition::equal('tags', 'UI'))
         ->getResult();
 
 The field is required to be marked as ``filterable`` in the index configuration, it can be also
@@ -77,10 +77,10 @@ The ``NotEqualCondition`` is used to filter the result by a specific field value
 
     <?php
 
-    use CmsIg\Seal\Search\Condition;
+    use CmsIg\Seal\Search\Condition\Condition;
 
     $result = $this->engine->createSearchBuilder('blog')
-        ->addFilter(new Condition\NotEqualCondition('tags', 'UI'))
+        ->addFilter(Condition::notEqual('tags', 'UI'))
         ->getResult();
 
 The field is required to be marked as ``filterable`` in the index configuration, it can be also
@@ -97,10 +97,10 @@ then using a ``EqualCondition``.
 
     <?php
 
-    use CmsIg\Seal\Search\Condition;
+    use CmsIg\Seal\Search\Condition\Condition;
 
     $result = $this->engine->createSearchBuilder('blog')
-        ->addFilter(new Condition\IdentifierCondition('23b30f01-d8fd-4dca-b36a-4710e360a965'))
+        ->addFilter(Condition::identifier('23b30f01-d8fd-4dca-b36a-4710e360a965'))
         ->getResult();
 
 GreaterThanCondition
@@ -113,10 +113,10 @@ the given value.
 
     <?php
 
-    use CmsIg\Seal\Search\Condition;
+    use CmsIg\Seal\Search\Condition\Condition;
 
     $result = $this->engine->createSearchBuilder('blog')
-        ->addFilter(new Condition\GreaterThanCondition('rating', 2.5))
+        ->addFilter(Condition::greaterThan('rating', 2.5))
         ->getResult();
 
 The field is required to be marked as ``filterable`` in the index configuration.
@@ -131,10 +131,10 @@ the given value.
 
     <?php
 
-    use CmsIg\Seal\Search\Condition;
+    use CmsIg\Seal\Search\Condition\Condition;
 
     $result = $this->engine->createSearchBuilder('blog')
-        ->addFilter(new Condition\GreaterThanEqualCondition('rating', 2.5))
+        ->addFilter(Condition::greaterThanEqual('rating', 2.5))
         ->getResult();
 
 The field is required to be marked as ``filterable`` in the index configuration.
@@ -149,10 +149,10 @@ the given value.
 
     <?php
 
-    use CmsIg\Seal\Search\Condition;
+    use CmsIg\Seal\Search\Condition\Condition;
 
     $result = $this->engine->createSearchBuilder('blog')
-        ->addFilter(new Condition\LessThanCondition('rating', 2.5))
+        ->addFilter(Condition::lessThan('rating', 2.5))
         ->getResult();
 
 The field is required to be marked as ``filterable`` in the index configuration.
@@ -167,10 +167,10 @@ the given value.
 
     <?php
 
-    use CmsIg\Seal\Search\Condition;
+    use CmsIg\Seal\Search\Condition\Condition;
 
     $result = $this->engine->createSearchBuilder('blog')
-        ->addFilter(new Condition\LessThanEqualCondition('rating', 2.5))
+        ->addFilter(Condition::lessThanEqual('rating', 2.5))
         ->getResult();
 
 The field is required to be marked as ``filterable`` in the index configuration.
@@ -184,10 +184,10 @@ The ``GeoDistanceCondition`` is used to filter results within a radius by specif
 
     <?php
 
-    use CmsIg\Seal\Search\Condition;
+    use CmsIg\Seal\Search\Condition\Condition;
 
     $result = $this->engine->createSearchBuilder('restaurants')
-        ->addFilter(new Condition\GeoDistanceCondition('location', 45.472735, 9.184019, 2000))
+        ->addFilter(Condition::geoDistance('location', 45.472735, 9.184019, 2000))
         ->getResult();
 
 The field is required to be marked as ``filterable`` in the index configuration.
@@ -201,10 +201,10 @@ The ``GeoBoundingBoxCondition`` is used to filter results within a bounding box 
 
     <?php
 
-    use CmsIg\Seal\Search\Condition;
+    use CmsIg\Seal\Search\Condition\Condition;
 
     $result = $this->engine->createSearchBuilder('restaurants')
-        ->addFilter(new Condition\GeoBoundingBoxCondition('location', 45.494181, 9.214024, 45.449484, 9.179175))
+        ->addFilter(Condition::geoBoundingBox('location', 45.494181, 9.214024, 45.449484, 9.179175))
         ->getResult();
 
 
@@ -224,12 +224,12 @@ The ``OrCondition`` is used to filter by two or more conditions where at least o
 
     <?php
 
-    use CmsIg\Seal\Search\Condition;
+    use CmsIg\Seal\Search\Condition\Condition;
 
     $result = $this->engine->createSearchBuilder('blog')
-        ->addFilter(new Condition\OrCondition(
-            new Condition\GreaterThanCondition('rating', 2.5),
-            new Condition\EqualCondition('isSpecial', true),
+        ->addFilter(Condition::or(
+            Condition::greaterThan('rating', 2.5),
+            Condition::equal('isSpecial', true),
         ))
         ->getResult();
 
@@ -246,14 +246,14 @@ in combination with ``OrCondition`` filters.
 
     <?php
 
-    use CmsIg\Seal\Search\Condition;
+    use CmsIg\Seal\Search\Condition\Condition;
 
     $result = $this->engine->createSearchBuilder('blog')
-        ->addFilter(new Condition\AndCondition(
-            new Condition\EqualCondition('tags', 'Tech'),
-            new Condition\OrCondition(
-                new Condition\EqualCondition('tags', 'UX'),
-                new Condition\EqualCondition('isSpecial', true),
+        ->addFilter(Condition::and(
+            Condition::equal('tags', 'Tech'),
+            Condition::or(
+                Condition::equal('tags', 'UX'),
+                Condition::equal('isSpecial', true),
             ),
         ))
         ->getResult();
@@ -290,10 +290,10 @@ Need to be queried this way `<object>.<field>`:
 
     <?php
 
-    use CmsIg\Seal\Search\Condition;
+    use CmsIg\Seal\Search\Condition\Condition;
 
     $result = $this->engine->createSearchBuilder('blog')
-        ->addFilter(new Condition\LessThanEqualCondition('rating.value', 2.5))
+        ->addFilter(Condition::lessThanEqual('rating.value', 2.5))
         ->getResult();
 
 To filter on ``Typed`` objects also the `.` symbol is used but the type name need to be included as well.
@@ -317,10 +317,10 @@ Need to be queried this way `<object>.<type>.<field>`:
 
     <?php
 
-    use CmsIg\Seal\Search\Condition;
+    use CmsIg\Seal\Search\Condition\Condition;
 
     $result = $this->engine->createSearchBuilder('blog')
-        ->addFilter(new Condition\EqualCondition('header.image.media', 21))
+        ->addFilter(Condition::equal('header.image.media', 21))
         ->getResult();
 
 Also nested objects and types can be queried the same way.
@@ -376,7 +376,7 @@ your results but also ``sort`` them by a given field.
 
     <?php
 
-    use CmsIg\Seal\Search\Condition;
+    use CmsIg\Seal\Search\Condition\Condition;
 
     $result = $this->engine->createSearchBuilder('blog')
         ->addSortBy('rating', 'desc')
@@ -386,7 +386,7 @@ your results but also ``sort`` them by a given field.
 
     <?php
 
-    use CmsIg\Seal\Search\Condition;
+    use CmsIg\Seal\Search\Condition\Condition;
 
     $result = $this->engine->createSearchBuilder('blog')
         ->addSortBy('rating', 'asc')
@@ -405,10 +405,10 @@ The abstraction can also be used to highlight the search term in the result.
 
     <?php
 
-    use CmsIg\Seal\Search\Condition;
+    use CmsIg\Seal\Search\Condition\Condition;
 
     $result = $this->engine->createSearchBuilder('blog')
-        ->addFilter(new Condition\SearchCondition('Search Term'))
+        ->addFilter(Condition::search('Search Term'))
         ->highlight(['title'], '<mark>', '</mark>');
         ->getResult();
 
@@ -446,19 +446,18 @@ search engines support:
 
     <?php
 
-    use CmsIg\Seal\Search\Facet\MinMaxFacet;
-    use CmsIg\Seal\Search\Facet\CountFacet;
+    use CmsIg\Seal\Search\Facet\Facet;
 
     $result = $this->engine->createSearchBuilder('blog')
-        ->addFacet(new MinMaxFacet('age'))
-        ->addFacet(new CountFacet('tags'))
+        ->addFacet(Facet::minMax('rating'))
+        ->addFacet(Facet::count('tags'))
         ->getResult();
 
     $facets = $result->facets(); // Output depends on the facet type
 
 .. note::
 
-    For ``->addFacet()`` to work, your fields (``age`` and ``tags`` in our our example) have to be configured using
+    For ``->addFacet()`` to work, your fields (``rating`` and ``tags`` in our our example) have to be configured using
     `facet: true` in the index schema.
 
 .. note::
@@ -479,10 +478,10 @@ for example. Instead of displaying all the product variants, you may group them 
 
     <?php
 
-    use CmsIg\Seal\Search\Condition;
+    use CmsIg\Seal\Search\Condition\Condition;
 
     $result = $this->engine->createSearchBuilder('blog')
-        ->addFilter(new Condition\SearchCondition('product title'))
+        ->addFilter(Condition::search('product title'))
         ->distinct('product_id')
         ->getResult();
     }

--- a/packages/seal/src/Search/Condition/Condition.php
+++ b/packages/seal/src/Search/Condition/Condition.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS-IG SEAL project.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace CmsIg\Seal\Search\Condition;
 
 /**
@@ -7,6 +18,10 @@ namespace CmsIg\Seal\Search\Condition;
  */
 final class Condition
 {
+    private function __construct()
+    {
+    }
+
     public static function search(string $query): SearchCondition
     {
         return new SearchCondition($query);
@@ -92,7 +107,7 @@ final class Condition
     }
 
     /**
-     * @var array<EqualCondition|GreaterThanCondition|GreaterThanEqualCondition|IdentifierCondition|InCondition|LessThanCondition|LessThanEqualCondition|NotEqualCondition|NotInCondition|AndCondition|OrCondition> $conditions
+     * @param EqualCondition|GreaterThanCondition|GreaterThanEqualCondition|IdentifierCondition|InCondition|LessThanCondition|LessThanEqualCondition|NotEqualCondition|NotInCondition|AndCondition|OrCondition $conditions
      */
     public static function and(...$conditions): AndCondition
     {
@@ -100,7 +115,7 @@ final class Condition
     }
 
     /**
-     * @var array<EqualCondition|GreaterThanCondition|GreaterThanEqualCondition|IdentifierCondition|InCondition|LessThanCondition|LessThanEqualCondition|NotEqualCondition|NotInCondition|AndCondition|OrCondition> $conditions
+     * @param EqualCondition|GreaterThanCondition|GreaterThanEqualCondition|IdentifierCondition|InCondition|LessThanCondition|LessThanEqualCondition|NotEqualCondition|NotInCondition|AndCondition|OrCondition $conditions
      */
     public static function or(...$conditions): OrCondition
     {

--- a/packages/seal/src/Search/Condition/Condition.php
+++ b/packages/seal/src/Search/Condition/Condition.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace CmsIg\Seal\Search\Condition;
+
+/**
+ * Simpler access to the different condition classes.
+ */
+final class Condition
+{
+    public static function search(string $query): SearchCondition
+    {
+        return new SearchCondition($query);
+    }
+
+    public static function identifier(string $id): IdentifierCondition
+    {
+        return new IdentifierCondition($id);
+    }
+
+    public static function equal(string $field, string|int|float|bool $value): EqualCondition
+    {
+        return new EqualCondition($field, $value);
+    }
+
+    public static function notEqual(string $field, string|int|float|bool $value): NotEqualCondition
+    {
+        return new NotEqualCondition($field, $value);
+    }
+
+    public static function greaterThan(string $field, string|int|float|bool $value): GreaterThanCondition
+    {
+        return new GreaterThanCondition($field, $value);
+    }
+
+    public static function greaterThanEqual(string $field, string|int|float|bool $value): GreaterThanEqualCondition
+    {
+        return new GreaterThanEqualCondition($field, $value);
+    }
+
+    public static function lessThan(string $field, string|int|float|bool $value): LessThanCondition
+    {
+        return new LessThanCondition($field, $value);
+    }
+
+    public static function lessThanEqual(string $field, string|int|float|bool $value): LessThanEqualCondition
+    {
+        return new LessThanEqualCondition($field, $value);
+    }
+
+    /**
+     * @param list<string|int|float|bool> $values
+     */
+    public static function in(string $field, array $values): InCondition
+    {
+        return new InCondition($field, $values);
+    }
+
+    /**
+     * @param list<string|int|float|bool> $values
+     */
+    public static function notIn(string $field, array $values): NotInCondition
+    {
+        return new NotInCondition($field, $values);
+    }
+
+    /**
+     * The order may first be unusually, but it is the same as in common JS libraries like.
+     *
+     * @see https://docs.mapbox.com/help/glossary/bounding-box/
+     * @see https://developers.google.com/maps/documentation/javascript/reference/coordinates#LatLngBounds
+     */
+    public static function geoBoundingBox(
+        string $field,
+        float $northLatitude, // top
+        float $eastLongitude, // right
+        float $southLatitude, // bottom
+        float $westLongitude, // left
+    ): GeoBoundingBoxCondition {
+        return new GeoBoundingBoxCondition($field, $northLatitude, $eastLongitude, $southLatitude, $westLongitude);
+    }
+
+    /**
+     * @param int $distance search radius in meters
+     */
+    public static function geoDistance(
+        string $field,
+        float $latitude,
+        float $longitude,
+        int $distance,
+    ): GeoDistanceCondition {
+        return new GeoDistanceCondition($field, $latitude, $longitude, $distance);
+    }
+
+    /**
+     * @var array<EqualCondition|GreaterThanCondition|GreaterThanEqualCondition|IdentifierCondition|InCondition|LessThanCondition|LessThanEqualCondition|NotEqualCondition|NotInCondition|AndCondition|OrCondition> $conditions
+     */
+    public static function and(...$conditions): AndCondition
+    {
+        return new AndCondition(...$conditions);
+    }
+
+    /**
+     * @var array<EqualCondition|GreaterThanCondition|GreaterThanEqualCondition|IdentifierCondition|InCondition|LessThanCondition|LessThanEqualCondition|NotEqualCondition|NotInCondition|AndCondition|OrCondition> $conditions
+     */
+    public static function or(...$conditions): OrCondition
+    {
+        return new OrCondition(...$conditions);
+    }
+}

--- a/packages/seal/src/Search/Facet/Facet.php
+++ b/packages/seal/src/Search/Facet/Facet.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace CmsIg\Seal\Search\Facet;
+
+/**
+ * Simpler access to the different facet classes.
+ */
+final class Facet
+{
+    /**
+     * @param array<string, mixed> $options
+     */
+    public static function count(string $field, array $options = []): CountFacet
+    {
+        return new CountFacet($field, $options);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public static function minMax(string $field, array $options = []): MinMaxFacet
+    {
+        return new MinMaxFacet($field, $options);
+    }
+}

--- a/packages/seal/src/Search/Facet/Facet.php
+++ b/packages/seal/src/Search/Facet/Facet.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS-IG SEAL project.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace CmsIg\Seal\Search\Facet;
 
 /**
@@ -7,6 +18,10 @@ namespace CmsIg\Seal\Search\Facet;
  */
 final class Facet
 {
+    private function __construct()
+    {
+    }
+
     /**
      * @param array<string, mixed> $options
      */

--- a/packages/seal/src/Testing/AbstractIndexerTestCase.php
+++ b/packages/seal/src/Testing/AbstractIndexerTestCase.php
@@ -18,7 +18,7 @@ use CmsIg\Seal\Adapter\IndexerInterface;
 use CmsIg\Seal\Adapter\SchemaManagerInterface;
 use CmsIg\Seal\Adapter\SearcherInterface;
 use CmsIg\Seal\Schema\Schema;
-use CmsIg\Seal\Search\Condition;
+use CmsIg\Seal\Search\Condition\Condition;
 use CmsIg\Seal\Search\SearchBuilder;
 use PHPUnit\Framework\TestCase;
 
@@ -103,7 +103,7 @@ abstract class AbstractIndexerTestCase extends TestCase
         foreach ($documents as $document) {
             $search = new SearchBuilder($schema, self::$searcher);
             $search->index(TestingHelper::INDEX_COMPLEX);
-            $search->addFilter(new Condition\IdentifierCondition($document['uuid']));
+            $search->addFilter(Condition::identifier($document['uuid']));
             $search->limit(1);
 
             $resultDocument = \iterator_to_array($search->getResult(), false)[0] ?? null;
@@ -137,7 +137,7 @@ abstract class AbstractIndexerTestCase extends TestCase
         foreach ($documents as $document) {
             $search = new SearchBuilder($schema, self::$searcher);
             $search->index(TestingHelper::INDEX_COMPLEX);
-            $search->addFilter(new Condition\IdentifierCondition($document['uuid']));
+            $search->addFilter(Condition::identifier($document['uuid']));
             $search->limit(1);
 
             $resultDocument = \iterator_to_array($search->getResult(), false)[0] ?? null;
@@ -168,7 +168,7 @@ abstract class AbstractIndexerTestCase extends TestCase
         foreach ($documents as $document) {
             $search = new SearchBuilder($schema, self::$searcher);
             $search->index(TestingHelper::INDEX_COMPLEX);
-            $search->addFilter(new Condition\IdentifierCondition($document['uuid']));
+            $search->addFilter(Condition::identifier($document['uuid']));
             $search->limit(1);
 
             $resultDocument = \iterator_to_array($search->getResult(), false)[0] ?? null;
@@ -205,7 +205,7 @@ abstract class AbstractIndexerTestCase extends TestCase
         foreach ($documents as $document) {
             $search = new SearchBuilder($schema, self::$searcher);
             $search->index(TestingHelper::INDEX_COMPLEX);
-            $search->addFilter(new Condition\IdentifierCondition($document['uuid']));
+            $search->addFilter(Condition::identifier($document['uuid']));
             $search->limit(1);
 
             $resultDocument = \iterator_to_array($search->getResult(), false)[0] ?? null;

--- a/packages/seal/src/Testing/AbstractSearcherTestCase.php
+++ b/packages/seal/src/Testing/AbstractSearcherTestCase.php
@@ -18,9 +18,8 @@ use CmsIg\Seal\Adapter\IndexerInterface;
 use CmsIg\Seal\Adapter\SchemaManagerInterface;
 use CmsIg\Seal\Adapter\SearcherInterface;
 use CmsIg\Seal\Schema\Schema;
-use CmsIg\Seal\Search\Condition;
-use CmsIg\Seal\Search\Facet\CountFacet;
-use CmsIg\Seal\Search\Facet\MinMaxFacet;
+use CmsIg\Seal\Search\Condition\Condition;
+use CmsIg\Seal\Search\Facet\Facet;
 use CmsIg\Seal\Search\SearchBuilder;
 use PHPUnit\Framework\TestCase;
 
@@ -103,7 +102,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\SearchCondition('Other'));
+        $search->addFilter(Condition::search('Other'));
         $search->distinct('commentsCount');
 
         $loadedDocuments = [...$search->getResult()];
@@ -136,8 +135,8 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFacet(new CountFacet(field: 'rating'));
-        $search->addFacet(new CountFacet(field: 'isSpecial'));
+        $search->addFacet(Facet::count(field: 'rating'));
+        $search->addFacet(Facet::count(field: 'isSpecial'));
 
         $facets = $search->getResult()->facets();
         TestingHelper::recursiveKeySort($facets);
@@ -159,9 +158,9 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\SearchCondition('Other'));
-        $search->addFacet(new CountFacet(field: 'rating'));
-        $search->addFacet(new CountFacet(field: 'isSpecial'));
+        $search->addFilter(Condition::search('Other'));
+        $search->addFacet(Facet::count(field: 'rating'));
+        $search->addFacet(Facet::count(field: 'isSpecial'));
 
         $facets = $search->getResult()->facets();
         TestingHelper::recursiveKeySort($facets);
@@ -205,7 +204,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFacet(new MinMaxFacet(field: 'rating'));
+        $search->addFacet(Facet::minMax(field: 'rating'));
 
         $facets = $search->getResult()->facets();
         TestingHelper::recursiveKeySort($facets);
@@ -219,8 +218,8 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\SearchCondition('Other'));
-        $search->addFacet(new MinMaxFacet(field: 'rating'));
+        $search->addFilter(Condition::search('Other'));
+        $search->addFacet(Facet::minMax(field: 'rating'));
 
         $facets = $search->getResult()->facets();
         TestingHelper::recursiveKeySort($facets);
@@ -258,7 +257,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFacet(new CountFacet(field: 'tags'));
+        $search->addFacet(Facet::count(field: 'tags'));
 
         $facets = $search->getResult()->facets();
         TestingHelper::recursiveKeySort($facets);
@@ -275,8 +274,8 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\SearchCondition('Blog'));
-        $search->addFacet(new CountFacet(field: 'tags'));
+        $search->addFilter(Condition::search('Blog'));
+        $search->addFacet(Facet::count(field: 'tags'));
 
         $facets = $search->getResult()->facets();
         TestingHelper::recursiveKeySort($facets);
@@ -345,7 +344,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\SearchCondition('Blog'));
+        $search->addFilter(Condition::search('Blog'));
 
         $expectedDocumentsVariantA = [
             $documents[0],
@@ -367,7 +366,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\SearchCondition('Thing'));
+        $search->addFilter(Condition::search('Thing'));
 
         $this->assertSame([$documents[2]], [...$search->getResult()]);
 
@@ -397,7 +396,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\SearchCondition('Blog'));
+        $search->addFilter(Condition::search('Blog'));
         $search->highlight(['title', 'article'], '<mark>', '</mark>');
 
         $expectedDocumentA = $documents[0];
@@ -436,7 +435,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\SearchCondition('Thing'));
+        $search->addFilter(Condition::search('Thing'));
 
         $this->assertSame([$documents[2]], [...$search->getResult()]);
 
@@ -466,7 +465,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\SearchCondition('admin.nonesearchablefield@localhost'));
+        $search->addFilter(Condition::search('admin.nonesearchablefield@localhost'));
 
         $this->assertCount(0, [...$search->getResult()]);
     }
@@ -488,7 +487,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = (new SearchBuilder($schema, self::$searcher))
             ->index(TestingHelper::INDEX_COMPLEX)
-            ->addFilter(new Condition\SearchCondition('Blog'))
+            ->addFilter(Condition::search('Blog'))
             ->limit(1);
 
         $loadedDocuments = [...$search->getResult()];
@@ -504,7 +503,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = (new SearchBuilder($schema, self::$searcher))
             ->index(TestingHelper::INDEX_COMPLEX)
-            ->addFilter(new Condition\SearchCondition('Blog'))
+            ->addFilter(Condition::search('Blog'))
             ->offset(1)
             ->limit(1);
 
@@ -541,7 +540,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\EqualCondition('tags', 'UI'));
+        $search->addFilter(Condition::equal('tags', 'UI'));
 
         $expectedDocumentsVariantA = [
             $documents[0],
@@ -587,7 +586,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\EqualCondition('isSpecial', true));
+        $search->addFilter(Condition::equal('isSpecial', true));
 
         $expectedDocumentsVariantA = [
             $documents[0],
@@ -637,7 +636,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\EqualCondition('tags', $specialString));
+        $search->addFilter(Condition::equal('tags', $specialString));
 
         $expectedDocumentsVariantA = [
             $documents[1],
@@ -681,8 +680,8 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\EqualCondition('tags', 'UI'));
-        $search->addFilter(new Condition\EqualCondition('tags', 'UX'));
+        $search->addFilter(Condition::equal('tags', 'UI'));
+        $search->addFilter(Condition::equal('tags', 'UX'));
 
         $loadedDocuments = [...$search->getResult()];
         $this->assertCount(1, $loadedDocuments);
@@ -718,8 +717,8 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\EqualCondition('tags', 'Tech'));
-        $search->addFilter(new Condition\SearchCondition('Blog'));
+        $search->addFilter(Condition::equal('tags', 'Tech'));
+        $search->addFilter(Condition::search('Blog'));
 
         $loadedDocuments = [...$search->getResult()];
         $this->assertCount(1, $loadedDocuments);
@@ -752,7 +751,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\NotEqualCondition('tags', 'UI'));
+        $search->addFilter(Condition::notEqual('tags', 'UI'));
 
         $expectedDocumentsVariantA = [
             $documents[2],
@@ -798,7 +797,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\GreaterThanCondition('rating', 2.5));
+        $search->addFilter(Condition::greaterthan('rating', 2.5));
 
         $loadedDocuments = [...$search->getResult()];
         $this->assertGreaterThanOrEqual(1, \count($loadedDocuments));
@@ -833,7 +832,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\GreaterThanCondition('created', '2022-12-26T12:00:00+01:00'));
+        $search->addFilter(Condition::greaterThan('created', '2022-12-26T12:00:00+01:00'));
 
         $loadedDocuments = [...$search->getResult()];
         $this->assertGreaterThanOrEqual(1, \count($loadedDocuments));
@@ -870,7 +869,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\GreaterThanEqualCondition('rating', 2.5));
+        $search->addFilter(Condition::greaterThanEqual('rating', 2.5));
 
         $loadedDocuments = [...$search->getResult()];
         $this->assertGreaterThan(1, \count($loadedDocuments));
@@ -910,7 +909,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\GreaterThanEqualCondition('created', '2022-12-26T12:00:00+01:00'));
+        $search->addFilter(Condition::greaterThanEqual('created', '2022-12-26T12:00:00+01:00'));
 
         $loadedDocuments = [...$search->getResult()];
         $this->assertGreaterThanOrEqual(2, \count($loadedDocuments));
@@ -947,7 +946,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\GreaterThanEqualCondition('categoryIds', 3.0));
+        $search->addFilter(Condition::greaterthanequal('categoryIds', 3.0));
 
         $loadedDocuments = [...$search->getResult()];
         $this->assertCount(2, $loadedDocuments);
@@ -987,7 +986,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\LessThanCondition('rating', 3.5));
+        $search->addFilter(Condition::lessThan('rating', 3.5));
 
         $loadedDocuments = [...$search->getResult()];
         $this->assertGreaterThanOrEqual(1, \count($loadedDocuments));
@@ -1027,7 +1026,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\LessThanEqualCondition('rating', 3.5));
+        $search->addFilter(Condition::lessthanequal('rating', 3.5));
 
         $loadedDocuments = [...$search->getResult()];
         $this->assertGreaterThan(1, \count($loadedDocuments));
@@ -1067,7 +1066,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\GeoDistanceCondition(
+        $search->addFilter(Condition::geoDistance(
             'location',
             // Berlin
             52.5200,
@@ -1132,7 +1131,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\GeoBoundingBoxCondition(
+        $search->addFilter(Condition::geoBoundingBox(
             'location',
             // Dublin - Athen
             53.3498, // top
@@ -1213,7 +1212,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\LessThanEqualCondition('categoryIds', 2.0));
+        $search->addFilter(Condition::lessThanEqual('categoryIds', 2.0));
 
         $loadedDocuments = [...$search->getResult()];
         $this->assertCount(2, $loadedDocuments);
@@ -1253,7 +1252,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\InCondition('tags', ['UI']));
+        $search->addFilter(Condition::in('tags', ['UI']));
 
         $expectedDocumentsVariantA = [
             $documents[0],
@@ -1299,7 +1298,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\NotInCondition('tags', ['UI']));
+        $search->addFilter(Condition::notIn('tags', ['UI']));
 
         $expectedDocumentsVariantA = [
             $documents[2],
@@ -1346,7 +1345,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\GreaterThanCondition('rating', 0));
+        $search->addFilter(Condition::greaterThan('rating', 0));
         $search->addSortBy('rating', 'asc');
 
         $loadedDocuments = [...$search->getResult()];
@@ -1385,7 +1384,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\GreaterThanCondition('rating', 0));
+        $search->addFilter(Condition::greaterthan('rating', 0));
         $search->addSortBy('rating', 'desc');
 
         $loadedDocuments = [...$search->getResult()];
@@ -1423,7 +1422,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\NotEqualCondition('uuid', '97cd3e94-c17f-4c11-a22b-d9da2e5318cd'));
+        $search->addFilter(Condition::notequal('uuid', '97cd3e94-c17f-4c11-a22b-d9da2e5318cd'));
         $search->addSortBy('title', 'asc');
 
         $loadedDocuments = [...$search->getResult()];
@@ -1462,7 +1461,7 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(new Condition\NotEqualCondition('uuid', '97cd3e94-c17f-4c11-a22b-d9da2e5318cd'));
+        $search->addFilter(Condition::notequal('uuid', '97cd3e94-c17f-4c11-a22b-d9da2e5318cd'));
         $search->addSortBy('title', 'desc');
 
         $loadedDocuments = [...$search->getResult()];
@@ -1514,11 +1513,11 @@ abstract class AbstractSearcherTestCase extends TestCase
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
 
-        $condition = new Condition\AndCondition(
-            new Condition\EqualCondition('tags', 'Tech'),
-            new Condition\OrCondition(
-                new Condition\EqualCondition('tags', 'UX'),
-                new Condition\EqualCondition('isSpecial', false),
+        $condition = Condition::and(
+            Condition::equal('tags', 'Tech'),
+            Condition::or(
+                Condition::equal('tags', 'UX'),
+                Condition::equal('isSpecial', false),
             ),
         );
 


### PR DESCRIPTION
Current state is that for a good `DX` developers need to import `CmsIg\Seal\Search\Condition` and use `new Condition\...`. This looks like this:

```php
use CmsIg\Seal\Search\Condition;

$result = $this->engine->createSearchBuilder('blog')
    ->addFilter(new Condition\AndCondition(
        new Condition\EqualCondition('tags', 'Tech'),
        new Condition\OrCondition(
            new Condition\EqualCondition('tags', 'UX'),
            new Condition\EqualCondition('isSpecial', true),
        ),
    ))
    ->getResult();
```

But some Code Styles prevent that and so they require to import every conditions by themselves. In that case the Developer Experience is bad as autocomplete don't work.

For core based filters we could maybe create a additional `Condition` class which is a helper to quickly create the conditions without the need for `new SomeCondition`, this could look like this:

```php
use CmsIg\Seal\Search\Condition\Condition;

$result = $this->engine->createSearchBuilder('blog')
    ->addFilter(Condition::and(
        Condition::equal('tags', 'Tech'),
        Condition::or(
            Condition::equal('tags', 'UX'),
            Condition::equal('isSpecial', true),
        ),
    ))
    ->getResult();
```

The query builder would so still be PHP and static code analyzer like phpstan can validate most params, but without the force of every conditions being imported by itself.

## Todo

- [x] Add Condition class
- [x] Add Facet class
- [x] Update Tests
- [x] Update Documentation

---

fixes #481