### PR TITLE
Add possibility for reusable ReindexProvider classes (BC Break ⚠️)

### DIFF
--- a/.examples/laravel/app/Search/BlogReindexProvider.php
+++ b/.examples/laravel/app/Search/BlogReindexProvider.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace App\Search;
 
 use CmsIg\Seal\Reindex\ReindexConfig;
-use CmsIg\Seal\Reindex\ReindexProviderInterface;
+use CmsIg\Seal\Reindex\StaticReindexProviderInterface;
 
-class BlogReindexProvider implements ReindexProviderInterface
+class BlogReindexProvider implements StaticReindexProviderInterface
 {
     public function total(): int|null
     {

--- a/.examples/laravel/app/Search/BlogReindexProvider.php
+++ b/.examples/laravel/app/Search/BlogReindexProvider.php
@@ -35,7 +35,7 @@ class BlogReindexProvider implements ReindexProviderInterface
         ];
     }
 
-    public function getIndex(): string
+    public function getIndexName(): string
     {
         return 'blog';
     }

--- a/.examples/laravel/app/Search/BlogReindexProvider.php
+++ b/.examples/laravel/app/Search/BlogReindexProvider.php
@@ -35,7 +35,7 @@ class BlogReindexProvider implements ReindexProviderInterface
         ];
     }
 
-    public static function getIndex(): string
+    public function getIndex(): string
     {
         return 'blog';
     }

--- a/.examples/mezzio/src/App/src/Search/BlogReindexProvider.php
+++ b/.examples/mezzio/src/App/src/Search/BlogReindexProvider.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace App\Search;
 
 use CmsIg\Seal\Reindex\ReindexConfig;
-use CmsIg\Seal\Reindex\ReindexProviderInterface;
+use CmsIg\Seal\Reindex\StaticReindexProviderInterface;
 
-class BlogReindexProvider implements ReindexProviderInterface
+class BlogReindexProvider implements StaticReindexProviderInterface
 {
     public function total(): int|null
     {

--- a/.examples/mezzio/src/App/src/Search/BlogReindexProvider.php
+++ b/.examples/mezzio/src/App/src/Search/BlogReindexProvider.php
@@ -35,7 +35,7 @@ class BlogReindexProvider implements ReindexProviderInterface
         ];
     }
 
-    public function getIndex(): string
+    public function getIndexName(): string
     {
         return 'blog';
     }

--- a/.examples/mezzio/src/App/src/Search/BlogReindexProvider.php
+++ b/.examples/mezzio/src/App/src/Search/BlogReindexProvider.php
@@ -35,7 +35,7 @@ class BlogReindexProvider implements ReindexProviderInterface
         ];
     }
 
-    public static function getIndex(): string
+    public function getIndex(): string
     {
         return 'blog';
     }

--- a/.examples/spiral/app/src/Search/BlogReindexProvider.php
+++ b/.examples/spiral/app/src/Search/BlogReindexProvider.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace App\Search;
 
 use CmsIg\Seal\Reindex\ReindexConfig;
-use CmsIg\Seal\Reindex\ReindexProviderInterface;
+use CmsIg\Seal\Reindex\StaticReindexProviderInterface;
 
-class BlogReindexProvider implements ReindexProviderInterface
+class BlogReindexProvider implements StaticReindexProviderInterface
 {
     public function total(): int|null
     {

--- a/.examples/spiral/app/src/Search/BlogReindexProvider.php
+++ b/.examples/spiral/app/src/Search/BlogReindexProvider.php
@@ -35,7 +35,7 @@ class BlogReindexProvider implements ReindexProviderInterface
         ];
     }
 
-    public function getIndex(): string
+    public function getIndexName(): string
     {
         return 'blog';
     }

--- a/.examples/spiral/app/src/Search/BlogReindexProvider.php
+++ b/.examples/spiral/app/src/Search/BlogReindexProvider.php
@@ -35,7 +35,7 @@ class BlogReindexProvider implements ReindexProviderInterface
         ];
     }
 
-    public static function getIndex(): string
+    public function getIndex(): string
     {
         return 'blog';
     }

--- a/.examples/symfony/src/Search/BlogReindexProvider.php
+++ b/.examples/symfony/src/Search/BlogReindexProvider.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace App\Search;
 
 use CmsIg\Seal\Reindex\ReindexConfig;
-use CmsIg\Seal\Reindex\ReindexProviderInterface;
+use CmsIg\Seal\Reindex\StaticReindexProviderInterface;
 
-class BlogReindexProvider implements ReindexProviderInterface
+class BlogReindexProvider implements StaticReindexProviderInterface
 {
     public function total(): int|null
     {

--- a/.examples/symfony/src/Search/BlogReindexProvider.php
+++ b/.examples/symfony/src/Search/BlogReindexProvider.php
@@ -35,7 +35,7 @@ class BlogReindexProvider implements ReindexProviderInterface
         ];
     }
 
-    public function getIndex(): string
+    public function getIndexName(): string
     {
         return 'blog';
     }

--- a/.examples/symfony/src/Search/BlogReindexProvider.php
+++ b/.examples/symfony/src/Search/BlogReindexProvider.php
@@ -35,7 +35,7 @@ class BlogReindexProvider implements ReindexProviderInterface
         ];
     }
 
-    public static function getIndex(): string
+    public function getIndex(): string
     {
         return 'blog';
     }

--- a/.examples/yii/src/Shared/Search/BlogReindexProvider.php
+++ b/.examples/yii/src/Shared/Search/BlogReindexProvider.php
@@ -35,7 +35,7 @@ class BlogReindexProvider implements ReindexProviderInterface
         ];
     }
 
-    public function getIndex(): string
+    public function getIndexName(): string
     {
         return 'blog';
     }

--- a/.examples/yii/src/Shared/Search/BlogReindexProvider.php
+++ b/.examples/yii/src/Shared/Search/BlogReindexProvider.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace App\Shared\Search;
 
 use CmsIg\Seal\Reindex\ReindexConfig;
-use CmsIg\Seal\Reindex\ReindexProviderInterface;
+use CmsIg\Seal\Reindex\StaticReindexProviderInterface;
 
-class BlogReindexProvider implements ReindexProviderInterface
+class BlogReindexProvider implements StaticReindexProviderInterface
 {
     public function total(): int|null
     {

--- a/.examples/yii/src/Shared/Search/BlogReindexProvider.php
+++ b/.examples/yii/src/Shared/Search/BlogReindexProvider.php
@@ -35,7 +35,7 @@ class BlogReindexProvider implements ReindexProviderInterface
         ];
     }
 
-    public static function getIndex(): string
+    public function getIndex(): string
     {
         return 'blog';
     }

--- a/docs/cookbooks/orm-examples.rst
+++ b/docs/cookbooks/orm-examples.rst
@@ -29,7 +29,7 @@ At first, a ``ReindexProvider`` is required for the newly created index.
         public function __construct(private BlogRepository $entityRepository)
         {}
 
-        public static function getIndex(): string
+        public function getIndex(): string
         {
             return 'blog';
         }

--- a/docs/cookbooks/orm-examples.rst
+++ b/docs/cookbooks/orm-examples.rst
@@ -29,7 +29,7 @@ At first, a ``ReindexProvider`` is required for the newly created index.
         public function __construct(private BlogRepository $entityRepository)
         {}
 
-        public function getIndex(): string
+        public function getIndexName(): string
         {
             return 'blog';
         }

--- a/docs/cookbooks/orm-examples.rst
+++ b/docs/cookbooks/orm-examples.rst
@@ -24,7 +24,7 @@ At first, a ``ReindexProvider`` is required for the newly created index.
 
     <?php
 
-    class BlogReindexProvider implements ReindexProviderInterface
+    class BlogReindexProvider implements StaticReindexProviderInterface
     {
         public function __construct(private BlogRepository $entityRepository)
         {}

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -2011,7 +2011,7 @@ First you need to create a ``ReindexProvider`` providing all your documents.
             ];
         }
 
-        public static function getIndex(): string
+        public function getIndex(): string
         {
             return 'blog';
         }

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -1986,7 +1986,7 @@ First you need to create a ``ReindexProvider`` providing all your documents.
 
     <?php
 
-    class BlogReindexProvider implements ReindexProviderInterface
+    class BlogReindexProvider implements StaticReindexProviderInterface
     {
         public function total(): ?int
         {

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -2011,7 +2011,7 @@ First you need to create a ``ReindexProvider`` providing all your documents.
             ];
         }
 
-        public function getIndex(): string
+        public function getIndexName(): string
         {
             return 'blog';
         }

--- a/docs/indexing/index.rst
+++ b/docs/indexing/index.rst
@@ -93,7 +93,7 @@ the ``ReindexProviderInterface`` and provides the documents for your index.
             ];
         }
 
-        public static function getIndex(): string
+        public function getIndex(): string
         {
             return 'blog';
         }

--- a/docs/indexing/index.rst
+++ b/docs/indexing/index.rst
@@ -93,7 +93,7 @@ the ``ReindexProviderInterface`` and provides the documents for your index.
             ];
         }
 
-        public function getIndex(): string
+        public function getIndexName(): string
         {
             return 'blog';
         }

--- a/docs/indexing/index.rst
+++ b/docs/indexing/index.rst
@@ -56,13 +56,13 @@ Reindex operations
 
 To reindex documents it is required to create atleast one ReindexProvider for
 the index you want to reindex. The ReindexProvider is a class which implements
-the ``ReindexProviderInterface`` and provides the documents for your index.
+the ``StaticReindexProviderInterface`` and provides the documents for your index.
 
 .. code-block:: php
 
     <?php
 
-    class BlogReindexProvider implements ReindexProviderInterface
+    class BlogReindexProvider implements StaticReindexProviderInterface
     {
         public function total(): ?int
         {

--- a/integrations/laravel/src/Console/ReindexCommand.php
+++ b/integrations/laravel/src/Console/ReindexCommand.php
@@ -15,7 +15,7 @@ namespace CmsIg\Seal\Integration\Laravel\Console;
 
 use CmsIg\Seal\EngineRegistry;
 use CmsIg\Seal\Reindex\ReindexConfig;
-use CmsIg\Seal\Reindex\ReindexProviderInterface;
+use CmsIg\Seal\Reindex\StaticReindexProviderInterface;
 use Illuminate\Console\Command;
 
 /**
@@ -38,7 +38,7 @@ final class ReindexCommand extends Command
     protected $description = 'Reindex configured search indexes.';
 
     /**
-     * @param iterable<ReindexProviderInterface> $reindexProviders
+     * @param iterable<StaticReindexProviderInterface> $reindexProviders
      */
     public function __construct(
         private readonly iterable $reindexProviders, // TODO move to handle method: https://discord.com/channels/297040613688475649/1105593000664498336

--- a/integrations/laravel/src/Facade/Engine.php
+++ b/integrations/laravel/src/Facade/Engine.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace CmsIg\Seal\Integration\Laravel\Facade;
 
 use CmsIg\Seal\EngineInterface;
-use CmsIg\Seal\Reindex\ReindexProviderInterface;
+use CmsIg\Seal\Reindex\StaticReindexProviderInterface;
 use CmsIg\Seal\Search\SearchBuilder;
 use Illuminate\Support\Facades\Facade;
 
@@ -28,7 +28,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static bool existIndex(string $index)
  * @method static void createSchema()
  * @method static void dropSchema()
- * @method static void reindex(iterable<ReindexProviderInterface> $reindexProviders, string|null $index = null, bool $dropIndex = false, callable $progressCallback = null)
+ * @method static void reindex(iterable<StaticReindexProviderInterface> $reindexProviders, string|null $index = null, bool $dropIndex = false, callable $progressCallback = null)
  *
  * @see \CmsIg\Seal\EngineInterface
  */

--- a/integrations/mezzio/src/Command/ReindexCommand.php
+++ b/integrations/mezzio/src/Command/ReindexCommand.php
@@ -15,7 +15,7 @@ namespace CmsIg\Seal\Integration\Mezzio\Command;
 
 use CmsIg\Seal\EngineRegistry;
 use CmsIg\Seal\Reindex\ReindexConfig;
-use CmsIg\Seal\Reindex\ReindexProviderInterface;
+use CmsIg\Seal\Reindex\StaticReindexProviderInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -28,7 +28,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 final class ReindexCommand extends Command
 {
     /**
-     * @param iterable<ReindexProviderInterface> $reindexProviders
+     * @param iterable<StaticReindexProviderInterface> $reindexProviders
      */
     public function __construct(
         private readonly EngineRegistry $engineRegistry,

--- a/integrations/mezzio/src/Service/CommandAbstractFactory.php
+++ b/integrations/mezzio/src/Service/CommandAbstractFactory.php
@@ -15,7 +15,7 @@ namespace CmsIg\Seal\Integration\Mezzio\Service;
 
 use CmsIg\Seal\EngineRegistry;
 use CmsIg\Seal\Integration\Mezzio\Command\ReindexCommand;
-use CmsIg\Seal\Reindex\ReindexProviderInterface;
+use CmsIg\Seal\Reindex\StaticReindexProviderInterface;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -43,11 +43,11 @@ final class CommandAbstractFactory
             foreach ($reindexProviderNames as $reindexProviderName) {
                 $reindexProvider = $container->get($reindexProviderName);
 
-                if (!$reindexProvider instanceof ReindexProviderInterface) {
+                if (!$reindexProvider instanceof StaticReindexProviderInterface) {
                     throw new \RuntimeException(\sprintf(
                         'Reindex provider "%s" does not implement "%s".',
                         $reindexProviderName,
-                        ReindexProviderInterface::class,
+                        StaticReindexProviderInterface::class,
                     ));
                 }
 

--- a/integrations/spiral/src/Bootloader/SealBootloader.php
+++ b/integrations/spiral/src/Bootloader/SealBootloader.php
@@ -34,7 +34,7 @@ use CmsIg\Seal\Integration\Spiral\Config\SealConfig;
 use CmsIg\Seal\Integration\Spiral\Console\IndexCreateCommand;
 use CmsIg\Seal\Integration\Spiral\Console\IndexDropCommand;
 use CmsIg\Seal\Integration\Spiral\Console\ReindexCommand;
-use CmsIg\Seal\Reindex\ReindexProviderInterface;
+use CmsIg\Seal\Reindex\StaticReindexProviderInterface;
 use CmsIg\Seal\Schema\Loader\LoaderInterface;
 use CmsIg\Seal\Schema\Loader\PhpFileLoader;
 use CmsIg\Seal\Schema\Schema;
@@ -182,11 +182,11 @@ final class SealBootloader extends Bootloader
                 foreach ($reindexProviderNames as $reindexProviderName) {
                     $reindexProvider = $container->get($reindexProviderName);
 
-                    if (!$reindexProvider instanceof ReindexProviderInterface) {
+                    if (!$reindexProvider instanceof StaticReindexProviderInterface) {
                         throw new \RuntimeException(\sprintf(
                             'Reindex provider "%s" does not implement "%s".',
                             $reindexProviderName,
-                            ReindexProviderInterface::class,
+                            StaticReindexProviderInterface::class,
                         ));
                     }
 

--- a/integrations/spiral/src/Console/ReindexCommand.php
+++ b/integrations/spiral/src/Console/ReindexCommand.php
@@ -15,7 +15,7 @@ namespace CmsIg\Seal\Integration\Spiral\Console;
 
 use CmsIg\Seal\EngineRegistry;
 use CmsIg\Seal\Reindex\ReindexConfig;
-use CmsIg\Seal\Reindex\ReindexProviderInterface;
+use CmsIg\Seal\Reindex\StaticReindexProviderInterface;
 use Spiral\Console\Attribute\AsCommand;
 use Spiral\Console\Attribute\Option;
 use Spiral\Console\Command;
@@ -49,7 +49,7 @@ final class ReindexCommand extends Command
     private string|null $identifiers = null; // @phpstan-ignore-line property.unusedType
 
     /**
-     * @param iterable<ReindexProviderInterface> $reindexProviders
+     * @param iterable<StaticReindexProviderInterface> $reindexProviders
      */
     public function __construct(
         private readonly iterable $reindexProviders, // TODO move to __invoke method

--- a/integrations/symfony/src/Command/ReindexCommand.php
+++ b/integrations/symfony/src/Command/ReindexCommand.php
@@ -15,7 +15,7 @@ namespace CmsIg\Seal\Integration\Symfony\Command;
 
 use CmsIg\Seal\EngineRegistry;
 use CmsIg\Seal\Reindex\ReindexConfig;
-use CmsIg\Seal\Reindex\ReindexProviderInterface;
+use CmsIg\Seal\Reindex\StaticReindexProviderInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -30,7 +30,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 final class ReindexCommand extends Command
 {
     /**
-     * @param iterable<ReindexProviderInterface> $reindexProviders
+     * @param iterable<StaticReindexProviderInterface> $reindexProviders
      */
     public function __construct(
         private readonly EngineRegistry $engineRegistry,

--- a/integrations/symfony/src/SealBundle.php
+++ b/integrations/symfony/src/SealBundle.php
@@ -18,7 +18,7 @@ use CmsIg\Seal\Adapter\Multi\MultiAdapterFactory;
 use CmsIg\Seal\Adapter\ReadWrite\ReadWriteAdapterFactory;
 use CmsIg\Seal\Engine;
 use CmsIg\Seal\EngineInterface;
-use CmsIg\Seal\Reindex\ReindexProviderInterface;
+use CmsIg\Seal\Reindex\StaticReindexProviderInterface;
 use CmsIg\Seal\Schema\Loader\PhpFileLoader;
 use CmsIg\Seal\Schema\Schema;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
@@ -126,7 +126,7 @@ final class SealBundle extends AbstractBundle
             );
         }
 
-        $builder->registerForAutoconfiguration(ReindexProviderInterface::class)
+        $builder->registerForAutoconfiguration(StaticReindexProviderInterface::class)
             ->addTag('cmsig_seal.reindex_provider');
 
         $container->import(\dirname(__DIR__) . '/config/services.php');

--- a/integrations/yii/config/di-console.php
+++ b/integrations/yii/config/di-console.php
@@ -15,7 +15,7 @@ use CmsIg\Seal\EngineRegistry;
 use CmsIg\Seal\Integration\Yii\Command\IndexCreateCommand;
 use CmsIg\Seal\Integration\Yii\Command\IndexDropCommand;
 use CmsIg\Seal\Integration\Yii\Command\ReindexCommand;
-use CmsIg\Seal\Reindex\ReindexProviderInterface;
+use CmsIg\Seal\Reindex\StaticReindexProviderInterface;
 use Psr\Container\ContainerInterface;
 
 /** @var \Yiisoft\Config\Config $config */
@@ -42,16 +42,16 @@ $diConfig[ReindexCommand::class] = static function (ContainerInterface $containe
     /** @var EngineRegistry $engineRegistry */
     $engineRegistry = $container->get(EngineRegistry::class);
 
-    /** @var array<ReindexProviderInterface> $reindexProviders */
+    /** @var array<StaticReindexProviderInterface> $reindexProviders */
     $reindexProviders = [];
     foreach ($reindexProviderNames as $reindexProviderName) {
         $reindexProvider = $container->get($reindexProviderName);
 
-        if (!$reindexProvider instanceof ReindexProviderInterface) {
+        if (!$reindexProvider instanceof StaticReindexProviderInterface) {
             throw new \RuntimeException(\sprintf(
                 'Reindex provider "%s" does not implement "%s".',
                 $reindexProviderName,
-                ReindexProviderInterface::class,
+                StaticReindexProviderInterface::class,
             ));
         }
 

--- a/integrations/yii/src/Command/ReindexCommand.php
+++ b/integrations/yii/src/Command/ReindexCommand.php
@@ -15,7 +15,7 @@ namespace CmsIg\Seal\Integration\Yii\Command;
 
 use CmsIg\Seal\EngineRegistry;
 use CmsIg\Seal\Reindex\ReindexConfig;
-use CmsIg\Seal\Reindex\ReindexProviderInterface;
+use CmsIg\Seal\Reindex\StaticReindexProviderInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -28,7 +28,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 final class ReindexCommand extends Command
 {
     /**
-     * @param iterable<ReindexProviderInterface> $reindexProviders
+     * @param iterable<StaticReindexProviderInterface> $reindexProviders
      */
     public function __construct(
         private readonly EngineRegistry $engineRegistry,

--- a/packages/seal/src/Engine.php
+++ b/packages/seal/src/Engine.php
@@ -154,14 +154,14 @@ final class Engine implements EngineInterface
         /** @var array<string, string> $identifiersPerIndex */
         $identifiersPerIndex = [];
         foreach ($reindexProviders as $reindexProvider) {
-            if (!isset($this->schema->indexes[$reindexProvider->getIndex()])) {
+            if (!isset($this->schema->indexes[$reindexProvider->getIndexName()])) {
                 continue;
             }
 
-            $identifiersPerIndex[$reindexProvider->getIndex()] = $this->schema->indexes[$reindexProvider->getIndex()]->getIdentifierField()->name;
+            $identifiersPerIndex[$reindexProvider->getIndexName()] = $this->schema->indexes[$reindexProvider->getIndexName()]->getIdentifierField()->name;
 
-            if ($reindexProvider->getIndex() === $reindexConfig->getIndex() || null === $reindexConfig->getIndex()) {
-                $reindexProvidersPerIndex[$reindexProvider->getIndex()][] = $reindexProvider;
+            if ($reindexProvider->getIndexName() === $reindexConfig->getIndexName() || null === $reindexConfig->getIndexName()) {
+                $reindexProvidersPerIndex[$reindexProvider->getIndexName()][] = $reindexProvider;
             }
         }
 
@@ -218,7 +218,7 @@ final class Engine implements EngineInterface
         }
 
         if ([] !== $documentIdsToDelete) {
-            $index = $reindexConfig->getIndex();
+            $index = $reindexConfig->getIndexName();
             \assert(null !== $index, 'Index must be set if identifiers are given in reindex config.');
             $tasks[] = $this->bulk($index, [], \array_keys($documentIdsToDelete), $reindexConfig->getBulkSize(), $options);
         }

--- a/packages/seal/src/Engine.php
+++ b/packages/seal/src/Engine.php
@@ -154,14 +154,14 @@ final class Engine implements EngineInterface
         /** @var array<string, string> $identifiersPerIndex */
         $identifiersPerIndex = [];
         foreach ($reindexProviders as $reindexProvider) {
-            if (!isset($this->schema->indexes[$reindexProvider::getIndex()])) {
+            if (!isset($this->schema->indexes[$reindexProvider->getIndex()])) {
                 continue;
             }
 
-            $identifiersPerIndex[$reindexProvider::getIndex()] = $this->schema->indexes[$reindexProvider::getIndex()]->getIdentifierField()->name;
+            $identifiersPerIndex[$reindexProvider->getIndex()] = $this->schema->indexes[$reindexProvider->getIndex()]->getIdentifierField()->name;
 
-            if ($reindexProvider::getIndex() === $reindexConfig->getIndex() || null === $reindexConfig->getIndex()) {
-                $reindexProvidersPerIndex[$reindexProvider::getIndex()][] = $reindexProvider;
+            if ($reindexProvider->getIndex() === $reindexConfig->getIndex() || null === $reindexConfig->getIndex()) {
+                $reindexProvidersPerIndex[$reindexProvider->getIndex()][] = $reindexProvider;
             }
         }
 

--- a/packages/seal/src/Engine.php
+++ b/packages/seal/src/Engine.php
@@ -16,7 +16,7 @@ namespace CmsIg\Seal;
 use CmsIg\Seal\Adapter\AdapterInterface;
 use CmsIg\Seal\Exception\DocumentNotFoundException;
 use CmsIg\Seal\Reindex\ReindexConfig;
-use CmsIg\Seal\Reindex\ReindexProviderInterface;
+use CmsIg\Seal\Reindex\StaticReindexProviderInterface;
 use CmsIg\Seal\Schema\Schema;
 use CmsIg\Seal\Search\Condition\IdentifierCondition;
 use CmsIg\Seal\Search\SearchBuilder;
@@ -149,7 +149,7 @@ final class Engine implements EngineInterface
         callable|null $progressCallback = null,
         array $options = [],
     ): TaskInterface|null {
-        /** @var array<string, ReindexProviderInterface[]> $reindexProvidersPerIndex */
+        /** @var array<string, StaticReindexProviderInterface[]> $reindexProvidersPerIndex */
         $reindexProvidersPerIndex = [];
         /** @var array<string, string> $identifiersPerIndex */
         $identifiersPerIndex = [];

--- a/packages/seal/src/EngineInterface.php
+++ b/packages/seal/src/EngineInterface.php
@@ -15,7 +15,7 @@ namespace CmsIg\Seal;
 
 use CmsIg\Seal\Exception\DocumentNotFoundException;
 use CmsIg\Seal\Reindex\ReindexConfig;
-use CmsIg\Seal\Reindex\ReindexProviderInterface;
+use CmsIg\Seal\Reindex\StaticReindexProviderInterface;
 use CmsIg\Seal\Search\SearchBuilder;
 use CmsIg\Seal\Task\TaskInterface;
 
@@ -90,7 +90,7 @@ interface EngineInterface
      * @experimental This method is experimental and may change in future versions, we are not sure if it stays here or the syntax change completely.
      *               For framework users it is uninteresting as there it is handled via CLI commands.
      *
-     * @param iterable<ReindexProviderInterface> $reindexProviders
+     * @param iterable<StaticReindexProviderInterface> $reindexProviders
      * @param callable(string, int, int|null): void|null $progressCallback
      *
      * TODO: native return type in next minor, major release

--- a/packages/seal/src/Reindex/ReindexConfig.php
+++ b/packages/seal/src/Reindex/ReindexConfig.php
@@ -25,7 +25,7 @@ final class ReindexConfig
      */
     private array $identifiers = [];
 
-    public function getIndex(): string|null
+    public function getIndexName(): string|null
     {
         return $this->index;
     }

--- a/packages/seal/src/Reindex/ReindexProviderInterface.php
+++ b/packages/seal/src/Reindex/ReindexProviderInterface.php
@@ -30,5 +30,5 @@ interface ReindexProviderInterface
     /**
      * The name of the index for which the documents are for.
      */
-    public static function getIndex(): string;
+    public function getIndex(): string;
 }

--- a/packages/seal/src/Reindex/ReindexProviderInterface.php
+++ b/packages/seal/src/Reindex/ReindexProviderInterface.php
@@ -13,22 +13,9 @@ declare(strict_types=1);
 
 namespace CmsIg\Seal\Reindex;
 
-interface ReindexProviderInterface
+/**
+ * @deprecated Use the StaticReindexProviderInterface instead, the ReindexProviderInterface will be removed in newer versions.
+ */
+interface ReindexProviderInterface extends StaticReindexProviderInterface
 {
-    /**
-     * Returns how many documents this provider will provide. Returns `null` if the total is unknown.
-     */
-    public function total(): int|null;
-
-    /**
-     * The reindex provider returns a Generator which provides the documents to reindex.
-     *
-     * @return \Generator<array<string, mixed>>
-     */
-    public function provide(ReindexConfig $reindexConfig): \Generator;
-
-    /**
-     * The name of the index for which the documents are for.
-     */
-    public function getIndexName(): string;
 }

--- a/packages/seal/src/Reindex/ReindexProviderInterface.php
+++ b/packages/seal/src/Reindex/ReindexProviderInterface.php
@@ -30,5 +30,5 @@ interface ReindexProviderInterface
     /**
      * The name of the index for which the documents are for.
      */
-    public function getIndex(): string;
+    public function getIndexName(): string;
 }

--- a/packages/seal/src/Reindex/ReindexProviderInterface.php
+++ b/packages/seal/src/Reindex/ReindexProviderInterface.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace CmsIg\Seal\Reindex;
 
 /**
- * @deprecated Use the StaticReindexProviderInterface instead, the ReindexProviderInterface will be removed in newer versions.
+ * @deprecated use the StaticReindexProviderInterface instead, the ReindexProviderInterface will be removed in newer versions
  */
 interface ReindexProviderInterface extends StaticReindexProviderInterface
 {

--- a/packages/seal/src/Reindex/StaticReindexProviderInterface.php
+++ b/packages/seal/src/Reindex/StaticReindexProviderInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS-IG SEAL project.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CmsIg\Seal\Reindex;
+
+interface StaticReindexProviderInterface
+{
+    /**
+     * Returns how many documents this provider will provide. Returns `null` if the total is unknown.
+     */
+    public function total(): int|null;
+
+    /**
+     * The reindex provider returns a Generator which provides the documents to reindex.
+     *
+     * @return \Generator<array<string, mixed>>
+     */
+    public function provide(ReindexConfig $reindexConfig): \Generator;
+
+    /**
+     * The name of the index for which the documents are for.
+     */
+    public function getIndexName(): string;
+}

--- a/packages/seal/src/Testing/AbstractAdapterTestCase.php
+++ b/packages/seal/src/Testing/AbstractAdapterTestCase.php
@@ -18,7 +18,7 @@ use CmsIg\Seal\Engine;
 use CmsIg\Seal\EngineInterface;
 use CmsIg\Seal\Exception\DocumentNotFoundException;
 use CmsIg\Seal\Reindex\ReindexConfig;
-use CmsIg\Seal\Reindex\ReindexProviderInterface;
+use CmsIg\Seal\Reindex\StaticReindexProviderInterface;
 use CmsIg\Seal\Schema\Schema;
 use PHPUnit\Framework\TestCase;
 
@@ -240,9 +240,9 @@ abstract class AbstractAdapterTestCase extends TestCase
     /**
      * @param array<array<string, mixed>> $documents
      */
-    private function createReindexProvider(array $documents): ReindexProviderInterface
+    private function createReindexProvider(array $documents): StaticReindexProviderInterface
     {
-        return new class($documents) implements ReindexProviderInterface {
+        return new class($documents) implements StaticReindexProviderInterface {
             /**
              * @param array<array<string, mixed>> $documents
              */

--- a/packages/seal/src/Testing/AbstractAdapterTestCase.php
+++ b/packages/seal/src/Testing/AbstractAdapterTestCase.php
@@ -264,7 +264,7 @@ abstract class AbstractAdapterTestCase extends TestCase
                 }
             }
 
-            public static function getIndex(): string
+            public function getIndex(): string
             {
                 return TestingHelper::INDEX_COMPLEX;
             }

--- a/packages/seal/src/Testing/AbstractAdapterTestCase.php
+++ b/packages/seal/src/Testing/AbstractAdapterTestCase.php
@@ -264,7 +264,7 @@ abstract class AbstractAdapterTestCase extends TestCase
                 }
             }
 
-            public function getIndex(): string
+            public function getIndexName(): string
             {
                 return TestingHelper::INDEX_COMPLEX;
             }


### PR DESCRIPTION
Currently it is not possible to create a reusable ReindexProvider as all ReindexProviders require to implement a static method `public static function getIndex(): string` we should get rid of them so people can create ReindexProviders which are reusable and just configurable by there constructor.

This also add possibility to wrap / decorate ReindexProviders easier, which we require for ODM (#81 #661).

## BC Breaks

The `ReindexProviderInterface` and `getIndex` method is not longer static and the interface was renamed to `StaticReindexProviderInterface` as in a `DynamicReindexProviderInterface` without getIndexName method will be added in upcoming PR:

```diff
-class YourClass implements ReindexProviderInterface {
+class YourClass implements StaticReindexProviderInterface {
    // ...
    
-   public static function getIndex(): string
+   public function getIndexName(): string
    {
        return 'test';
    }
}
```

If you need to support 0.12 and 0.13 the same time you can implement both methods and keep using the deprecated ReindexProviderInterface until 0.14 or 1.0:

```diff
class YourClass implements ReindexProviderInterface {
    // ...
    
    public static function getIndex(): string
    {
        return 'index';
    }
    
+   public function getIndexName(): string
+   {
+        return self::getIndex();
+   }
}
```

fixes #615