### PR TITLE
Mention rollerworks in alternative or similar projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,10 @@ Have also a look at the following tags:
 The following projects in the past target a similar problem:
 
 - [https://github.com/nresni/Ariadne](https://github.com/nresni/Ariadne) (Solr, Elasticsearch, Zendsearch: outdated 12 years ago)
-- [https://github.com/massiveart/MassiveSearchBundle](https://github.com/massiveart/MassiveSearchBundle) (ZendSearch, Elasticsearch)
-- [https://github.com/laravel/scout](https://github.com/laravel/scout) (Algolia, Meilisearch, Typesense)
-- [https://github.com/Mezcalito/ux-search/](https://github.com/Mezcalito/ux-search/) (Doctrine, Meilisearch, Algolia)
+- [https://github.com/massiveart/MassiveSearchBundle](https://github.com/massiveart/MassiveSearchBundle) (ZendSearch, Elasticsearch: for Symfony only and Lucene query syntax)
+- [https://github.com/laravel/scout](https://github.com/laravel/scout) (Algolia, Meilisearch, Typesense: for Laravel only)
+- [https://github.com/Mezcalito/ux-search/](https://github.com/Mezcalito/ux-search/) (Doctrine, Meilisearch, Algolia: Symfony UX focused)
+- [https://github.com/rollerworks/search](https://github.com/rollerworks/search) (Doctrine DBAL, Doctrine ORM, ElasticSearch: focused on Query building)
 
 ## 📩 Authors
 

--- a/docs/research/index.rst
+++ b/docs/research/index.rst
@@ -373,6 +373,7 @@ Similar Projects
 Following projects in the past target similar problem:
 
 - `https://github.com/nresni/Ariadne <https://github.com/nresni/Ariadne>`__  (Solr, Elasticsearch, Zendsearch: outdated 12 years ago)
-- `https://github.com/massiveart/MassiveSearchBundle <https://github.com/massiveart/MassiveSearchBundle>`__ (ZendSearch, Elasticsearch)
-- `https://github.com/laravel/scout <https://github.com/laravel/scout>`__  (Algolia, Meilisearch, Typesense)
-- `https://github.com/Mezcalito/ux-search/ <https://github.com/Mezcalito/ux-search/>`__  (Doctrine, Meilisearch, Algolia)
+- `https://github.com/massiveart/MassiveSearchBundle <https://github.com/massiveart/MassiveSearchBundle>`__ (ZendSearch, Elasticsearch: for Symfony only and Lucene query syntax)
+- `https://github.com/laravel/scout <https://github.com/laravel/scout>`__  (Algolia, Meilisearch, Typesense: for Laravel only)
+- `https://github.com/Mezcalito/ux-search/ <https://github.com/Mezcalito/ux-search/>`__  (Doctrine, Meilisearch, Algolia: Symfony UX focused)
+- `https://github.com/rollerworks/search <https://github.com/rollerworks/search/>`__  (Doctrine DBAL, Doctrine ORM, ElasticSearch: focused on Query building)


### PR DESCRIPTION
Why it is not directly focused on search engine or the index, reindex part of it or how even the data is put into the source. I think it still worth mentioning the project by @sstok also in the similar alternatives:

https://github.com/rollerworks/search

What could maybe be possible that somebody create a Rollerworks Extension supporting also [SEALs Search & Filters](https://php-cmsig.github.io/search/search-and-filters/index.html).

__Why even care about other projects?__

The idea did came up why first time I did read the README of [thephpleague/object-mapper](https://github.com/thephpleague/object-mapper?tab=readme-ov-file#alternatives). Who listed alternatives and think that is how Open Source should be, about sharing, cooperations and friendly coexisting. There exists always multiple solutions for the same problem and if there are such solutions we know we should share them with others.