### PR TITLE
Add HTTPS support also for Opensearch, Solr, Redis Adapter and adopt Meilisearch TLS parsing

### DIFF
--- a/docs/cookbooks/create-own-adapter.rst
+++ b/docs/cookbooks/create-own-adapter.rst
@@ -254,6 +254,7 @@ integrations into Frameworks Dependency Injection container and constructing the
          *     port?: int,
          *     user?: string,
          *     pass?: string,
+         *     query: array<string, string|string[]>,
          * } $dsn
          */
         public function createClient(array $dsn): SearchClient
@@ -264,8 +265,12 @@ integrations into Frameworks Dependency Injection container and constructing the
                 return $client;
             }
 
+            $tlsQuery = $dsn['query']['tls'] ?? 'false';
+            $useTls = \filter_var($tlsQuery, \FILTER_VALIDATE_BOOL, \FILTER_REQUIRE_SCALAR);
+            $scheme = $useTls ? 'https' : 'http';
+
             $client = new Client(
-                $dsn['host'] . ':' . ($dsn['port'] ?? 9200),+
+                $scheme . '://' . $dsn['host'] . ':' . ($dsn['port'] ?? ($useTls ? 443 : 80)),
                 $dsn['user'] ?? '',
                 $pass = $dsn['pass'] ?? '',
             );

--- a/packages/seal-elasticsearch-adapter/README.md
+++ b/packages/seal-elasticsearch-adapter/README.md
@@ -72,6 +72,8 @@ Via DSN for your favorite framework:
 
 ```env
 elasticsearch://127.0.0.1:9200
+elasticsearch://127.0.0.1:9200?tls=true
+elasticsearch://username:password@127.0.0.1:9200?tls=true
 ```
 
 ## Authors

--- a/packages/seal-meilisearch-adapter/README.md
+++ b/packages/seal-meilisearch-adapter/README.md
@@ -65,6 +65,7 @@ Via DSN for your favorite framework:
 ```env
 meilisearch://127.0.0.1:7700
 meilisearch://apiKey@127.0.0.1:7700
+meilisearch://apiKey@127.0.0.1:7700?tls=true
 ```
 
 ## Authors

--- a/packages/seal-meilisearch-adapter/src/MeilisearchAdapterFactory.php
+++ b/packages/seal-meilisearch-adapter/src/MeilisearchAdapterFactory.php
@@ -58,10 +58,12 @@ class MeilisearchAdapterFactory implements AdapterFactoryInterface
         }
 
         $apiKey = $dsn['user'] ?? null;
-        $tls = $dsn['query']['tls'] ?? false;
+        $tlsQuery = $dsn['query']['tls'] ?? 'false';
+        \assert(\is_string($tlsQuery), 'The "tls" query param must be a string.');
+        $useTls = \filter_var($tlsQuery, \FILTER_VALIDATE_BOOL, \FILTER_REQUIRE_SCALAR);
 
         return new Client(
-            ($tls ? 'https' : 'http') . '://' . $dsn['host'] . ':' . ($dsn['port'] ?? 7700),
+            ($useTls ? 'https' : 'http') . '://' . $dsn['host'] . ':' . ($dsn['port'] ?? 7700),
             $apiKey,
         );
     }

--- a/packages/seal-opensearch-adapter/README.md
+++ b/packages/seal-opensearch-adapter/README.md
@@ -58,6 +58,8 @@ Via DSN for your favorite framework:
 
 ```env
 opensearch://127.0.0.1:9200
+opensearch://127.0.0.1:9200?tls=true
+opensearch://username:password@127.0.0.1:9200?tls=true
 ```
 
 ## Authors

--- a/packages/seal-opensearch-adapter/src/OpensearchAdapterFactory.php
+++ b/packages/seal-opensearch-adapter/src/OpensearchAdapterFactory.php
@@ -44,6 +44,7 @@ class OpensearchAdapterFactory implements AdapterFactoryInterface
      *     port?: int,
      *     user?: string,
      *     pass?: string,
+     *     query: array<string, string|string[]>,
      * } $dsn
      */
     public function createClient(array $dsn): Client
@@ -58,8 +59,14 @@ class OpensearchAdapterFactory implements AdapterFactoryInterface
             return $client;
         }
 
+        $tlsQuery = $dsn['query']['tls'] ?? 'false';
+        \assert(\is_string($tlsQuery), 'The "tls" query param must be a string.');
+        $useTls = \filter_var($tlsQuery, \FILTER_VALIDATE_BOOL, \FILTER_REQUIRE_SCALAR);
+        $scheme = $useTls ? 'https' : 'http';
+        $port = $dsn['port'] ?? ($useTls ? 443 : 9200);
+
         $client = ClientBuilder::create()->setHosts([
-            $dsn['host'] . ':' . ($dsn['port'] ?? 9200),
+            $scheme . '://' . $dsn['host'] . ':' . $port,
         ]);
 
         $user = $dsn['user'] ?? '';

--- a/packages/seal-redisearch-adapter/README.md
+++ b/packages/seal-redisearch-adapter/README.md
@@ -70,6 +70,7 @@ Via DSN for your favorite framework:
 redis://127.0.0.1:6379
 redis://supersecure@127.0.0.1:6379
 redis://phpredis:phpredis@127.0.0.1:6379
+redis://phpredis:phpredis@127.0.0.1:6380&tls=true
 ```
 
 The `ext-redis` and `ext-json` PHP extension is required for this adapter.

--- a/packages/seal-redisearch-adapter/src/RediSearchAdapterFactory.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchAdapterFactory.php
@@ -42,6 +42,7 @@ class RediSearchAdapterFactory implements AdapterFactoryInterface
      *     port?: int,
      *     user?: string,
      *     pass?: string,
+     *     query: array<string, string|string[]>,
      * } $dsn
      */
     public function createClient(array $dsn): \Redis
@@ -60,8 +61,14 @@ class RediSearchAdapterFactory implements AdapterFactoryInterface
         $password = $dsn['pass'] ?? '';
         $password = '' !== $password ? [$user, $password] : $user;
 
+        $tlsQuery = $dsn['query']['tls'] ?? 'false';
+        \assert(\is_string($tlsQuery), 'The "tls" query param must be a string.');
+        $useTls = \filter_var($tlsQuery, \FILTER_VALIDATE_BOOL, \FILTER_REQUIRE_SCALAR);
+        $port = $dsn['port'] ?? ($useTls ? 6380 : 6379);
+        $scheme = $useTls ? 'tls://' : '';
+
         $client = new \Redis();
-        $client->pconnect($dsn['host'], $dsn['port'] ?? 6379);
+        $client->pconnect($scheme . $dsn['host'], $port);
 
         if ($password) {
             $client->auth($password);

--- a/packages/seal-solr-adapter/README.md
+++ b/packages/seal-solr-adapter/README.md
@@ -57,6 +57,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 $client = new Client(new Curl(), new EventDispatcher(), [
     'endpoint' => [
         'localhost' => [
+            'scheme' => 'http',
             'host' => '127.0.0.1',
             'port' => '8983',
             // authenticated required for configset api https://solr.apache.org/guide/8_9/configsets-api.html
@@ -78,6 +79,7 @@ Via DSN for your favorite framework:
 ```env
 solr://127.0.0.1:8983
 solr://solr:SolrRocks@127.0.0.1:8983
+solr://solr:SolrRocks@127.0.0.1:8983?tls=true
 ```
 
 ## Authors

--- a/packages/seal-solr-adapter/src/SolrAdapterFactory.php
+++ b/packages/seal-solr-adapter/src/SolrAdapterFactory.php
@@ -51,6 +51,7 @@ class SolrAdapterFactory implements AdapterFactoryInterface
      *     port?: int,
      *     user?: string,
      *     pass?: string,
+     *     query: array<string, string|string[]>,
      * } $dsn
      */
     public function createClient(array $dsn): Client
@@ -65,13 +66,20 @@ class SolrAdapterFactory implements AdapterFactoryInterface
             return $client;
         }
 
+        $tlsQuery = $dsn['query']['tls'] ?? 'false';
+        \assert(\is_string($tlsQuery), 'The "tls" query param must be a string.');
+        $useTls = \filter_var($tlsQuery, \FILTER_VALIDATE_BOOL, \FILTER_REQUIRE_SCALAR);
+        $scheme = $useTls ? 'https' : 'http';
+        $port = $dsn['port'] ?? ($useTls ? 443 : 8983);
+
         $adapter = $this->createClientAdapter();
         $eventDispatcher = $this->createEventDispatcher();
         $options = [
             'endpoint' => [
                 'localhost' => \array_filter([
+                    'scheme' => $scheme,
                     'host' => $dsn['host'],
-                    'port' => $dsn['port'] ?? 8983,
+                    'port' => $port,
                     'username' => $dsn['user'] ?? null,
                     'password' => $dsn['pass'] ?? null,
                 ]),


### PR DESCRIPTION
Related to https://github.com/PHP-CMSIG/search/pull/651 and https://github.com/PHP-CMSIG/search/pull/649 part of https://github.com/PHP-CMSIG/search/issues/638

Add support for `?tls=true` to the different adapters.