### PR TITLE
Add possibility for reusable ReindexProvider classes (BC Break ⚠️) 

### DIFF
--- a/.examples/laravel/app/Search/BlogReindexProvider.php
+++ b/.examples/laravel/app/Search/BlogReindexProvider.php
@@ -35,7 +35,7 @@ class BlogReindexProvider implements ReindexProviderInterface
         ];
     }
 
-    public static function getIndex(): string
+    public function getIndex(): string
     {
         return 'blog';
     }

--- a/.examples/mezzio/src/App/src/Search/BlogReindexProvider.php
+++ b/.examples/mezzio/src/App/src/Search/BlogReindexProvider.php
@@ -35,7 +35,7 @@ class BlogReindexProvider implements ReindexProviderInterface
         ];
     }
 
-    public static function getIndex(): string
+    public function getIndex(): string
     {
         return 'blog';
     }

--- a/.examples/spiral/app/src/Search/BlogReindexProvider.php
+++ b/.examples/spiral/app/src/Search/BlogReindexProvider.php
@@ -35,7 +35,7 @@ class BlogReindexProvider implements ReindexProviderInterface
         ];
     }
 
-    public static function getIndex(): string
+    public function getIndex(): string
     {
         return 'blog';
     }

--- a/.examples/symfony/src/Search/BlogReindexProvider.php
+++ b/.examples/symfony/src/Search/BlogReindexProvider.php
@@ -35,7 +35,7 @@ class BlogReindexProvider implements ReindexProviderInterface
         ];
     }
 
-    public static function getIndex(): string
+    public function getIndex(): string
     {
         return 'blog';
     }

--- a/.examples/yii/src/Shared/Search/BlogReindexProvider.php
+++ b/.examples/yii/src/Shared/Search/BlogReindexProvider.php
@@ -35,7 +35,7 @@ class BlogReindexProvider implements ReindexProviderInterface
         ];
     }
 
-    public static function getIndex(): string
+    public function getIndex(): string
     {
         return 'blog';
     }

--- a/docs/cookbooks/orm-examples.rst
+++ b/docs/cookbooks/orm-examples.rst
@@ -29,7 +29,7 @@ At first, a ``ReindexProvider`` is required for the newly created index.
         public function __construct(private BlogRepository $entityRepository)
         {}
 
-        public static function getIndex(): string
+        public function getIndex(): string
         {
             return 'blog';
         }

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -2025,7 +2025,7 @@ First you need to create a ``ReindexProvider`` providing all your documents.
             ];
         }
 
-        public static function getIndex(): string
+        public function getIndex(): string
         {
             return 'blog';
         }

--- a/docs/indexing/index.rst
+++ b/docs/indexing/index.rst
@@ -93,7 +93,7 @@ the ``ReindexProviderInterface`` and provides the documents for your index.
             ];
         }
 
-        public static function getIndex(): string
+        public function getIndex(): string
         {
             return 'blog';
         }

--- a/packages/seal/src/Reindex/ReindexProviderInterface.php
+++ b/packages/seal/src/Reindex/ReindexProviderInterface.php
@@ -30,5 +30,5 @@ interface ReindexProviderInterface
     /**
      * The name of the index for which the documents are for.
      */
-    public static function getIndex(): string;
+    public function getIndex(): string;
 }

--- a/packages/seal/src/Testing/AbstractAdapterTestCase.php
+++ b/packages/seal/src/Testing/AbstractAdapterTestCase.php
@@ -264,7 +264,7 @@ abstract class AbstractAdapterTestCase extends TestCase
                 }
             }
 
-            public static function getIndex(): string
+            public function getIndex(): string
             {
                 return TestingHelper::INDEX_COMPLEX;
             }


### PR DESCRIPTION
Currently it is not possible to create a reusable ReindexProvider as all ReindexProviders require to implement a static method `public static function getIndex(): string` we should get rid of them so a people can ReindexProviders which are reusable and just configurable by there constructor.


## BC Breaks

The `ReindexProviderInterface` and `getIndex` method is not longer static:

```diff
class YourClass implements ReindexProviderInterface {
    // ...
    
-   public static function getIndex(): string
+   public function getIndex(): string
    {
        return 'test';
    }
}
```