### PR TITLE
Add support for TLS with Typesense adapter

### DIFF
--- a/packages/seal-elasticsearch-adapter/src/ElasticsearchAdapterFactory.php
+++ b/packages/seal-elasticsearch-adapter/src/ElasticsearchAdapterFactory.php
@@ -64,7 +64,7 @@ class ElasticsearchAdapterFactory implements AdapterFactoryInterface
         \assert(\is_string($tlsQuery), 'The "tls" query param must be a string.');
         $useTls = \filter_var($tlsQuery, \FILTER_VALIDATE_BOOL, \FILTER_REQUIRE_SCALAR);
         $scheme = $useTls ? 'https' : 'http';
-        $port = $dsn['port'] ?? 9200;
+        $port = $dsn['port'] ?? ($useTls ? 443 : 9200);
 
         $client = ClientBuilder::create()->setHosts([
             $scheme . '://' . $dsn['host'] . ':' . $port,

--- a/packages/seal-typesense-adapter/README.md
+++ b/packages/seal-typesense-adapter/README.md
@@ -80,6 +80,13 @@ Via DSN for your favorite framework:
 typesense://S3CR3T@127.0.0.1:8108
 ```
 
+Or with TLS enabled (uses `https` and defaults to port `443`):
+
+```env
+typesense://S3CR3T@127.0.0.1?tls=true
+typesense://S3CR3T@127.0.0.1:443?tls=true
+```
+
 ## Authors
 
 - [Alexander Schranz](https://github.com/alexander-schranz/)

--- a/packages/seal-typesense-adapter/src/TypesenseAdapterFactory.php
+++ b/packages/seal-typesense-adapter/src/TypesenseAdapterFactory.php
@@ -44,6 +44,7 @@ class TypesenseAdapterFactory implements AdapterFactoryInterface
      *     host: string,
      *     port?: int,
      *     user?: string,
+     *     query: array<string, string>,
      * } $dsn
      */
     public function createClient(array $dsn): Client
@@ -58,14 +59,20 @@ class TypesenseAdapterFactory implements AdapterFactoryInterface
             return $client;
         }
 
+        $tlsQuery = $dsn['query']['tls'] ?? 'false';
+        \assert(\is_string($tlsQuery), 'The "tls" query param must be a string.');
+        $useTls = \filter_var($tlsQuery, \FILTER_VALIDATE_BOOL, \FILTER_REQUIRE_SCALAR);
+        $protocol = $useTls ? 'https' : 'http';
+        $port = $dsn['port'] ?? $useTls ? 443 : 8108;
+
         return new Client(
             [
                 'api_key' => $dsn['user'] ?? null,
                 'nodes' => [
                     [
                         'host' => $dsn['host'],
-                        'port' => $dsn['port'] ?? 8108,
-                        'protocol' => 'http',
+                        'port' => $port,
+                        'protocol' => $protocol,
                     ],
                 ],
                 'client' => $this->createClientClient(),

--- a/packages/seal-typesense-adapter/src/TypesenseAdapterFactory.php
+++ b/packages/seal-typesense-adapter/src/TypesenseAdapterFactory.php
@@ -44,7 +44,7 @@ class TypesenseAdapterFactory implements AdapterFactoryInterface
      *     host: string,
      *     port?: int,
      *     user?: string,
-     *     query: array<string, string>,
+     *     query: array<string, string|string[]>,
      * } $dsn
      */
     public function createClient(array $dsn): Client

--- a/packages/seal-typesense-adapter/src/TypesenseAdapterFactory.php
+++ b/packages/seal-typesense-adapter/src/TypesenseAdapterFactory.php
@@ -63,7 +63,7 @@ class TypesenseAdapterFactory implements AdapterFactoryInterface
         \assert(\is_string($tlsQuery), 'The "tls" query param must be a string.');
         $useTls = \filter_var($tlsQuery, \FILTER_VALIDATE_BOOL, \FILTER_REQUIRE_SCALAR);
         $protocol = $useTls ? 'https' : 'http';
-        $port = $dsn['port'] ?? $useTls ? 443 : 8108;
+        $port = $dsn['port'] ?? ($useTls ? 443 : 8108);
 
         return new Client(
             [


### PR DESCRIPTION
## Problem

The Typesense adapter currently only supports HTTP connections. This makes it
impossible to connect to any Typesense instance that requires HTTPS, such as:

- **Typesense Cloud** — which exclusively uses HTTPS on port 443
  (e.g., `xxx.a1.typesense.net:443`)
- **Self-hosted instances** behind a reverse proxy with SSL termination
  (e.g., Cloudflare Tunnel, Nginx with TLS, Traefik)

Without HTTPS support, users are unable to use SEAL with Typesense Cloud at all,
and self-hosted setups require insecure HTTP connections.

## Solution

Add support for a `tls=true` query parameter in the Typesense DSN to enable
HTTPS connections.

### Usage

## Solution

Add support for a `tls=true` query parameter in the Typesense DSN to enable
HTTPS connections.

### Usage

HTTP
SEAL_DSN="typesense://S3CR3T@127.0.0.1"

HTTPS
SEAL_DSN="typesense://S3CR3T@127.0.0.1?tls=true"
SEAL_DSN="typesense://S3CR3T@127.0.0.1:443?tls=true"

### Changes
- `TypesenseAdapterFactory`: Parse `tls` query parameter from DSN and set
  protocol to `https` when `tls=true`
- Updated documentation

### Backwards Compatible
Yes — existing `typesense://` DSN strings without `?tls=true` continue to
work unchanged with HTTP.