### PR TITLE
Build docs only against 0.12 branch

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -3,7 +3,7 @@ name: Docs Deploy
 on:
     push:
         branches:
-            - '[0-9]+.[0-9]+'
+            - '0.12'
     workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
As we prepare the next minor release docs should still show the current 0.12 version.