### PR TITLE
Use in integration tests also Opensearch 3

### DIFF
--- a/.examples/laravel/docker-compose.yml
+++ b/.examples/laravel/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - meilisearch-data:/data.ms
 
   opensearch:
-    image: opensearchproject/opensearch:2
+    image: opensearchproject/opensearch:3
     environment:
       discovery.type: single-node
       cluster.routing.allocation.disk.threshold_enabled: 'false'

--- a/.examples/mezzio/docker-compose.yml
+++ b/.examples/mezzio/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - meilisearch-data:/data.ms
 
   opensearch:
-    image: opensearchproject/opensearch:2
+    image: opensearchproject/opensearch:3
     environment:
       discovery.type: single-node
       cluster.routing.allocation.disk.threshold_enabled: 'false'

--- a/.examples/spiral/docker-compose.yml
+++ b/.examples/spiral/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - meilisearch-data:/data.ms
 
   opensearch:
-    image: opensearchproject/opensearch:2
+    image: opensearchproject/opensearch:3
     environment:
       discovery.type: single-node
       cluster.routing.allocation.disk.threshold_enabled: 'false'

--- a/.examples/symfony/docker-compose.yml
+++ b/.examples/symfony/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - meilisearch-data:/data.ms
 
   opensearch:
-    image: opensearchproject/opensearch:2
+    image: opensearchproject/opensearch:3
     environment:
       discovery.type: single-node
       cluster.routing.allocation.disk.threshold_enabled: 'false'

--- a/.examples/yii/docker-compose.yml
+++ b/.examples/yii/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - meilisearch-data:/data.ms
 
   opensearch:
-    image: opensearchproject/opensearch:2
+    image: opensearchproject/opensearch:3
     environment:
       discovery.type: single-node
       cluster.routing.allocation.disk.threshold_enabled: 'false'

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -236,7 +236,7 @@ search engine.
 
             services:
               opensearch:
-                image: opensearchproject/opensearch:2
+                image: opensearchproject/opensearch:3
                 environment:
                   discovery.type: single-node
                   cluster.routing.allocation.disk.threshold_enabled: 'false'


### PR DESCRIPTION
missed in: https://github.com/PHP-CMSIG/search/pull/530

Stumbled over this while I checked if we need update docker compose files for [Opensearch 3.4](https://github.com/opensearch-project/OpenSearch/releases/tag/3.4.0) and found out that we still had version 2 in some cases.