### PR TITLE
Add support for Solr 10

### DIFF
--- a/.examples/laravel/docker-compose.yml
+++ b/.examples/laravel/docker-compose.yml
@@ -76,30 +76,18 @@ services:
       retries: 20
     volumes:
       - typesense-data:/data
+
   solr:
-    image: "solr:9"
+    image: "solr:10"
     ports:
      - "8983:8983"
-     - "9983:9983"
-    command: solr -f -cloud
     healthcheck:
-      test: ["CMD-SHELL", "curl --silent --fail localhost:8983 || exit 1"]
+      test: ["CMD-SHELL", "curl --silent --fail http://localhost:8983/solr/admin/info/system?wt=json || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 20
-    environment:
-      SOLR_OPTS: '-Dsolr.disableConfigSetsCreateAuthChecks=true'
     volumes:
       - solr-data:/var/solr
-
-  zookeeper:
-    image: "solr:9"
-    depends_on:
-      - "solr"
-    network_mode: "service:solr"
-    environment:
-      SOLR_OPTS: '-Dsolr.disableConfigSetsCreateAuthChecks=true'
-    command: bash -c "set -x; export; wait-for-solr.sh; solr zk -z localhost:9983 upconfig -n default -d /opt/solr/server/solr/configsets/_default; tail -f /dev/null"
 
 volumes:
   elasticsearch-data:

--- a/.examples/mezzio/docker-compose.yml
+++ b/.examples/mezzio/docker-compose.yml
@@ -76,30 +76,18 @@ services:
       retries: 20
     volumes:
       - typesense-data:/data
+
   solr:
-    image: "solr:9"
+    image: "solr:10"
     ports:
       - "8983:8983"
-      - "9983:9983"
-    command: solr -f -cloud
     healthcheck:
-      test: ["CMD-SHELL", "curl --silent --fail localhost:8983 || exit 1"]
+      test: ["CMD-SHELL", "curl --silent --fail http://localhost:8983/solr/admin/info/system?wt=json || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 20
-    environment:
-      SOLR_OPTS: '-Dsolr.disableConfigSetsCreateAuthChecks=true'
     volumes:
       - solr-data:/var/solr
-
-  zookeeper:
-    image: "solr:9"
-    depends_on:
-      - "solr"
-    network_mode: "service:solr"
-    environment:
-      SOLR_OPTS: '-Dsolr.disableConfigSetsCreateAuthChecks=true'
-    command: bash -c "set -x; export; wait-for-solr.sh; solr zk -z localhost:9983 upconfig -n default -d /opt/solr/server/solr/configsets/_default; tail -f /dev/null"
 
 volumes:
   elasticsearch-data:

--- a/.examples/spiral/docker-compose.yml
+++ b/.examples/spiral/docker-compose.yml
@@ -76,30 +76,18 @@ services:
       retries: 20
     volumes:
       - typesense-data:/data
+
   solr:
-    image: "solr:9"
+    image: "solr:10"
     ports:
       - "8983:8983"
-      - "9983:9983"
-    command: solr -f -cloud
     healthcheck:
-      test: ["CMD-SHELL", "curl --silent --fail localhost:8983 || exit 1"]
+      test: ["CMD-SHELL", "curl --silent --fail http://localhost:8983/solr/admin/info/system?wt=json || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 20
-    environment:
-      SOLR_OPTS: '-Dsolr.disableConfigSetsCreateAuthChecks=true'
     volumes:
       - solr-data:/var/solr
-
-  zookeeper:
-    image: "solr:9"
-    depends_on:
-      - "solr"
-    network_mode: "service:solr"
-    environment:
-      SOLR_OPTS: '-Dsolr.disableConfigSetsCreateAuthChecks=true'
-    command: bash -c "set -x; export; wait-for-solr.sh; solr zk -z localhost:9983 upconfig -n default -d /opt/solr/server/solr/configsets/_default; tail -f /dev/null"
 
 volumes:
   elasticsearch-data:

--- a/.examples/symfony/docker-compose.yml
+++ b/.examples/symfony/docker-compose.yml
@@ -78,28 +78,16 @@ services:
       - typesense-data:/data
 
   solr:
-    image: "solr:9"
+    image: "solr:10"
     ports:
       - "8983:8983"
-      - "9983:9983"
-    command: solr -f -cloud
     healthcheck:
-      test: ["CMD-SHELL", "curl --silent --fail localhost:8983 || exit 1"]
+      test: ["CMD-SHELL", "curl --silent --fail http://localhost:8983/solr/admin/info/system?wt=json || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 20
-    environment:
-      SOLR_OPTS: '-Dsolr.disableConfigSetsCreateAuthChecks=true'
     volumes:
       - solr-data:/var/solr
-  zookeeper:
-    image: "solr:9"
-    depends_on:
-      - "solr"
-    network_mode: "service:solr"
-    environment:
-      SOLR_OPTS: '-Dsolr.disableConfigSetsCreateAuthChecks=true'
-    command: bash -c "set -x; export; wait-for-solr.sh; solr zk -z localhost:9983 upconfig -n default -d /opt/solr/server/solr/configsets/_default; tail -f /dev/null"
 
 volumes:
   elasticsearch-data:

--- a/.examples/yii/docker-compose.yml
+++ b/.examples/yii/docker-compose.yml
@@ -76,30 +76,18 @@ services:
       retries: 20
     volumes:
       - typesense-data:/data
+
   solr:
-    image: "solr:9"
+    image: "solr:10"
     ports:
       - "8983:8983"
-      - "9983:9983"
-    command: solr -f -cloud
     healthcheck:
-      test: ["CMD-SHELL", "curl --silent --fail localhost:8983 || exit 1"]
+      test: ["CMD-SHELL", "curl --silent --fail http://localhost:8983/solr/admin/info/system?wt=json || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 20
-    environment:
-      SOLR_OPTS: '-Dsolr.disableConfigSetsCreateAuthChecks=true'
     volumes:
       - solr-data:/var/solr
-
-  zookeeper:
-    image: "solr:9"
-    depends_on:
-      - "solr"
-    network_mode: "service:solr"
-    environment:
-      SOLR_OPTS: '-Dsolr.disableConfigSetsCreateAuthChecks=true'
-    command: bash -c "set -x; export; wait-for-solr.sh; solr zk -z localhost:9983 upconfig -n default -d /opt/solr/server/solr/configsets/_default; tail -f /dev/null"
 
 volumes:
   elasticsearch-data:

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -305,38 +305,24 @@ search engine.
     .. group-tab:: Solr
 
         A instance of `Solr <https://solr.apache.org/>`__ can be started with the following docker-compose file.
-        It uses the required cloud mode to run the search engine. Running it
-        without cloud mode is not supported yet:
+        It uses the required cloud mode to run the search engine, which is enabled since Solr 10 automatically.
+        Running it without cloud mode is not supported:
 
         .. code-block:: yaml
 
             # docker-compose.yml
-
             services:
               solr:
-                image: "solr:9"
+                image: "solr:10"
                 ports:
                  - "8983:8983"
-                 - "9983:9983"
-                command: solr -f -cloud
                 healthcheck:
-                  test: ["CMD-SHELL", "curl --silent --fail localhost:8983 || exit 1"]
+                  test: ["CMD-SHELL", "curl --silent --fail http://localhost:8983/solr/admin/info/system?wt=json || exit 1"]
                   interval: 5s
                   timeout: 5s
                   retries: 20
-                environment:
-                  SOLR_OPTS: '-Dsolr.disableConfigSetsCreateAuthChecks=true'
                 volumes:
                   - solr-data:/var/solr
-
-              zookeeper:
-                image: "solr:9"
-                depends_on:
-                  - "solr"
-                network_mode: "service:solr"
-                environment:
-                  SOLR_OPTS: '-Dsolr.disableConfigSetsCreateAuthChecks=true'
-                command: bash -c "set -x; export; wait-for-solr.sh; solr zk -z localhost:9983 upconfig -n default -d /opt/solr/server/solr/configsets/_default; tail -f /dev/null"
 
             volumes:
               solr-data:

--- a/packages/seal-solr-adapter/docker-compose.yml
+++ b/packages/seal-solr-adapter/docker-compose.yml
@@ -1,28 +1,15 @@
 services:
   solr:
-    image: "solr:9"
+    image: "solr:10"
     ports:
      - "8983:8983"
-     - "9983:9983"
-    command: solr -f -cloud
     healthcheck:
-      test: ["CMD-SHELL", "curl --silent --fail localhost:8983 || exit 1"]
+      test: ["CMD-SHELL", "curl --silent --fail http://localhost:8983/solr/admin/info/system?wt=json || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 20
-    environment:
-      SOLR_OPTS: '-Dsolr.disableConfigSetsCreateAuthChecks=true'
     volumes:
       - solr-data:/var/solr
-
-  zookeeper:
-    image: "solr:9"
-    depends_on:
-      - "solr"
-    network_mode: "service:solr"
-    environment:
-      SOLR_OPTS: '-Dsolr.disableConfigSetsCreateAuthChecks=true'
-    command: bash -c "set -x; export; wait-for-solr.sh; solr zk -z localhost:9983 upconfig -n default -d /opt/solr/server/solr/configsets/_default; tail -f /dev/null"
 
 volumes:
   solr-data:


### PR DESCRIPTION
A new version of Apache Solr was released at 3 March 2026, the [Version 10](https://solr.apache.org/guide/solr/latest/upgrade-notes/major-changes-in-solr-10.html) makes our required "Cloud Mode" default which make the dev docker compose also a lot smaller.