### PR TITLE
Remove none found identifiers in reindex

### DIFF
--- a/packages/seal/src/Engine.php
+++ b/packages/seal/src/Engine.php
@@ -145,15 +145,22 @@ final class Engine implements EngineInterface
     ): void {
         /** @var array<string, ReindexProviderInterface[]> $reindexProvidersPerIndex */
         $reindexProvidersPerIndex = [];
+        /** @var array<string, string> $identifiersPerIndex */
+        $identifiersPerIndex = [];
         foreach ($reindexProviders as $reindexProvider) {
             if (!isset($this->schema->indexes[$reindexProvider::getIndex()])) {
                 continue;
             }
 
+            $identifiersPerIndex[$reindexProvider::getIndex()] = $this->schema->indexes[$reindexProvider::getIndex()]->getIdentifierField()->name;
+
             if ($reindexProvider::getIndex() === $reindexConfig->getIndex() || null === $reindexConfig->getIndex()) {
                 $reindexProvidersPerIndex[$reindexProvider::getIndex()][] = $reindexProvider;
             }
         }
+
+        // Track documents that need to be deleted if an identifiers array was given
+        $documentIdsToDelete = array_flip($reindexConfig->getIdentifiers());
 
         foreach ($reindexProvidersPerIndex as $index => $reindexProviders) {
             if ($reindexConfig->shouldDropIndex() && $this->existIndex($index)) {
@@ -169,13 +176,16 @@ final class Engine implements EngineInterface
             foreach ($reindexProviders as $reindexProvider) {
                 $this->bulk(
                     $index,
-                    (function () use ($index, $reindexProvider, $reindexConfig, $progressCallback) {
+                    (function () use ($index, $reindexProvider, $reindexConfig, $progressCallback, $documentIdsToDelete, $identifiersPerIndex) {
                         $count = 0;
                         $total = $reindexProvider->total();
 
                         $lastCount = -1;
                         foreach ($reindexProvider->provide($reindexConfig) as $document) {
                             ++$count;
+
+                            // Document still exists, do not delete
+                            unset($documentIdsToDelete[$document[$identifiersPerIndex[$index]]]);
 
                             yield $document;
 
@@ -197,6 +207,12 @@ final class Engine implements EngineInterface
                     $reindexConfig->getBulkSize(),
                 );
             }
+        }
+
+        if ([] !== $documentIdsToDelete) {
+            $index = $reindexConfig->getIndex();
+            \assert(null !== $index, 'Index must be set if identifiers are given in reindex config.');
+            $this->bulk($index, [], $documentIdsToDelete, $reindexConfig->getBulkSize());
         }
     }
 }

--- a/packages/seal/src/Engine.php
+++ b/packages/seal/src/Engine.php
@@ -121,7 +121,7 @@ final class Engine implements EngineInterface
             return null;
         }
 
-        return new MultiTask($tasks); // @phpstan-ignore-line
+        return new MultiTask($tasks);
     }
 
     public function dropSchema(array $options = []): TaskInterface|null
@@ -135,14 +135,20 @@ final class Engine implements EngineInterface
             return null;
         }
 
-        return new MultiTask($tasks); // @phpstan-ignore-line
+        return new MultiTask($tasks);
     }
 
+    /**
+     * TODO remove phpdoc when added to interface
+     *
+     * @param array{return_slow_promise_result?: true} $options
+     */
     public function reindex(
         iterable $reindexProviders,
         ReindexConfig $reindexConfig,
         callable|null $progressCallback = null,
-    ): void {
+        array $options = [],
+    ): TaskInterface|null {
         /** @var array<string, ReindexProviderInterface[]> $reindexProvidersPerIndex */
         $reindexProvidersPerIndex = [];
         /** @var array<string, string> $identifiersPerIndex */
@@ -162,6 +168,7 @@ final class Engine implements EngineInterface
         // Track documents that need to be deleted if an identifiers array was given
         $documentIdsToDelete = \array_flip($reindexConfig->getIdentifiers());
 
+        $tasks = [];
         foreach ($reindexProvidersPerIndex as $index => $reindexProviders) {
             if ($reindexConfig->shouldDropIndex() && $this->existIndex($index)) {
                 $task = $this->dropIndex($index, ['return_slow_promise_result' => true]);
@@ -174,7 +181,7 @@ final class Engine implements EngineInterface
             }
 
             foreach ($reindexProviders as $reindexProvider) {
-                $this->bulk(
+                $tasks[] = $this->bulk(
                     $index,
                     (function () use ($index, $reindexProvider, $reindexConfig, $progressCallback, &$documentIdsToDelete, $identifiersPerIndex) {
                         $count = 0;
@@ -205,6 +212,7 @@ final class Engine implements EngineInterface
                     })(),
                     [],
                     $reindexConfig->getBulkSize(),
+                    $options,
                 );
             }
         }
@@ -212,7 +220,13 @@ final class Engine implements EngineInterface
         if ([] !== $documentIdsToDelete) {
             $index = $reindexConfig->getIndex();
             \assert(null !== $index, 'Index must be set if identifiers are given in reindex config.');
-            $this->bulk($index, [], \array_keys($documentIdsToDelete), $reindexConfig->getBulkSize());
+            $tasks[] = $this->bulk($index, [], \array_keys($documentIdsToDelete), $reindexConfig->getBulkSize(), $options);
         }
+
+        if (!($options['return_slow_promise_result'] ?? false)) {
+            return null;
+        }
+
+        return new MultiTask($tasks); // @phpstan-ignore-line
     }
 }

--- a/packages/seal/src/Engine.php
+++ b/packages/seal/src/Engine.php
@@ -176,7 +176,7 @@ final class Engine implements EngineInterface
             foreach ($reindexProviders as $reindexProvider) {
                 $this->bulk(
                     $index,
-                    (function () use ($index, $reindexProvider, $reindexConfig, $progressCallback, $documentIdsToDelete, $identifiersPerIndex) {
+                    (function () use ($index, $reindexProvider, $reindexConfig, $progressCallback, &$documentIdsToDelete, $identifiersPerIndex) {
                         $count = 0;
                         $total = $reindexProvider->total();
 
@@ -212,7 +212,7 @@ final class Engine implements EngineInterface
         if ([] !== $documentIdsToDelete) {
             $index = $reindexConfig->getIndex();
             \assert(null !== $index, 'Index must be set if identifiers are given in reindex config.');
-            $this->bulk($index, [], $documentIdsToDelete, $reindexConfig->getBulkSize());
+            $this->bulk($index, [], \array_keys($documentIdsToDelete), $reindexConfig->getBulkSize());
         }
     }
 }

--- a/packages/seal/src/Engine.php
+++ b/packages/seal/src/Engine.php
@@ -160,7 +160,7 @@ final class Engine implements EngineInterface
         }
 
         // Track documents that need to be deleted if an identifiers array was given
-        $documentIdsToDelete = array_flip($reindexConfig->getIdentifiers());
+        $documentIdsToDelete = \array_flip($reindexConfig->getIdentifiers());
 
         foreach ($reindexProvidersPerIndex as $index => $reindexProviders) {
             if ($reindexConfig->shouldDropIndex() && $this->existIndex($index)) {

--- a/packages/seal/src/EngineInterface.php
+++ b/packages/seal/src/EngineInterface.php
@@ -73,14 +73,14 @@ interface EngineInterface
     public function existIndex(string $index): bool;
 
     /**
-     * @param array{return_slow_promise_result?: bool} $options
+     * @param array{return_slow_promise_result?: true} $options
      *
      * @return ($options is non-empty-array ? TaskInterface<null> : null)
      */
     public function createSchema(array $options = []): TaskInterface|null;
 
     /**
-     * @param array{return_slow_promise_result?: bool} $options
+     * @param array{return_slow_promise_result?: true} $options
      *
      * @return ($options is non-empty-array ? TaskInterface<null> : null)
      */
@@ -92,10 +92,16 @@ interface EngineInterface
      *
      * @param iterable<ReindexProviderInterface> $reindexProviders
      * @param callable(string, int, int|null): void|null $progressCallback
+     *
+     * TODO: native return type in next minor, major release.
+     *
+     * @phpstan-ignore-next-line
+     * @return ($options is non-empty-array ? TaskInterface<null> : null)
      */
     public function reindex(
         iterable $reindexProviders,
         ReindexConfig $reindexConfig,
         callable|null $progressCallback = null,
-    ): void;
+        /* array $options = [], */
+    );
 }

--- a/packages/seal/src/Testing/AbstractAdapterTestCase.php
+++ b/packages/seal/src/Testing/AbstractAdapterTestCase.php
@@ -170,7 +170,7 @@ abstract class AbstractAdapterTestCase extends TestCase
         ];
 
         $reindexProvider = $this->createReindexProvider($documents);
-        $engine->reindex([$reindexProvider], new ReindexConfig());
+        $engine->reindex([$reindexProvider], new ReindexConfig(), null, ['return_slow_promise_result' => true])->wait(); // @phpstan-ignore-line
 
         $expectedDocuments = [];
         foreach ($documents as $document) {
@@ -192,7 +192,7 @@ abstract class AbstractAdapterTestCase extends TestCase
                 $documents,
             ),
         );
-        $engine->reindex([$reindexProvider], $reindexConfig);
+        $engine->reindex([$reindexProvider], $reindexConfig, null, ['return_slow_promise_result' => true])->wait(); // @phpstan-ignore-line
 
         $exception = null;
         try {
@@ -204,6 +204,7 @@ abstract class AbstractAdapterTestCase extends TestCase
         $this->assertInstanceOf(DocumentNotFoundException::class, $exception);
 
         foreach ($expectedDocuments as $document) {
+            \assert(\is_string($document['uuid']), 'UUID is not a string');
             self::$taskHelper->tasks[] = $engine->deleteDocument(TestingHelper::INDEX_COMPLEX, $document['uuid'], ['return_slow_promise_result' => true]);
         }
 
@@ -235,6 +236,9 @@ abstract class AbstractAdapterTestCase extends TestCase
         self::$taskHelper->waitForAll();
     }
 
+    /**
+     * @param array<array<string, mixed>> $documents
+     */
     private function createReindexProvider(array $documents): ReindexProviderInterface
     {
         return new class($documents) implements ReindexProviderInterface {

--- a/packages/seal/src/Testing/AbstractAdapterTestCase.php
+++ b/packages/seal/src/Testing/AbstractAdapterTestCase.php
@@ -17,6 +17,8 @@ use CmsIg\Seal\Adapter\AdapterInterface;
 use CmsIg\Seal\Engine;
 use CmsIg\Seal\EngineInterface;
 use CmsIg\Seal\Exception\DocumentNotFoundException;
+use CmsIg\Seal\Reindex\ReindexConfig;
+use CmsIg\Seal\Reindex\ReindexProviderInterface;
 use CmsIg\Seal\Schema\Schema;
 use PHPUnit\Framework\TestCase;
 
@@ -151,6 +153,63 @@ abstract class AbstractAdapterTestCase extends TestCase
         }
     }
 
+    public function testReindex(): void
+    {
+        $engine = self::getEngine();
+        $task = self::getEngine()->createSchema(['return_slow_promise_result' => true]);
+        $task->wait();
+
+        $removedDocument = [
+            'uuid' => '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+            'title' => 'Removed Document',
+        ];
+
+        $documents = [
+            ...TestingHelper::createComplexFixtures(),
+            $removedDocument,
+        ];
+
+        $reindexProvider = $this->createReindexProvider($documents);
+        $engine->reindex([$reindexProvider], new ReindexConfig());
+
+        $expectedDocuments = [];
+        foreach ($documents as $document) {
+            $expectedDocuments[] = $engine->getDocument(TestingHelper::INDEX_COMPLEX, $document['uuid']);
+        }
+
+        unset($expectedDocuments[\count($expectedDocuments) - 1]);
+
+        $this->assertCount(
+            \count($documents) - 1,
+            $expectedDocuments,
+        );
+
+        $reindexProvider = $this->createReindexProvider($expectedDocuments);
+        $reindexConfig = (new ReindexConfig())
+            ->withIndex(TestingHelper::INDEX_COMPLEX)
+            ->withIdentifiers(\array_map(
+                fn ($document) => $document['uuid'],
+                $documents,
+            ),
+        );
+        $engine->reindex([$reindexProvider], $reindexConfig);
+
+        $exception = null;
+        try {
+            $engine->getDocument(TestingHelper::INDEX_COMPLEX, '3fa85f64-5717-4562-b3fc-2c963f66afa6');
+        } catch (\Exception $e) {
+            $exception = $e;
+        }
+
+        $this->assertInstanceOf(DocumentNotFoundException::class, $exception);
+
+        foreach ($expectedDocuments as $document) {
+            self::$taskHelper->tasks[] = $engine->deleteDocument(TestingHelper::INDEX_COMPLEX, $document['uuid'], ['return_slow_promise_result' => true]);
+        }
+
+        self::$taskHelper->waitForAll();
+    }
+
     public function testCountDocuments(): void
     {
         $engine = self::getEngine();
@@ -174,5 +233,36 @@ abstract class AbstractAdapterTestCase extends TestCase
         }
 
         self::$taskHelper->waitForAll();
+    }
+
+    private function createReindexProvider(array $documents): ReindexProviderInterface
+    {
+        return new class($documents) implements ReindexProviderInterface {
+            /**
+             * @param array<array<string, mixed>> $documents
+             */
+            public function __construct(private readonly array $documents)
+            {
+            }
+
+            public function total(): int
+            {
+                return 4;
+            }
+
+            public function provide(ReindexConfig $reindexConfig): \Generator
+            {
+                $documents = $this->documents;
+
+                foreach ($documents as $document) {
+                    yield $document;
+                }
+            }
+
+            public static function getIndex(): string
+            {
+                return TestingHelper::INDEX_COMPLEX;
+            }
+        };
     }
 }


### PR DESCRIPTION
To make removal easier the reindex will automatically remove document which where not provided by requested by the ReindexConfig. This make specially handling inside ORMs or Listeners on Add, Update, Remove a lot easier. As they just need to feel up identifiers. Thx goes to @Toflar who provided suggestion in #472.

fixes #472

### ToDo

 - [x] Add test case
 - [x] Reindex is async and requires in some cases return a task