### PR TITLE
Fix Elasticsearch Lexical Error in SearchCondition

### DIFF
--- a/packages/seal-algolia-adapter/tests/AlgoliaSchemaManagerTest.php
+++ b/packages/seal-algolia-adapter/tests/AlgoliaSchemaManagerTest.php
@@ -90,6 +90,7 @@ class AlgoliaSchemaManagerTest extends AbstractSchemaManagerTestCase
             'searchableAttributes' => [
                 'title',
                 'article',
+                'code',
                 'blocks.text.title',
                 'blocks.text.description',
                 'blocks.embed.title',

--- a/packages/seal-elasticsearch-adapter/src/ElasticsearchSearcher.php
+++ b/packages/seal-elasticsearch-adapter/src/ElasticsearchSearcher.php
@@ -243,7 +243,7 @@ final class ElasticsearchSearcher implements SearcherInterface
         foreach ($filters as $filter) {
             match (true) {
                 $filter instanceof Condition\IdentifierCondition => $filterQueries[]['ids']['values'][] = $filter->identifier, // @phpstan-ignore-line offsetAccess.nonOffsetAccessible
-                $filter instanceof Condition\SearchCondition => $filterQueries[]['multi_match']['query'] = $filter->query, // @phpstan-ignore-line offsetAccess.nonOffsetAccessible
+                $filter instanceof Condition\SearchCondition => $filterQueries[]['bool']['must']['multi_match']['query'] = $filter->query, // @phpstan-ignore-line offsetAccess.nonOffsetAccessible
                 $filter instanceof Condition\EqualCondition => $filterQueries[]['term'][$this->getFilterField($index, $filter->field)]['value'] = $filter->value, // @phpstan-ignore-line offsetAccess.nonOffsetAccessible
                 $filter instanceof Condition\NotEqualCondition => $filterQueries[]['bool']['must_not']['term'][$this->getFilterField($index, $filter->field)]['value'] = $filter->value, // @phpstan-ignore-line offsetAccess.nonOffsetAccessible
                 $filter instanceof Condition\GreaterThanCondition => $filterQueries[]['range'][$this->getFilterField($index, $filter->field)]['gt'] = $filter->value, // @phpstan-ignore-line offsetAccess.nonOffsetAccessible

--- a/packages/seal-elasticsearch-adapter/src/ElasticsearchSearcher.php
+++ b/packages/seal-elasticsearch-adapter/src/ElasticsearchSearcher.php
@@ -243,7 +243,7 @@ final class ElasticsearchSearcher implements SearcherInterface
         foreach ($filters as $filter) {
             match (true) {
                 $filter instanceof Condition\IdentifierCondition => $filterQueries[]['ids']['values'][] = $filter->identifier, // @phpstan-ignore-line offsetAccess.nonOffsetAccessible
-                $filter instanceof Condition\SearchCondition => $filterQueries[]['bool']['must']['query_string']['query'] = $filter->query, // @phpstan-ignore-line offsetAccess.nonOffsetAccessible
+                $filter instanceof Condition\SearchCondition => $filterQueries[]['multi_match']['query'] = $filter->query, // @phpstan-ignore-line offsetAccess.nonOffsetAccessible
                 $filter instanceof Condition\EqualCondition => $filterQueries[]['term'][$this->getFilterField($index, $filter->field)]['value'] = $filter->value, // @phpstan-ignore-line offsetAccess.nonOffsetAccessible
                 $filter instanceof Condition\NotEqualCondition => $filterQueries[]['bool']['must_not']['term'][$this->getFilterField($index, $filter->field)]['value'] = $filter->value, // @phpstan-ignore-line offsetAccess.nonOffsetAccessible
                 $filter instanceof Condition\GreaterThanCondition => $filterQueries[]['range'][$this->getFilterField($index, $filter->field)]['gt'] = $filter->value, // @phpstan-ignore-line offsetAccess.nonOffsetAccessible

--- a/packages/seal-elasticsearch-adapter/tests/ElasticsearchSchemaManagerTest.php
+++ b/packages/seal-elasticsearch-adapter/tests/ElasticsearchSchemaManagerTest.php
@@ -124,6 +124,9 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
                 'type' => 'integer',
                 'index' => false,
             ],
+            'code' => [
+                'type' => 'text',
+            ],
             'comments' => [
                 'properties' => [
                     'email' => [

--- a/packages/seal-memory-adapter/src/MemorySearcher.php
+++ b/packages/seal-memory-adapter/src/MemorySearcher.php
@@ -164,7 +164,8 @@ final class MemorySearcher implements SearcherInterface
                 $searchableDocument = $this->getSearchableDocument($index->fields, $document);
 
                 $text = \json_encode($searchableDocument, \JSON_THROW_ON_ERROR);
-                $terms = \explode(' ', $filter->query);
+                $query = preg_replace('#(/|"|\\\\)#', '\\\\$0', $filter->query);
+                $terms = \explode(' ', $query);
                 $searchTerms = \array_unique([...$searchTerms, ...$terms]);
 
                 $hasSomeMatch = false;

--- a/packages/seal-memory-adapter/src/MemorySearcher.php
+++ b/packages/seal-memory-adapter/src/MemorySearcher.php
@@ -164,7 +164,7 @@ final class MemorySearcher implements SearcherInterface
                 $searchableDocument = $this->getSearchableDocument($index->fields, $document);
 
                 $text = \json_encode($searchableDocument, \JSON_THROW_ON_ERROR);
-                $query = preg_replace('#(/|"|\\\\)#', '\\\\$0', $filter->query);
+                $query = \trim(\json_encode($filter->query, \JSON_THROW_ON_ERROR), '"');
                 $terms = \explode(' ', $query);
                 $searchTerms = \array_unique([...$searchTerms, ...$terms]);
 

--- a/packages/seal-opensearch-adapter/src/OpensearchSearcher.php
+++ b/packages/seal-opensearch-adapter/src/OpensearchSearcher.php
@@ -207,7 +207,7 @@ final class OpensearchSearcher implements SearcherInterface
         foreach ($filters as $filter) {
             match (true) {
                 $filter instanceof Condition\IdentifierCondition => $filterQueries[]['ids']['values'][] = $filter->identifier, // @phpstan-ignore-line offsetAccess.nonOffsetAccessible
-                $filter instanceof Condition\SearchCondition => $filterQueries[]['bool']['must']['query_string']['query'] = $filter->query, // @phpstan-ignore-line offsetAccess.nonOffsetAccessible
+                $filter instanceof Condition\SearchCondition => $filterQueries[]['multi_match']['query'] = $filter->query, // @phpstan-ignore-line offsetAccess.nonOffsetAccessible
                 $filter instanceof Condition\EqualCondition => $filterQueries[]['term'][$this->getFilterField($index, $filter->field)]['value'] = $filter->value, // @phpstan-ignore-line offsetAccess.nonOffsetAccessible
                 $filter instanceof Condition\NotEqualCondition => $filterQueries[]['bool']['must_not']['term'][$this->getFilterField($index, $filter->field)]['value'] = $filter->value, // @phpstan-ignore-line offsetAccess.nonOffsetAccessible
                 $filter instanceof Condition\GreaterThanCondition => $filterQueries[]['range'][$this->getFilterField($index, $filter->field)]['gt'] = $filter->value, // @phpstan-ignore-line offsetAccess.nonOffsetAccessible

--- a/packages/seal-opensearch-adapter/src/OpensearchSearcher.php
+++ b/packages/seal-opensearch-adapter/src/OpensearchSearcher.php
@@ -207,7 +207,7 @@ final class OpensearchSearcher implements SearcherInterface
         foreach ($filters as $filter) {
             match (true) {
                 $filter instanceof Condition\IdentifierCondition => $filterQueries[]['ids']['values'][] = $filter->identifier, // @phpstan-ignore-line offsetAccess.nonOffsetAccessible
-                $filter instanceof Condition\SearchCondition => $filterQueries[]['multi_match']['query'] = $filter->query, // @phpstan-ignore-line offsetAccess.nonOffsetAccessible
+                $filter instanceof Condition\SearchCondition => $filterQueries[]['bool']['must']['multi_match']['query'] = $filter->query, // @phpstan-ignore-line offsetAccess.nonOffsetAccessible
                 $filter instanceof Condition\EqualCondition => $filterQueries[]['term'][$this->getFilterField($index, $filter->field)]['value'] = $filter->value, // @phpstan-ignore-line offsetAccess.nonOffsetAccessible
                 $filter instanceof Condition\NotEqualCondition => $filterQueries[]['bool']['must_not']['term'][$this->getFilterField($index, $filter->field)]['value'] = $filter->value, // @phpstan-ignore-line offsetAccess.nonOffsetAccessible
                 $filter instanceof Condition\GreaterThanCondition => $filterQueries[]['range'][$this->getFilterField($index, $filter->field)]['gt'] = $filter->value, // @phpstan-ignore-line offsetAccess.nonOffsetAccessible

--- a/packages/seal-opensearch-adapter/tests/OpensearchSchemaManagerTest.php
+++ b/packages/seal-opensearch-adapter/tests/OpensearchSchemaManagerTest.php
@@ -168,7 +168,6 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             ],
             'location' => [
                 'type' => 'geo_point',
-                'index' => false,
             ],
             'metadata' => [
                 'type' => 'keyword',

--- a/packages/seal-opensearch-adapter/tests/OpensearchSchemaManagerTest.php
+++ b/packages/seal-opensearch-adapter/tests/OpensearchSchemaManagerTest.php
@@ -115,6 +115,9 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             'categoryIds' => [
                 'type' => 'integer',
             ],
+            'code' => [
+                'type' => 'text',
+            ],
             'comments' => [
                 'properties' => [
                     'email' => [
@@ -165,6 +168,7 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             ],
             'location' => [
                 'type' => 'geo_point',
+                'index' => false,
             ],
             'metadata' => [
                 'type' => 'keyword',

--- a/packages/seal/src/Testing/AbstractSearcherTestCase.php
+++ b/packages/seal/src/Testing/AbstractSearcherTestCase.php
@@ -370,6 +370,13 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $this->assertSame([$documents[2]], [...$search->getResult()]);
 
+
+        $search = new SearchBuilder($schema, self::$searcher);
+        $search->index(TestingHelper::INDEX_COMPLEX);
+        $search->addFilter(Condition::search('FARA25008/B'));
+
+        $this->assertSame([$documents[0]], [...$search->getResult()]);
+
         foreach ($documents as $document) {
             self::$taskHelper->tasks[] = self::$indexer->delete(
                 $schema->indexes[TestingHelper::INDEX_COMPLEX],

--- a/packages/seal/src/Testing/TestingHelper.php
+++ b/packages/seal/src/Testing/TestingHelper.php
@@ -154,6 +154,10 @@ final class TestingHelper
                         'title' => 'Title 2',
                     ],
                     [
+                        'type' => 'text',
+                        'title' => 'FARA25008/B',
+                    ],
+                    [
                         'type' => 'embed',
                         'title' => 'Video',
                         'media' => 'https://www.youtube.com/watch?v=iYM2zFP3Zn0',

--- a/packages/seal/src/Testing/TestingHelper.php
+++ b/packages/seal/src/Testing/TestingHelper.php
@@ -57,6 +57,7 @@ final class TestingHelper
                 ],
             ]),
             'article' => new Field\TextField('article'),
+            'code' => new Field\TextField('code'),
             'blocks' => new Field\TypedField('blocks', 'type', [
                 'text' => [
                     'title' => new Field\TextField('title'),
@@ -142,6 +143,7 @@ final class TestingHelper
                     'media' => 1,
                 ],
                 'article' => '<article><h2>New Subtitle</h2><p>A html field with some content</p></article>',
+                'code' => 'FARA25008/B',
                 'blocks' => [
                     [
                         'type' => 'text',
@@ -152,10 +154,6 @@ final class TestingHelper
                     [
                         'type' => 'text',
                         'title' => 'Title 2',
-                    ],
-                    [
-                        'type' => 'text',
-                        'title' => 'FARA25008/B',
                     ],
                     [
                         'type' => 'embed',
@@ -207,6 +205,7 @@ final class TestingHelper
                     'media' => 'https://www.youtube.com/watch?v=iYM2zFP3Zn0',
                 ],
                 'article' => '<article><h2>Other Subtitle</h2><p>A html field with some content</p></article>',
+                'code' => 'OSA20249/C',
                 'footer' => [
                     'title' => 'Other Footer',
                 ],

--- a/packages/seal/tests/Marshaller/MarshallerTest.php
+++ b/packages/seal/tests/Marshaller/MarshallerTest.php
@@ -79,6 +79,7 @@ class MarshallerTest extends TestCase
                 ],
             ],
             'article' => '<article><h2>New Subtitle</h2><p>A html field with some content</p></article>',
+            'code' => 'FARA25008/B',
             'blocks' => [
                 'text' => [
                     [


### PR DESCRIPTION
The elasticsearch adapter converts `SearchCondition` to `query_string` filter. This can be used for very powerful searches but is also very fragile. If the search functionality is presented to a user that doesn't know the search syntax and structure or is not aware that elasticsearch database is used this could lead to errors.

This PR switches from  `query_string` to `multi_match`. This will remove the powerful search provided by `query_string` but will also remove all errors that will be produced by the simple user. It also should most closely match the search functionality to all other adapters that doesn't have the same capabilities like the elasticsearch `query_string` filter.

[Specific characters](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-query-string-query#_reserved_characters) used by `query_string`
[Warning](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-query-string-query) to use `match` instead of `query_string` if the extra functionality is not required]
`multi_match` [docs](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-multi-match-query)