### PR TITLE
Fix not dump config files for in-memory loupe setups

### DIFF
--- a/packages/seal-loupe-adapter/src/LoupeHelper.php
+++ b/packages/seal-loupe-adapter/src/LoupeHelper.php
@@ -28,7 +28,7 @@ final class LoupeHelper
     /**
      * @var array<string, Configuration>
      */
-    private static array $inMemoryConfigurations = [];
+    private array $inMemoryConfigurations = [];
 
     /**
      * @var array<string, Loupe>
@@ -56,7 +56,7 @@ final class LoupeHelper
     public function existIndex(Index $index): bool
     {
         if ('' === $this->directory) {
-            return isset(self::$inMemoryConfigurations[$index->name]);
+            return isset($this->inMemoryConfigurations[$index->name]);
         }
 
         $indexDirectory = $this->getIndexDirectory($index);
@@ -66,9 +66,11 @@ final class LoupeHelper
 
     public function dropIndex(Index $index): void
     {
-        unset($this->loupe[$index->name], self::$inMemoryConfigurations[$index->name]);
+        unset($this->loupe[$index->name]);
 
         if ('' === $this->directory) {
+            unset($this->inMemoryConfigurations[$index->name]);
+
             return;
         }
 
@@ -96,9 +98,10 @@ final class LoupeHelper
     {
         $configuration = $this->createConfiguration($index);
         $this->loupe[$index->name] = $this->createLoupe($index, $configuration);
-        self::$inMemoryConfigurations[$index->name] = $configuration;
 
         if ('' === $this->directory) {
+            $this->inMemoryConfigurations[$index->name] = $configuration;
+
             return;
         }
 
@@ -108,6 +111,7 @@ final class LoupeHelper
     public function reset(): void
     {
         $this->loupe = [];
+        $this->inMemoryConfigurations = [];
     }
 
     /**
@@ -122,7 +126,7 @@ final class LoupeHelper
     {
         if (!$configuration instanceof Configuration) {
             if ('' === $this->directory) {
-                $configuration = self::$inMemoryConfigurations[$index->name] ?? $this->createConfiguration($index);
+                $configuration = $this->inMemoryConfigurations[$index->name] ?? $this->createConfiguration($index);
             } else {
                 $configurationFile = $this->getConfigurationFile($index);
 

--- a/packages/seal-loupe-adapter/src/LoupeHelper.php
+++ b/packages/seal-loupe-adapter/src/LoupeHelper.php
@@ -26,7 +26,12 @@ final class LoupeHelper
     public const SEPARATOR = '_';
 
     /**
-     * @var Loupe[]
+     * @var array<string, Configuration>
+     */
+    private static array $inMemoryConfigurations = [];
+
+    /**
+     * @var array<string, Loupe>
      */
     private array $loupe = [];
 
@@ -50,6 +55,10 @@ final class LoupeHelper
 
     public function existIndex(Index $index): bool
     {
+        if ('' === $this->directory) {
+            return isset(self::$inMemoryConfigurations[$index->name]);
+        }
+
         $indexDirectory = $this->getIndexDirectory($index);
 
         return \file_exists($indexDirectory);
@@ -57,6 +66,12 @@ final class LoupeHelper
 
     public function dropIndex(Index $index): void
     {
+        unset($this->loupe[$index->name], self::$inMemoryConfigurations[$index->name]);
+
+        if ('' === $this->directory) {
+            return;
+        }
+
         if ($this->existIndex($index)) {
             $indexDirectory = $this->getIndexDirectory($index);
 
@@ -81,6 +96,7 @@ final class LoupeHelper
     {
         $configuration = $this->createConfiguration($index);
         $this->loupe[$index->name] = $this->createLoupe($index, $configuration);
+        self::$inMemoryConfigurations[$index->name] = $configuration;
 
         if ('' === $this->directory) {
             return;
@@ -105,16 +121,20 @@ final class LoupeHelper
     private function createLoupe(Index $index, Configuration|null $configuration = null): Loupe
     {
         if (!$configuration instanceof Configuration) {
-            $configurationFile = $this->getConfigurationFile($index);
-
-            if (!\file_exists($configurationFile)) {
-                $configuration = $this->createAndDumpConfiguration($index);
+            if ('' === $this->directory) {
+                $configuration = self::$inMemoryConfigurations[$index->name] ?? $this->createConfiguration($index);
             } else {
-                /** @var string $configurationContent */
-                $configurationContent = \file_get_contents($configurationFile);
+                $configurationFile = $this->getConfigurationFile($index);
 
-                /** @var Configuration $configuration */
-                $configuration = \unserialize($configurationContent);
+                if (!\file_exists($configurationFile)) {
+                    $configuration = $this->createAndDumpConfiguration($index);
+                } else {
+                    /** @var string $configurationContent */
+                    $configurationContent = \file_get_contents($configurationFile);
+
+                    /** @var Configuration $configuration */
+                    $configuration = \unserialize($configurationContent);
+                }
             }
         }
 

--- a/packages/seal-loupe-adapter/src/LoupeHelper.php
+++ b/packages/seal-loupe-adapter/src/LoupeHelper.php
@@ -79,9 +79,14 @@ final class LoupeHelper
 
     public function createIndex(Index $index): void
     {
-        $configuration = $this->createAndDumpConfiguration($index);
-        \file_put_contents($this->getConfigurationFile($index), \serialize($configuration));
+        $configuration = $this->createConfiguration($index);
         $this->loupe[$index->name] = $this->createLoupe($index, $configuration);
+
+        if ('' === $this->directory) {
+            return;
+        }
+
+        \file_put_contents($this->getConfigurationFile($index), \serialize($configuration));
     }
 
     public function reset(): void

--- a/packages/seal-loupe-adapter/src/LoupeHelper.php
+++ b/packages/seal-loupe-adapter/src/LoupeHelper.php
@@ -125,21 +125,7 @@ final class LoupeHelper
     private function createLoupe(Index $index, Configuration|null $configuration = null): Loupe
     {
         if (!$configuration instanceof Configuration) {
-            if ('' === $this->directory) {
-                $configuration = $this->inMemoryConfigurations[$index->name] ?? $this->createConfiguration($index);
-            } else {
-                $configurationFile = $this->getConfigurationFile($index);
-
-                if (!\file_exists($configurationFile)) {
-                    $configuration = $this->createAndDumpConfiguration($index);
-                } else {
-                    /** @var string $configurationContent */
-                    $configurationContent = \file_get_contents($configurationFile);
-
-                    /** @var Configuration $configuration */
-                    $configuration = \unserialize($configurationContent);
-                }
-            }
+            $configuration = $this->getOrCreateConfiguration($index);
         }
 
         if ('' === $this->directory) {
@@ -149,17 +135,43 @@ final class LoupeHelper
         return $this->loupeFactory->create($this->getIndexDirectory($index), $configuration);
     }
 
+    private function getOrCreateConfiguration(Index $index): Configuration
+    {
+        if ('' === $this->directory) {
+            return $this->inMemoryConfigurations[$index->name] ?? $this->createAndDumpConfiguration($index);
+        }
+
+        $configurationFile = $this->getConfigurationFile($index);
+
+        if (\file_exists($configurationFile)) {
+            /** @var string $configurationContent */
+            $configurationContent = \file_get_contents($configurationFile);
+
+            /** @var Configuration $configuration */
+            $configuration = \unserialize($configurationContent);
+        }
+
+        return $configuration ?? $this->createAndDumpConfiguration($index);
+    }
+
     private function createAndDumpConfiguration(Index $index): Configuration
     {
+        // dumping the configuration allows us to search and index without knowing the configuration
+        // this way when a similar class like this would be part of loupe only the createIndex method
+        // would require then to know the configuration
+        $configuration = $this->createConfiguration($index);
+
+        if ('' === $this->directory) {
+            $this->inMemoryConfigurations[$index->name] = $configuration;
+
+            return $configuration;
+        }
+
         $indexDirectory = $this->getIndexDirectory($index);
         if (!\file_exists($indexDirectory)) {
             \mkdir($indexDirectory, recursive: true);
         }
 
-        // dumping the configuration allows us to search and index without knowing the configuration
-        // this way when a similar class like this would be part of loupe only the createIndex method
-        // would require then to know the configuration
-        $configuration = $this->createConfiguration($index);
         \file_put_contents($this->getConfigurationFile($index), \serialize($configuration));
 
         return $configuration;


### PR DESCRIPTION
Noticed while working on some functional tests ^^