### PR TITLE
Add support for JsonObjectField

### DIFF
--- a/docs/schema/index.rst
+++ b/docs/schema/index.rst
@@ -308,6 +308,44 @@ via ``sortable``, ``multiple`` and ``filterable`` flags.
 Complex Field Types
 -------------------
 
+JsonObjectField
+~~~~~~~~~~~~~~~
+
+The ``JsonObject`` field type is used to index json string object. Unlike the other field types it is
+**not** ``searchable``, ``filterable``, ``sortable`` and is just used to store additonal metadata.
+
+It is represented in PHP as an ``associative array``.
+
+Lets have a look at the following example field:
+
+.. code-block:: php
+
+    <?php
+
+    $document = [
+        // ...
+        "metadata" => [
+            "routeAttributes" => [
+                "site" => "intranet",
+            ],
+        ],
+    ];
+
+The following field definitions will show us how we can use ``JsonObject`` field to index the above field:
+
+.. code-block:: php
+
+    <?php
+
+    use CmsIg\Seal\Schema\Field;
+    use CmsIg\Seal\Schema\Index;
+
+    $index = new Index('blog', [
+        'metadata' => new Field\JsonObjectField('metadata'),
+    ]);
+
+This field type is ``experimental`` if you use it give feedback to `this Github Issue <https://github.com/PHP-CMSIG/search/issues/614>`_
+
 ObjectField
 ~~~~~~~~~~~
 
@@ -700,6 +738,11 @@ A whole complex example ``Index`` with different types of ``Fields`` for documen
         ],
         'tags' => ['Tech', 'UI'],
         'categoryIds' => [1, 2],
+        'metadata' => [
+            'routeAttributes' => [
+                'site' => 'intranet',
+            ],
+        ],
     ];
 
     $documentB = [
@@ -719,6 +762,11 @@ A whole complex example ``Index`` with different types of ``Fields`` for documen
         'comments' => [],
         'tags' => ['UI', 'UX'],
         'categoryIds' => [2, 3],
+        'metadata' => [
+            'routeAttributes' => [
+                'site' => 'intranet',
+            ],
+        ],
     ];
 
 Can be saved in an ``Index`` via the following ``Index`` and ``Field`` definitions:
@@ -765,6 +813,7 @@ Can be saved in an ``Index`` via the following ``Index`` and ``Field`` definitio
         ], multiple: true),
         'tags' => new Field\TextField('tags', multiple: true, filterable: true),
         'categoryIds' => new Field\IntegerField('categoryIds', multiple: true, filterable: true),
+        'metadata' => new Field\JsonObjectField('metadata'),
     ]);
 
 Best Practices
@@ -789,6 +838,7 @@ look like this:
         'url' => new Field\TextField('url'),
         'image' => new Field\IntegerField('image'),
         'content' => new Field\TextField('content', multiple: true),
+        'metadata' => new Field\JsonObjectField('metadata'),
     ]);
 
 Where the ``content`` field contains all relevant searchable texts. Optionally you maybe have some

--- a/packages/seal-elasticsearch-adapter/src/ElasticsearchSchemaManager.php
+++ b/packages/seal-elasticsearch-adapter/src/ElasticsearchSchemaManager.php
@@ -125,6 +125,11 @@ final class ElasticsearchSchemaManager implements SchemaManagerInterface
                     'type' => 'object',
                     'properties' => $this->createPropertiesMapping($field->fields),
                 ],
+                $field instanceof Field\JsonObjectField => $properties[$name] = [
+                    'type' => 'keyword',
+                    'index' => false,
+                    'doc_values' => false,
+                ],
                 $field instanceof Field\TypedField => $properties = \array_replace($properties, $this->createTypedFieldMapping($name, $field)),
                 default => throw new \RuntimeException(\sprintf('Field type "%s" is not supported.', $field::class)),
             };

--- a/packages/seal-elasticsearch-adapter/tests/ElasticsearchSchemaManagerTest.php
+++ b/packages/seal-elasticsearch-adapter/tests/ElasticsearchSchemaManagerTest.php
@@ -179,6 +179,11 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
                 'type' => 'geo_point',
                 'index' => false,
             ],
+            'metadata' => [
+                'type' => 'keyword',
+                'index' => false,
+                'doc_values' => false,
+            ],
             'rating' => [
                 'type' => 'float',
                 'index' => false,

--- a/packages/seal-opensearch-adapter/src/OpensearchSchemaManager.php
+++ b/packages/seal-opensearch-adapter/src/OpensearchSchemaManager.php
@@ -125,6 +125,11 @@ final class OpensearchSchemaManager implements SchemaManagerInterface
                     'type' => 'object',
                     'properties' => $this->createPropertiesMapping($field->fields),
                 ],
+                $field instanceof Field\JsonObjectField => $properties[$name] = [
+                    'type' => 'keyword',
+                    'index' => false,
+                    'doc_values' => false,
+                ],
                 $field instanceof Field\TypedField => $properties = \array_replace($properties, $this->createTypedFieldMapping($name, $field)),
                 default => throw new \RuntimeException(\sprintf('Field type "%s" is not supported.', $field::class)),
             };

--- a/packages/seal-opensearch-adapter/tests/OpensearchSchemaManagerTest.php
+++ b/packages/seal-opensearch-adapter/tests/OpensearchSchemaManagerTest.php
@@ -166,6 +166,11 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             'location' => [
                 'type' => 'geo_point',
             ],
+            'metadata' => [
+                'type' => 'keyword',
+                'index' => false,
+                'doc_values' => false,
+            ],
             'rating' => [
                 'type' => 'float',
             ],

--- a/packages/seal-redisearch-adapter/src/RediSearchSchemaManager.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchSchemaManager.php
@@ -176,6 +176,13 @@ final class RediSearchSchemaManager implements SchemaManagerInterface
                     'filterable' => $field->filterable || $field->facet, // @phpstan-ignore-line
                 ],
                 $field instanceof Field\ObjectField => $indexFields = \array_replace($indexFields, $this->createJsonFields($field->fields, $name, $jsonPath)),
+                $field instanceof Field\JsonObjectField => $indexFields[$name] = [
+                    'jsonPath' => $jsonPath,
+                    'type' => 'TEXT',
+                    'searchable' => false,
+                    'sortable' => false,
+                    'filterable' => false,
+                ],
                 $field instanceof Field\TypedField => \array_map(function ($fields, $type) use ($name, &$indexFields, $jsonPath, $field) {
                     $newJsonPath = $jsonPath . '[\'' . $type . '\']';
                     if ($field->multiple) {

--- a/packages/seal-solr-adapter/src/SolrSchemaManager.php
+++ b/packages/seal-solr-adapter/src/SolrSchemaManager.php
@@ -198,6 +198,15 @@ final class SolrSchemaManager implements SchemaManagerInterface
                     'multiValued' => $isMultiple,
                 ],
                 $field instanceof Field\ObjectField => $indexFields = \array_replace($indexFields, $this->createIndexFields($field->fields, $name . '.', $isMultiple)),
+                $field instanceof Field\JsonObjectField => $indexFields[$name] = [
+                    'name' => $name,
+                    'type' => 'string',
+                    'indexed' => false,
+                    'docValues' => false,
+                    'stored' => true,
+                    'useDocValuesAsStored' => false,
+                    'multiValued' => $isMultiple,
+                ],
                 $field instanceof Field\TypedField => \array_map(function ($fields, $type) use ($name, &$indexFields, $isMultiple) {
                     $indexFields = \array_replace($indexFields, $this->createIndexFields($fields, $name . '.' . $type . '.', $isMultiple));
 

--- a/packages/seal-typesense-adapter/src/TypesenseSchemaManager.php
+++ b/packages/seal-typesense-adapter/src/TypesenseSchemaManager.php
@@ -149,6 +149,14 @@ final class TypesenseSchemaManager implements SchemaManagerInterface
                     'facet' => $field->filterable || $field->facet, // @phpstan-ignore-line
                 ],
                 $field instanceof Field\ObjectField => $fields = [...$fields, ...$this->createObjectFields($name, $field)],
+                $field instanceof Field\JsonObjectField => $fields[] = [
+                    'name' => $name,
+                    'type' => $field->multiple ? 'string[]' : 'string',
+                    'optional' => true,
+                    'sort' => false,
+                    'index' => false,
+                    'facet' => false,
+                ],
                 $field instanceof Field\TypedField => $fields = [...$fields, ...$this->createTypedFields($name, $field)],
                 default => throw new \RuntimeException(\sprintf('Field type "%s" is not supported.', $field::class)),
             };

--- a/packages/seal-typesense-adapter/src/TypesenseSchemaManager.php
+++ b/packages/seal-typesense-adapter/src/TypesenseSchemaManager.php
@@ -142,7 +142,7 @@ final class TypesenseSchemaManager implements SchemaManagerInterface
                 ],
                 $field instanceof Field\GeoPointField => $fields[] = [
                     'name' => $name,
-                    'type' => $field->multiple ? 'geopoint[]' : 'geopoint',
+                    'type' => $field->multiple ? 'geopoint[]' : 'geopoint', // @phpstan-ignore-line
                     'optional' => true,
                     'sort' => $field->sortable,
                     'index' => $field->searchable || $field->filterable, // @phpstan-ignore-line
@@ -151,7 +151,7 @@ final class TypesenseSchemaManager implements SchemaManagerInterface
                 $field instanceof Field\ObjectField => $fields = [...$fields, ...$this->createObjectFields($name, $field)],
                 $field instanceof Field\JsonObjectField => $fields[] = [
                     'name' => $name,
-                    'type' => $field->multiple ? 'string[]' : 'string',
+                    'type' => $field->multiple ? 'string[]' : 'string', // @phpstan-ignore-line
                     'optional' => true,
                     'sort' => false,
                     'index' => false,

--- a/packages/seal/src/Engine.php
+++ b/packages/seal/src/Engine.php
@@ -139,7 +139,7 @@ final class Engine implements EngineInterface
     }
 
     /**
-     * TODO remove phpdoc when added to interface
+     * TODO remove phpdoc when added to interface.
      *
      * @param array{return_slow_promise_result?: true} $options
      */

--- a/packages/seal/src/EngineInterface.php
+++ b/packages/seal/src/EngineInterface.php
@@ -93,9 +93,10 @@ interface EngineInterface
      * @param iterable<ReindexProviderInterface> $reindexProviders
      * @param callable(string, int, int|null): void|null $progressCallback
      *
-     * TODO: native return type in next minor, major release.
+     * TODO: native return type in next minor, major release
      *
      * @phpstan-ignore-next-line
+     *
      * @return ($options is non-empty-array ? TaskInterface<null> : null)
      */
     public function reindex(

--- a/packages/seal/src/Marshaller/Marshaller.php
+++ b/packages/seal/src/Marshaller/Marshaller.php
@@ -83,7 +83,7 @@ final class Marshaller
      */
     private function marshallGeoPointField(array|null $value, Field\GeoPointField $field): array|string|null
     {
-        if ($field->multiple) {
+        if ($field->multiple) { // @phpstan-ignore-line
             throw new \LogicException('GeoPointField currently does not support multiple values.');
         }
 
@@ -174,11 +174,14 @@ final class Marshaller
      */
     private function marshallJsonObjectFields(array $document, Field\JsonObjectField $field): array|string
     {
-        if (!$field->multiple) {
+        /** @var bool $multiple */
+        $multiple = $field->multiple;
+
+        if (!$multiple) {
             return \json_encode($document, \JSON_THROW_ON_ERROR);
         }
 
-        /** @var array<array<string, mixed>> $rawDocuments */
+        /** @var array<string> $rawDocuments */
         $rawDocuments = [];
         /** @var array<string, mixed> $data */
         foreach ($document as $data) {
@@ -329,18 +332,31 @@ final class Marshaller
      *
      * @return array<string, mixed>|array<array<string, mixed>>
      */
-    private function unmarshallJsonObjectFields(string|array $raw, Field\JsonObjectField $field): array
+    private function unmarshallJsonObjectFields(string|array|null $raw, Field\JsonObjectField $field): array
     {
-        if (!$field->multiple) {
-            return \json_decode($raw, true, flags: \JSON_THROW_ON_ERROR);
+        /** @var bool $multiple */
+        $multiple = $field->multiple;
+
+        if (!$multiple) {
+            /** @var string $raw */
+            $json = \json_decode($raw, true, flags: \JSON_THROW_ON_ERROR);
+
+            /** @var array<string, mixed> */
+            return $json;
+        }
+
+        /** @var string[]|null $raw */
+        if (null === $raw) {
+            return [];
         }
 
         /** @var array<array<string, mixed>> $documentFields */
         $documentFields = [];
 
-        /** @var array<string, mixed> $data */
         foreach ($raw as $data) {
-            $documentFields[] = \json_decode($data, true, flags: \JSON_THROW_ON_ERROR);;
+            $json = \json_decode($data, true, flags: \JSON_THROW_ON_ERROR);
+
+            $documentFields[] = $json;
         }
 
         return $documentFields;
@@ -395,7 +411,7 @@ final class Marshaller
      */
     private function unmarshallGeoPointField(array $document, Field\GeoPointField $field): array|null
     {
-        if ($field->multiple) {
+        if ($field->multiple) { // @phpstan-ignore-line
             throw new \LogicException('GeoPointField currently does not support multiple values.');
         }
 

--- a/packages/seal/src/Marshaller/Marshaller.php
+++ b/packages/seal/src/Marshaller/Marshaller.php
@@ -59,6 +59,7 @@ final class Marshaller
 
             match (true) {
                 $field instanceof Field\ObjectField => $rawDocument[$name] = $this->marshallObjectFields($document[$field->name], $field), // @phpstan-ignore-line
+                $field instanceof Field\JsonObjectField => $rawDocument[$name] = $this->marshallJsonObjectFields($document[$field->name], $field), // @phpstan-ignore-line
                 $field instanceof Field\TypedField => $rawDocument = \array_replace($rawDocument, $this->marhsallTypedFields($name, $document[$field->name], $field)), // @phpstan-ignore-line
                 $field instanceof Field\DateTimeField => $rawDocument[$name] = $this->marshallDateTimeField($document[$field->name], $field), // @phpstan-ignore-line
                 $field instanceof Field\GeoPointField => $rawDocument[$this->geoPointFieldConfig['name'] ?? $name] = $this->marshallGeoPointField($document[$field->name], $field), // @phpstan-ignore-line
@@ -167,6 +168,27 @@ final class Marshaller
     }
 
     /**
+     * @param array<string, mixed>|array<array<string, mixed>> $document
+     *
+     * @return string|array<string>
+     */
+    private function marshallJsonObjectFields(array $document, Field\JsonObjectField $field): array|string
+    {
+        if (!$field->multiple) {
+            return \json_encode($document, \JSON_THROW_ON_ERROR);
+        }
+
+        /** @var array<array<string, mixed>> $rawDocuments */
+        $rawDocuments = [];
+        /** @var array<string, mixed> $data */
+        foreach ($document as $data) {
+            $rawDocuments[] = \json_encode($document, \JSON_THROW_ON_ERROR);
+        }
+
+        return $rawDocuments;
+    }
+
+    /**
      * @param array<string, mixed>|array<int, array<string, mixed>> $document
      *
      * @return array<string, mixed>
@@ -228,6 +250,7 @@ final class Marshaller
 
             match (true) {
                 $field instanceof Field\ObjectField => $document[$field->name] = $this->unmarshallObjectFields($raw[$name], $field), // @phpstan-ignore-line
+                $field instanceof Field\JsonObjectField => $document[$field->name] = $this->unmarshallJsonObjectFields($raw[$name], $field), // @phpstan-ignore-line
                 $field instanceof Field\TypedField => $document = \array_replace($document, $this->unmarshallTypedFields($name, $raw, $field)),
                 $field instanceof Field\DateTimeField => $document[$name] = $this->unmarshallDateTimeField($raw[$field->name], $field), // @phpstan-ignore-line
                 $field instanceof Field\GeoPointField => $document[$name] = $this->unmarshallGeoPointField($raw, $field),
@@ -296,6 +319,28 @@ final class Marshaller
         /** @var array<string, mixed> $data */
         foreach ($raw as $data) {
             $documentFields[] = $this->unmarshall($field->fields, $data);
+        }
+
+        return $documentFields;
+    }
+
+    /**
+     * @param string|string[] $raw
+     *
+     * @return array<string, mixed>|array<array<string, mixed>>
+     */
+    private function unmarshallJsonObjectFields(string|array $raw, Field\JsonObjectField $field): array
+    {
+        if (!$field->multiple) {
+            return \json_decode($raw, true, flags: \JSON_THROW_ON_ERROR);
+        }
+
+        /** @var array<array<string, mixed>> $documentFields */
+        $documentFields = [];
+
+        /** @var array<string, mixed> $data */
+        foreach ($raw as $data) {
+            $documentFields[] = \json_decode($data, true, flags: \JSON_THROW_ON_ERROR);;
         }
 
         return $documentFields;

--- a/packages/seal/src/Schema/Field/GeoPointField.php
+++ b/packages/seal/src/Schema/Field/GeoPointField.php
@@ -21,6 +21,7 @@ namespace CmsIg\Seal\Schema\Field;
  *
  * ATTENTION: Different search engines support only one field for geopoint per index.
  *
+ * @property false $multiple
  * @property false $searchable
  * @property false $facet
  *

--- a/packages/seal/src/Schema/Field/JsonObjectField.php
+++ b/packages/seal/src/Schema/Field/JsonObjectField.php
@@ -17,6 +17,13 @@ namespace CmsIg\Seal\Schema\Field;
  * @experimental This is an experimental feature and the API can change at any time.
  *               If you use it let us know and give feedback here: https://github.com/PHP-CMSIG/search/issues/614
  *
+ * @property false $multiple
+ * @property false $searchable
+ * @property false $filterable
+ * @property false $sortable
+ * @property false $facet
+ * @property false $distinct
+ *
  * @readonly
  *
  * Type to store unstructured JSON objects (array<string, mixed) for example for some metadata.
@@ -24,6 +31,7 @@ namespace CmsIg\Seal\Schema\Field;
 final class JsonObjectField extends AbstractField
 {
     /**
+     * @param false $multiple
      * @param array<string, mixed> $options
      */
     public function __construct(

--- a/packages/seal/src/Schema/Field/JsonObjectField.php
+++ b/packages/seal/src/Schema/Field/JsonObjectField.php
@@ -14,11 +14,14 @@ declare(strict_types=1);
 namespace CmsIg\Seal\Schema\Field;
 
 /**
+ * @experimental This is an experimental feature and the API can change at any time.
+ *               If you use it let us know and give feedback here: https://github.com/PHP-CMSIG/search/issues/614
+ *
  * @readonly
  *
- * Type to store any text, options can maybe use to specify it more specific.
+ * Type to store unstructured JSON objects (array<string, mixed) for example for some metadata.
  */
-final class TextField extends AbstractField
+final class JsonObjectField extends AbstractField
 {
     /**
      * @param array<string, mixed> $options
@@ -26,22 +29,17 @@ final class TextField extends AbstractField
     public function __construct(
         string $name,
         bool $multiple = false,
-        bool $searchable = true,
-        bool $filterable = false,
-        bool $sortable = false,
-        bool $distinct = false,
-        bool $facet = false,
         array $options = [],
     ) {
         parent::__construct(
             $name,
             $multiple,
-            $searchable,
-            $filterable,
-            $sortable,
-            $distinct,
-            $facet,
-            $options,
+            searchable: false,
+            filterable: false,
+            sortable: false,
+            distinct: false,
+            facet: false,
+            options: $options,
         );
     }
 }

--- a/packages/seal/src/Testing/AbstractAdapterTestCase.php
+++ b/packages/seal/src/Testing/AbstractAdapterTestCase.php
@@ -187,11 +187,12 @@ abstract class AbstractAdapterTestCase extends TestCase
         $reindexProvider = $this->createReindexProvider($expectedDocuments);
         $reindexConfig = (new ReindexConfig())
             ->withIndex(TestingHelper::INDEX_COMPLEX)
-            ->withIdentifiers(\array_map(
-                fn ($document) => $document['uuid'],
-                $documents,
-            ),
-        );
+            ->withIdentifiers(
+                \array_map(
+                    fn ($document) => $document['uuid'],
+                    $documents,
+                ),
+            );
         $engine->reindex([$reindexProvider], $reindexConfig, null, ['return_slow_promise_result' => true])->wait(); // @phpstan-ignore-line
 
         $exception = null;

--- a/packages/seal/src/Testing/TestingHelper.php
+++ b/packages/seal/src/Testing/TestingHelper.php
@@ -80,6 +80,7 @@ final class TestingHelper
             ], multiple: true),
             'tags' => new Field\TextField('tags', multiple: true, filterable: true, facet: true),
             'categoryIds' => new Field\IntegerField('categoryIds', multiple: true, filterable: true),
+            'metadata' => new Field\JsonObjectField('metadata'),
             'location' => new Field\GeoPointField('location', filterable: true, sortable: true),
         ];
 
@@ -122,6 +123,7 @@ final class TestingHelper
      *     }>|null,
      *     tags?: string[]|null,
      *     categoryIds?: int[]|null,
+     *     metadata?: array<string, mixed>,
      *     location?: array{
      *         latitude: float,
      *         longitude: float,
@@ -181,6 +183,11 @@ final class TestingHelper
                 ],
                 'tags' => ['Tech', 'UI'],
                 'categoryIds' => [1, 2],
+                'metadata' => [
+                    'routeAttributes' => [
+                        'site' => 'example',
+                    ],
+                ],
                 'location' => [
                     // New York
                     'latitude' => 40.7128,
@@ -204,6 +211,11 @@ final class TestingHelper
                 'isSpecial' => false,
                 'tags' => ['UI', 'UX'],
                 'categoryIds' => [2, 3],
+                'metadata' => [
+                    'routeAttributes' => [
+                        'site' => 'example',
+                    ],
+                ],
                 'location' => [
                     // London
                     'latitude' => 51.5074,

--- a/packages/seal/tests/Marshaller/FlattenMarshallerTest.php
+++ b/packages/seal/tests/Marshaller/FlattenMarshallerTest.php
@@ -119,6 +119,11 @@ class FlattenMarshallerTest extends TestCase
                 ],
                 'tags' => ['Tech', 'UI'],
                 'categoryIds' => [1, 2],
+                'metadata' => [
+                    'routeAttributes' => [
+                        'site' => 'example',
+                    ],
+                ],
                 'location' => [
                     'latitude' => 40.7128,
                     'longitude' => -74.006,
@@ -146,6 +151,7 @@ class FlattenMarshallerTest extends TestCase
                 'tags' => ['Tech', 'UI'],
                 'tags.raw' => ['Tech', 'UI'],
                 'categoryIds' => [1, 2],
+                'metadata' => '{"routeAttributes":{"site":"example"}}',
                 'location' => [
                     'latitude' => 40.7128,
                     'longitude' => -74.006,
@@ -187,6 +193,7 @@ class FlattenMarshallerTest extends TestCase
                 ], multiple: true),
                 'tags' => new Field\TextField('tags', multiple: true, filterable: true),
                 'categoryIds' => new Field\IntegerField('categoryIds', multiple: true, searchable: false, filterable: true),
+                'metadata' => new Field\JsonObjectField('metadata'),
                 'location' => new Field\GeoPointField('location', filterable: true, sortable: true),
             ],
         ];

--- a/packages/seal/tests/Marshaller/MarshallerTest.php
+++ b/packages/seal/tests/Marshaller/MarshallerTest.php
@@ -125,6 +125,7 @@ class MarshallerTest extends TestCase
             ],
             'tags' => ['Tech', 'UI'],
             'categoryIds' => [1, 2],
+            'metadata' => '{"routeAttributes":{"site":"example"}}',
             'location' => [
                 'latitude' => 40.7128,
                 'longitude' => -74.006,


### PR DESCRIPTION
This adds a new field type which is just here to store metadata in a json object (`array<string, mixed>`). This kind of data is not search, facet or filterable.

Usage:

```php
new Index('test', [
    'uuid' => new Field\IdentifierField('uuid'),
    'title' => new Field\TextField('title', sortable: true),
    'metadata' => new Field\JsonObjectField('metadata'),
]);
```

```php
$engine->saveDocument([
    'uuid' => $uuid,
    'title' => $title,
    'metadata' => [
        'routeAttributes' => [
            'site' => 'example',
        ],
    ],
]);
```

See https://github.com/PHP-CMSIG/search/issues/614

This feature is experimental and may change in future releases.