### PR TITLE
Fix filtering on TextField for Solr adapter

### DIFF
--- a/packages/seal-solr-adapter/src/SolrSearcher.php
+++ b/packages/seal-solr-adapter/src/SolrSearcher.php
@@ -224,7 +224,7 @@ final class SolrSearcher implements SearcherInterface
     {
         $field = $index->getFieldByPath($name);
 
-        if ($field instanceof Field\TextField) {
+        if ($field instanceof Field\TextField && $field->searchable && ($field->filterable || $field->sortable || $field->facet)) {
             return $name . '.raw';
         }
 


### PR DESCRIPTION
This PR fixes issue #671 where filtering on a TextField with `searchable: false` and `filterable: true` causes an "undefined field" error in Solr.

### Problem
- `SolrSchemaManager` only creates `.raw` subfield when TextField is searchable AND filterable/sortable/facet
- `SolrSearcher::getFilterField()` always returned `.raw` for any TextField being filtered
- Mismatch causes query builder to reference non-existent `.raw` field

### Solution
Update `getFilterField()` to use the same condition as schema creation:
- Only append `.raw` when field is a TextField AND searchable AND (filterable OR sortable OR facet)

Fixes #671