### PR TITLE
Add SearchBuilder JSON serialization support

### DIFF
--- a/docs/search-and-filters/index.rst
+++ b/docs/search-and-filters/index.rst
@@ -520,12 +520,97 @@ for example. Instead of displaying all the product variants, you may group them 
         ->addFilter(Condition::search('product title'))
         ->distinct('product_id')
         ->getResult();
-    }
 
 .. note::
 
     For `->distinct()` to work, your field (`product_id` in our example) has to be configured using
     `distinct: true` in the  index schema.
+
+--------------
+
+Serializing searches
+--------------------
+
+SEAL keeps the core ``SearchBuilder``, conditions and facets focused on building searches. If you
+want to exchange search state with a UI, for example through a single request query parameter such
+as ``?search=<json>``, use the ``ArraySearchBuilderFactory``.
+
+The factory translates between a ``SearchBuilder`` and an array or JSON payload. The index name is
+not part of the serialized payload. Your application still decides which index to target.
+
+.. code-block:: php
+
+    <?php
+
+    use CmsIg\Seal\Search\Condition\Condition;
+    use CmsIg\Seal\Search\Facet\Facet;
+    use CmsIg\Seal\Search\SearchBuilderFactory\ArraySearchBuilderFactory;
+
+    $searchBuilderFactory = new ArraySearchBuilderFactory($this->engine);
+
+    $searchBuilder = $this->engine->createSearchBuilder('blog')
+        ->addFilter(Condition::search('product title'))
+        ->addFilter(Condition::equal('tags', 'php'))
+        ->addSortBy('rating', 'desc')
+        ->limit(20)
+        ->addFacet(Facet::count('tags'));
+
+    $json = $searchBuilderFactory->toJson($searchBuilder);
+
+You can also work with arrays directly instead of JSON:
+
+.. code-block:: php
+
+    <?php
+
+    $payload = $searchBuilderFactory->toArray($searchBuilder);
+
+To build a ``SearchBuilder`` back from external input, pass a
+``SearchBuilderFactoryConfig`` explicitly. This is required on purpose. The config defines exactly
+which parts of the search language your endpoint wants to expose.
+
+Nothing is allowed by default.
+
+Only after a field or feature is allowed in the config can it be used. Even then, SEAL still checks
+the index schema. So a field must be allowed by your config and configured in the schema as
+``filterable``, ``sortable``, ``facet``, ``distinct`` or ``searchable`` where applicable.
+
+This is especially important for public APIs. An index may support internal fields such as
+``authorEmail`` or ``internalStatus`` for back office workflows, while a public endpoint should only
+accept a small safe subset.
+
+.. code-block:: php
+
+    <?php
+
+    use CmsIg\Seal\Search\SearchBuilderFactory\ArraySearchBuilderFactory;
+    use CmsIg\Seal\Search\SearchBuilderFactory\SearchBuilderFactoryConfig;
+
+    $searchBuilderFactory = new ArraySearchBuilderFactory($this->engine);
+
+    $config = new SearchBuilderFactoryConfig(
+        filterFields: ['tags', 'rating'],
+        sortFields: ['rating'],
+        facetFields: ['tags'],
+        highlightFields: ['title', 'article'],
+        allowSearch: true,
+        maxLimit: 100,
+    );
+
+    $result = $searchBuilderFactory
+        ->buildFromJson('blog', $config, $_GET['search'])
+        ->getResult();
+
+If your input already arrives as an array, for example from a custom request
+mapping, use ``build()`` instead:
+
+.. code-block:: php
+
+    <?php
+
+    $result = $searchBuilderFactory
+        ->build('blog', $config, $requestData)
+        ->getResult();
 
 --------------
 

--- a/packages/seal/src/Search/SearchBuilderFactory/ArraySearchBuilderFactory.php
+++ b/packages/seal/src/Search/SearchBuilderFactory/ArraySearchBuilderFactory.php
@@ -1,0 +1,302 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS-IG SEAL project.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CmsIg\Seal\Search\SearchBuilderFactory;
+
+use CmsIg\Seal\EngineInterface;
+use CmsIg\Seal\Search\Condition\AbstractGroupCondition;
+use CmsIg\Seal\Search\Condition\AndCondition;
+use CmsIg\Seal\Search\Condition\EqualCondition;
+use CmsIg\Seal\Search\Condition\GeoBoundingBoxCondition;
+use CmsIg\Seal\Search\Condition\GeoDistanceCondition;
+use CmsIg\Seal\Search\Condition\GreaterThanCondition;
+use CmsIg\Seal\Search\Condition\GreaterThanEqualCondition;
+use CmsIg\Seal\Search\Condition\IdentifierCondition;
+use CmsIg\Seal\Search\Condition\InCondition;
+use CmsIg\Seal\Search\Condition\LessThanCondition;
+use CmsIg\Seal\Search\Condition\LessThanEqualCondition;
+use CmsIg\Seal\Search\Condition\NotEqualCondition;
+use CmsIg\Seal\Search\Condition\NotInCondition;
+use CmsIg\Seal\Search\Condition\OrCondition;
+use CmsIg\Seal\Search\Condition\SearchCondition;
+use CmsIg\Seal\Search\Facet\AbstractFacet;
+use CmsIg\Seal\Search\Facet\CountFacet;
+use CmsIg\Seal\Search\Facet\MinMaxFacet;
+use CmsIg\Seal\Search\SearchBuilder;
+use CmsIg\Seal\Search\TypeUtil;
+
+final class ArraySearchBuilderFactory
+{
+    public function __construct(
+        private readonly EngineInterface $engine,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function build(string $index, SearchBuilderFactoryConfig $config, array $data): SearchBuilder
+    {
+        $searchBuilder = $this->engine->createSearchBuilder($index);
+        $searchIndex = $searchBuilder->getSearch()->index;
+
+        foreach (TypeUtil::readArrayByKey($data, 'filters', []) as $filter) {
+            $deserializedFilter = $this->deserializeCondition(TypeUtil::ensureStringKeyedArrayValue($filter, 'filter'));
+            $config->validateCondition($deserializedFilter, $searchIndex);
+            $searchBuilder->addFilter($deserializedFilter);
+        }
+
+        foreach (TypeUtil::readArrayByKey($data, 'sortBys', []) as $field => $direction) {
+            if (!\is_string($field) || !\is_string($direction) || !\in_array($direction, ['asc', 'desc'], true)) {
+                throw new \InvalidArgumentException('Search builder sortBys must be a map of field names to "asc" or "desc".');
+            }
+
+            $config->validateSort($field, $searchIndex);
+            $searchBuilder->addSortBy($field, $direction);
+        }
+
+        $limit = TypeUtil::readNullableNonNegativeIntByKey($data, 'limit');
+        $config->validateLimit($limit);
+        if (null !== $limit) {
+            $searchBuilder->limit($limit);
+        }
+
+        $searchBuilder->offset(TypeUtil::readNonNegativeIntByKey($data, 'offset'));
+
+        $highlight = TypeUtil::readStringKeyedArrayByKey($data, 'highlight', []);
+        $highlightFields = TypeUtil::readStringListByKey($highlight, 'fields', []);
+        foreach ($highlightFields as $field) {
+            $config->validateHighlight($field, $searchIndex);
+        }
+
+        $searchBuilder->highlight(
+            $highlightFields,
+            TypeUtil::readStringByKey($highlight, 'preTag', '<mark>'),
+            TypeUtil::readStringByKey($highlight, 'postTag', '</mark>'),
+        );
+
+        $distinct = TypeUtil::readNullableStringByKey($data, 'distinct');
+        if (null !== $distinct) {
+            $config->validateDistinct($distinct, $searchIndex);
+        }
+
+        $searchBuilder->distinct($distinct);
+
+        foreach (TypeUtil::readArrayByKey($data, 'facets', []) as $facet) {
+            $deserializedFacet = $this->deserializeFacet(TypeUtil::ensureStringKeyedArrayValue($facet, 'facet'));
+            $config->validateFacet($deserializedFacet, $searchIndex);
+            $searchBuilder->addFacet($deserializedFacet);
+        }
+
+        return $searchBuilder;
+    }
+
+    public function buildFromJson(string $index, SearchBuilderFactoryConfig $config, string $json): SearchBuilder
+    {
+        $data = \json_decode($json, true, 512, \JSON_THROW_ON_ERROR);
+        if (!\is_array($data)) {
+            throw new \InvalidArgumentException('Search builder JSON must decode to an object.');
+        }
+
+        /** @var array<string, mixed> $data */
+        return $this->build($index, $config, $data);
+    }
+
+    /**
+     * @return array{
+     *     filters: array<array<string, mixed>>,
+     *     sortBys: array<string, 'asc'|'desc'>,
+     *     limit: int|null,
+     *     offset: int,
+     *     highlight: array{fields: array<string>, preTag: string, postTag: string},
+     *     distinct: string|null,
+     *     facets: array<array<string, mixed>>,
+     * }
+     */
+    public function toArray(SearchBuilder $searchBuilder): array
+    {
+        $search = $searchBuilder->getSearch();
+
+        return [
+            'filters' => \array_map(fn (object $condition): array => $this->serializeCondition($condition), $search->filters),
+            'sortBys' => $search->sortBys,
+            'limit' => $search->limit,
+            'offset' => $search->offset,
+            'highlight' => [
+                'fields' => $search->highlightFields,
+                'preTag' => $search->highlightPreTag,
+                'postTag' => $search->highlightPostTag,
+            ],
+            'distinct' => $search->distinct,
+            'facets' => \array_map(fn (AbstractFacet $facet): array => $this->serializeFacet($facet), $search->facets),
+        ];
+    }
+
+    public function toJson(SearchBuilder $searchBuilder): string
+    {
+        return \json_encode($this->toArray($searchBuilder), \JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function deserializeCondition(array $data): SearchCondition|IdentifierCondition|EqualCondition|NotEqualCondition|GreaterThanCondition|GreaterThanEqualCondition|LessThanCondition|LessThanEqualCondition|InCondition|NotInCondition|GeoDistanceCondition|GeoBoundingBoxCondition|AndCondition|OrCondition
+    {
+        return match (TypeUtil::readStringByKey($data, 'type')) {
+            'search' => new SearchCondition(TypeUtil::readStringByKey($data, 'query')),
+            'identifier' => new IdentifierCondition(TypeUtil::readStringByKey($data, 'identifier')),
+            'equal' => new EqualCondition(TypeUtil::readStringByKey($data, 'field'), TypeUtil::readScalarByKey($data, 'value')),
+            'notEqual' => new NotEqualCondition(TypeUtil::readStringByKey($data, 'field'), TypeUtil::readScalarByKey($data, 'value')),
+            'greaterThan' => new GreaterThanCondition(TypeUtil::readStringByKey($data, 'field'), TypeUtil::readScalarByKey($data, 'value')),
+            'greaterThanEqual' => new GreaterThanEqualCondition(TypeUtil::readStringByKey($data, 'field'), TypeUtil::readScalarByKey($data, 'value')),
+            'lessThan' => new LessThanCondition(TypeUtil::readStringByKey($data, 'field'), TypeUtil::readScalarByKey($data, 'value')),
+            'lessThanEqual' => new LessThanEqualCondition(TypeUtil::readStringByKey($data, 'field'), TypeUtil::readScalarByKey($data, 'value')),
+            'in' => new InCondition(TypeUtil::readStringByKey($data, 'field'), TypeUtil::readScalarListByKey($data, 'values')),
+            'notIn' => new NotInCondition(TypeUtil::readStringByKey($data, 'field'), TypeUtil::readScalarListByKey($data, 'values')),
+            'geoDistance' => new GeoDistanceCondition(
+                TypeUtil::readStringByKey($data, 'field'),
+                TypeUtil::readFloatByKey($data, 'latitude'),
+                TypeUtil::readFloatByKey($data, 'longitude'),
+                TypeUtil::readIntByKey($data, 'distance'),
+            ),
+            'geoBoundingBox' => new GeoBoundingBoxCondition(
+                TypeUtil::readStringByKey($data, 'field'),
+                TypeUtil::readFloatByKey($data, 'northLatitude'),
+                TypeUtil::readFloatByKey($data, 'eastLongitude'),
+                TypeUtil::readFloatByKey($data, 'southLatitude'),
+                TypeUtil::readFloatByKey($data, 'westLongitude'),
+            ),
+            'and' => new AndCondition(...$this->deserializeConditions(TypeUtil::readArrayByKey($data, 'conditions'))),
+            'or' => new OrCondition(...$this->deserializeConditions(TypeUtil::readArrayByKey($data, 'conditions'))),
+            default => throw new \InvalidArgumentException(\sprintf('Unsupported condition type "%s".', TypeUtil::readStringByKey($data, 'type'))),
+        };
+    }
+
+    /**
+     * @param array<mixed> $conditions
+     *
+     * @return list<SearchCondition|IdentifierCondition|EqualCondition|NotEqualCondition|GreaterThanCondition|GreaterThanEqualCondition|LessThanCondition|LessThanEqualCondition|InCondition|NotInCondition|GeoDistanceCondition|GeoBoundingBoxCondition|AndCondition|OrCondition>
+     */
+    private function deserializeConditions(array $conditions): array
+    {
+        $deserializedConditions = [];
+        foreach ($conditions as $condition) {
+            $deserializedConditions[] = $this->deserializeCondition(TypeUtil::ensureStringKeyedArrayValue($condition, 'grouped condition'));
+        }
+
+        return $deserializedConditions;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function deserializeFacet(array $data): AbstractFacet
+    {
+        return match (TypeUtil::readStringByKey($data, 'type')) {
+            'count' => new CountFacet(
+                TypeUtil::readStringByKey($data, 'field'),
+                TypeUtil::readStringKeyedArrayByKey($data, 'options', []),
+            ),
+            'minMax' => new MinMaxFacet(
+                TypeUtil::readStringByKey($data, 'field'),
+                TypeUtil::readStringKeyedArrayByKey($data, 'options', []),
+            ),
+            default => throw new \InvalidArgumentException(\sprintf('Unsupported facet type "%s".', TypeUtil::readStringByKey($data, 'type'))),
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serializeCondition(object $condition): array
+    {
+        return match (true) {
+            $condition instanceof SearchCondition => [
+                'type' => 'search',
+                'query' => $condition->query,
+            ],
+            $condition instanceof IdentifierCondition => [
+                'type' => 'identifier',
+                'identifier' => $condition->identifier,
+            ],
+            $condition instanceof EqualCondition => $this->serializeFieldValueCondition('equal', $condition->field, $condition->value),
+            $condition instanceof NotEqualCondition => $this->serializeFieldValueCondition('notEqual', $condition->field, $condition->value),
+            $condition instanceof GreaterThanCondition => $this->serializeFieldValueCondition('greaterThan', $condition->field, $condition->value),
+            $condition instanceof GreaterThanEqualCondition => $this->serializeFieldValueCondition('greaterThanEqual', $condition->field, $condition->value),
+            $condition instanceof LessThanCondition => $this->serializeFieldValueCondition('lessThan', $condition->field, $condition->value),
+            $condition instanceof LessThanEqualCondition => $this->serializeFieldValueCondition('lessThanEqual', $condition->field, $condition->value),
+            $condition instanceof InCondition => [
+                'type' => 'in',
+                'field' => $condition->field,
+                'values' => $condition->values,
+            ],
+            $condition instanceof NotInCondition => [
+                'type' => 'notIn',
+                'field' => $condition->field,
+                'values' => $condition->values,
+            ],
+            $condition instanceof GeoDistanceCondition => [
+                'type' => 'geoDistance',
+                'field' => $condition->field,
+                'latitude' => $condition->latitude,
+                'longitude' => $condition->longitude,
+                'distance' => $condition->distance,
+            ],
+            $condition instanceof GeoBoundingBoxCondition => [
+                'type' => 'geoBoundingBox',
+                'field' => $condition->field,
+                'northLatitude' => $condition->northLatitude,
+                'eastLongitude' => $condition->eastLongitude,
+                'southLatitude' => $condition->southLatitude,
+                'westLongitude' => $condition->westLongitude,
+            ],
+            $condition instanceof AbstractGroupCondition => [
+                'type' => $condition instanceof AndCondition ? 'and' : 'or',
+                'conditions' => \array_map(fn (object $groupedCondition): array => $this->serializeCondition($groupedCondition), $condition->conditions),
+            ],
+            default => throw new \InvalidArgumentException(\sprintf('Unsupported search condition "%s".', $condition::class)),
+        };
+    }
+
+    /**
+     * @return array{type: string, field: string, value: string|int|float|bool}
+     */
+    private function serializeFieldValueCondition(string $type, string $field, string|int|float|bool $value): array
+    {
+        return [
+            'type' => $type,
+            'field' => $field,
+            'value' => $value,
+        ];
+    }
+
+    /**
+     * @return array{type: string, field: string, options: array<string, mixed>}
+     */
+    private function serializeFacet(AbstractFacet $facet): array
+    {
+        return match (true) {
+            $facet instanceof CountFacet => [
+                'type' => 'count',
+                'field' => $facet->field,
+                'options' => $facet->options,
+            ],
+            $facet instanceof MinMaxFacet => [
+                'type' => 'minMax',
+                'field' => $facet->field,
+                'options' => $facet->options,
+            ],
+            default => throw new \InvalidArgumentException(\sprintf('Unsupported facet type "%s".', $facet::class)),
+        };
+    }
+}

--- a/packages/seal/src/Search/SearchBuilderFactory/SearchBuilderFactoryConfig.php
+++ b/packages/seal/src/Search/SearchBuilderFactory/SearchBuilderFactoryConfig.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS-IG SEAL project.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CmsIg\Seal\Search\SearchBuilderFactory;
+
+use CmsIg\Seal\Schema\Index;
+use CmsIg\Seal\Search\Condition\AbstractGroupCondition;
+use CmsIg\Seal\Search\Condition\EqualCondition;
+use CmsIg\Seal\Search\Condition\GeoBoundingBoxCondition;
+use CmsIg\Seal\Search\Condition\GeoDistanceCondition;
+use CmsIg\Seal\Search\Condition\GreaterThanCondition;
+use CmsIg\Seal\Search\Condition\GreaterThanEqualCondition;
+use CmsIg\Seal\Search\Condition\IdentifierCondition;
+use CmsIg\Seal\Search\Condition\InCondition;
+use CmsIg\Seal\Search\Condition\LessThanCondition;
+use CmsIg\Seal\Search\Condition\LessThanEqualCondition;
+use CmsIg\Seal\Search\Condition\NotEqualCondition;
+use CmsIg\Seal\Search\Condition\NotInCondition;
+use CmsIg\Seal\Search\Condition\SearchCondition;
+use CmsIg\Seal\Search\Facet\AbstractFacet;
+
+final class SearchBuilderFactoryConfig
+{
+    /**
+     * @param array<string> $filterFields
+     * @param array<string> $sortFields
+     * @param array<string> $facetFields
+     * @param array<string> $distinctFields
+     * @param array<string> $highlightFields
+     */
+    public function __construct(
+        public readonly array $filterFields = [],
+        public readonly array $sortFields = [],
+        public readonly array $facetFields = [],
+        public readonly array $distinctFields = [],
+        public readonly array $highlightFields = [],
+        public readonly bool $allowSearch = false,
+        public readonly bool $allowIdentifier = false,
+        public readonly int|null $maxLimit = 0,
+    ) {
+    }
+
+    public function validateCondition(object $condition, Index $index): void
+    {
+        if ($condition instanceof SearchCondition) {
+            if (false === $this->allowSearch) {
+                throw new \InvalidArgumentException('Search conditions are not allowed by this search builder factory config.');
+            }
+
+            return;
+        }
+
+        if ($condition instanceof IdentifierCondition) {
+            if (false === $this->allowIdentifier) {
+                throw new \InvalidArgumentException('Identifier conditions are not allowed by this search builder factory config.');
+            }
+
+            return;
+        }
+
+        if ($condition instanceof AbstractGroupCondition) {
+            foreach ($condition->conditions as $groupedCondition) {
+                $this->validateCondition($groupedCondition, $index);
+            }
+
+            return;
+        }
+
+        if (
+            $condition instanceof EqualCondition
+            || $condition instanceof NotEqualCondition
+            || $condition instanceof GreaterThanCondition
+            || $condition instanceof GreaterThanEqualCondition
+            || $condition instanceof LessThanCondition
+            || $condition instanceof LessThanEqualCondition
+            || $condition instanceof InCondition
+            || $condition instanceof NotInCondition
+            || $condition instanceof GeoDistanceCondition
+            || $condition instanceof GeoBoundingBoxCondition
+        ) {
+            $this->assertSchemaField('filterable', $condition->field, $index->filterableFields, $index);
+            $this->assertAllowed('filter', $condition->field, $this->filterFields);
+
+            return;
+        }
+
+        throw new \InvalidArgumentException(\sprintf('Unsupported search condition "%s".', $condition::class));
+    }
+
+    public function validateSort(string $field, Index $index): void
+    {
+        $this->assertSchemaField('sortable', $field, $index->sortableFields, $index);
+        $this->assertAllowed('sort', $field, $this->sortFields);
+    }
+
+    public function validateLimit(int|null $limit): void
+    {
+        if (null !== $limit && null !== $this->maxLimit && $limit > $this->maxLimit) {
+            throw new \InvalidArgumentException(\sprintf('Search builder limit "%d" exceeds the allowed maximum of "%d".', $limit, $this->maxLimit));
+        }
+    }
+
+    public function validateHighlight(string $field, Index $index): void
+    {
+        $this->assertSchemaField('searchable', $field, $index->searchableFields, $index);
+        $this->assertAllowed('highlight', $field, $this->highlightFields);
+    }
+
+    public function validateDistinct(string $field, Index $index): void
+    {
+        $this->assertSchemaField('distinct', $field, $index->distinctFields, $index);
+        $this->assertAllowed('distinct', $field, $this->distinctFields);
+    }
+
+    public function validateFacet(AbstractFacet $facet, Index $index): void
+    {
+        $this->assertSchemaField('facet', $facet->field, $index->facetFields, $index);
+        $this->assertAllowed('facet', $facet->field, $this->facetFields);
+    }
+
+    /**
+     * @param array<string> $allowed
+     */
+    private function assertAllowed(string $context, string $value, array $allowed): void
+    {
+        if (!\in_array($value, $allowed, true)) {
+            throw new \InvalidArgumentException(\sprintf('Search builder %s "%s" is not allowed by this config.', $context, $value));
+        }
+    }
+
+    /**
+     * @param array<string> $allowedFields
+     */
+    private function assertSchemaField(string $context, string $field, array $allowedFields, Index $index): void
+    {
+        if (!\in_array($field, $allowedFields, true)) {
+            throw new \InvalidArgumentException(\sprintf('Search builder %s field "%s" is not configured as %s in index "%s".', $context, $field, $context, $index->name));
+        }
+    }
+}

--- a/packages/seal/src/Search/SearchBuilderFactory/SearchBuilderFactoryConfig.php
+++ b/packages/seal/src/Search/SearchBuilderFactory/SearchBuilderFactoryConfig.php
@@ -28,6 +28,7 @@ use CmsIg\Seal\Search\Condition\NotEqualCondition;
 use CmsIg\Seal\Search\Condition\NotInCondition;
 use CmsIg\Seal\Search\Condition\SearchCondition;
 use CmsIg\Seal\Search\Facet\AbstractFacet;
+use CmsIg\Seal\Search\TypeUtil;
 
 final class SearchBuilderFactoryConfig
 {
@@ -48,6 +49,59 @@ final class SearchBuilderFactoryConfig
         public readonly bool $allowIdentifier = false,
         public readonly int|null $maxLimit = 0,
     ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $allowSearch = $data['allowSearch'] ?? false;
+        if (!\is_bool($allowSearch)) {
+            throw new \InvalidArgumentException('Value for "allowSearch" must be a boolean.');
+        }
+
+        $allowIdentifier = $data['allowIdentifier'] ?? false;
+        if (!\is_bool($allowIdentifier)) {
+            throw new \InvalidArgumentException('Value for "allowIdentifier" must be a boolean.');
+        }
+
+        return new self(
+            TypeUtil::readStringListByKey($data, 'filterFields', []),
+            TypeUtil::readStringListByKey($data, 'sortFields', []),
+            TypeUtil::readStringListByKey($data, 'facetFields', []),
+            TypeUtil::readStringListByKey($data, 'distinctFields', []),
+            TypeUtil::readStringListByKey($data, 'highlightFields', []),
+            $allowSearch,
+            $allowIdentifier,
+            TypeUtil::readNullableNonNegativeIntByKey($data, 'maxLimit', 0),
+        );
+    }
+
+    /**
+     * @return array{
+     *     filterFields: array<string>,
+     *     sortFields: array<string>,
+     *     facetFields: array<string>,
+     *     distinctFields: array<string>,
+     *     highlightFields: array<string>,
+     *     allowSearch: bool,
+     *     allowIdentifier: bool,
+     *     maxLimit: int|null
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'filterFields' => $this->filterFields,
+            'sortFields' => $this->sortFields,
+            'facetFields' => $this->facetFields,
+            'distinctFields' => $this->distinctFields,
+            'highlightFields' => $this->highlightFields,
+            'allowSearch' => $this->allowSearch,
+            'allowIdentifier' => $this->allowIdentifier,
+            'maxLimit' => $this->maxLimit,
+        ];
     }
 
     public function validateCondition(object $condition, Index $index): void

--- a/packages/seal/src/Search/TypeUtil.php
+++ b/packages/seal/src/Search/TypeUtil.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS-IG SEAL project.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CmsIg\Seal\Search;
+
+/**
+ * @internal
+ */
+final class TypeUtil
+{
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function readStringByKey(array $data, string $key, string|null $default = null): string
+    {
+        $value = $data[$key] ?? $default;
+        if (!\is_string($value)) {
+            throw new \InvalidArgumentException(\sprintf('Value for "%s" must be a string.', $key));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function readNullableStringByKey(array $data, string $key, string|null $default = null): string|null
+    {
+        $value = $data[$key] ?? $default;
+        if (null !== $value && !\is_string($value)) {
+            throw new \InvalidArgumentException(\sprintf('Value for "%s" must be a string or null.', $key));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function readScalarByKey(array $data, string $key): string|int|float|bool
+    {
+        $value = $data[$key] ?? null;
+        if (!\is_string($value) && !\is_int($value) && !\is_float($value) && !\is_bool($value)) {
+            throw new \InvalidArgumentException(\sprintf('Value for "%s" must be a string, integer, float or boolean.', $key));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @param array<mixed>|null $default
+     *
+     * @return array<mixed>
+     */
+    public static function readArrayByKey(array $data, string $key, array|null $default = null): array
+    {
+        $value = $data[$key] ?? $default;
+        if (!\is_array($value)) {
+            throw new \InvalidArgumentException(\sprintf('Value for "%s" must be an array.', $key));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @param array<string, mixed>|null $default
+     *
+     * @return array<string, mixed>
+     */
+    public static function readStringKeyedArrayByKey(array $data, string $key, array|null $default = null): array
+    {
+        return self::ensureStringKeyedArray(self::readArrayByKey($data, $key, $default), $key);
+    }
+
+    /**
+     * @param array<mixed> $value
+     *
+     * @return array<string, mixed>
+     */
+    public static function ensureStringKeyedArray(array $value, string $context): array
+    {
+        $stringKeyedValue = [];
+        foreach (\array_keys($value) as $key) {
+            if (!\is_string($key)) {
+                throw new \InvalidArgumentException(\sprintf('Value for "%s" must be an array with string keys.', $context));
+            }
+
+            $stringKeyedValue[$key] = $value[$key];
+        }
+
+        return $stringKeyedValue;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function ensureStringKeyedArrayValue(mixed $value, string $context): array
+    {
+        if (!\is_array($value)) {
+            throw new \InvalidArgumentException(\sprintf('Value for "%s" must be an array.', $context));
+        }
+
+        return self::ensureStringKeyedArray($value, $context);
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param class-string<T> $class
+     *
+     * @return T
+     */
+    public static function ensureInstanceOf(mixed $value, string $class, string $context): object
+    {
+        if (!$value instanceof $class) {
+            $actual = \get_debug_type($value);
+
+            throw new \InvalidArgumentException(\sprintf('Value for "%s" must be an instance of "%s", "%s" given.', $context, $class, $actual));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return list<string|int|float|bool>
+     */
+    public static function readScalarListByKey(array $data, string $key): array
+    {
+        $values = self::readArrayByKey($data, $key);
+        foreach ($values as $index => $value) {
+            try {
+                $values[$index] = self::readScalarByKey([$key => $value], $key);
+            } catch (\InvalidArgumentException $exception) {
+                throw new \InvalidArgumentException(\sprintf('Value for "%s" at index "%s" must be a string, integer, float or boolean.', $key, $index), $exception->getCode(), previous: $exception);
+            }
+        }
+
+        /** @var list<string|int|float|bool> $values */
+        $values = \array_values($values);
+
+        return $values;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @param array<string>|null $default
+     *
+     * @return array<string>
+     */
+    public static function readStringListByKey(array $data, string $key, array|null $default = null): array
+    {
+        $values = self::readArrayByKey($data, $key, $default);
+        foreach ($values as $index => $value) {
+            try {
+                $values[$index] = self::readStringByKey([$key => $value], $key);
+            } catch (\InvalidArgumentException $exception) {
+                throw new \InvalidArgumentException(\sprintf('Value for "%s" at index "%s" must be a string.', $key, $index), $exception->getCode(), previous: $exception);
+            }
+        }
+
+        /** @var array<string> $values */
+        $values = \array_values($values);
+
+        return $values;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function readFloatByKey(array $data, string $key): float
+    {
+        $value = $data[$key] ?? null;
+        if (!\is_float($value) && !\is_int($value)) {
+            throw new \InvalidArgumentException(\sprintf('Value for "%s" must be a number.', $key));
+        }
+
+        return (float) $value;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function readIntByKey(array $data, string $key): int
+    {
+        $value = $data[$key] ?? null;
+        if (!\is_int($value)) {
+            throw new \InvalidArgumentException(\sprintf('Value for "%s" must be an integer.', $key));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function readNonNegativeIntByKey(array $data, string $key, int $default = 0): int
+    {
+        $value = $data[$key] ?? $default;
+        if (!\is_int($value) || $value < 0) {
+            throw new \InvalidArgumentException(\sprintf('Value for "%s" must be a non-negative integer.', $key));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function readNullableNonNegativeIntByKey(array $data, string $key, int|null $default = null): int|null
+    {
+        $value = $data[$key] ?? $default;
+        if (null !== $value && (!\is_int($value) || $value < 0)) {
+            throw new \InvalidArgumentException(\sprintf('Value for "%s" must be a non-negative integer or null.', $key));
+        }
+
+        return $value;
+    }
+}

--- a/packages/seal/tests/Search/SearchBuilderFactory/ArraySearchBuilderFactoryTest.php
+++ b/packages/seal/tests/Search/SearchBuilderFactory/ArraySearchBuilderFactoryTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS-IG SEAL project.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CmsIg\Seal\Tests\Search\SearchBuilderFactory;
+
+use CmsIg\Seal\Adapter\SearcherInterface;
+use CmsIg\Seal\EngineInterface;
+use CmsIg\Seal\Schema\Index;
+use CmsIg\Seal\Search\Condition\Condition;
+use CmsIg\Seal\Search\Facet\Facet;
+use CmsIg\Seal\Search\Result;
+use CmsIg\Seal\Search\Search;
+use CmsIg\Seal\Search\SearchBuilder;
+use CmsIg\Seal\Search\SearchBuilderFactory\ArraySearchBuilderFactory;
+use CmsIg\Seal\Search\SearchBuilderFactory\SearchBuilderFactoryConfig;
+use CmsIg\Seal\Testing\TestingHelper;
+use PHPUnit\Framework\TestCase;
+
+class ArraySearchBuilderFactoryTest extends TestCase
+{
+    public function testSerializeAndDeserializeSearchBuilder(): void
+    {
+        $factory = $this->createArraySearchBuilderFactory();
+
+        $builder = $this->createSearchBuilder()
+            ->addFilter(Condition::search('cms'))
+            ->addFilter(Condition::or(
+                Condition::equal('tags', 'php'),
+                Condition::greaterThanEqual('rating', 4.5),
+            ))
+            ->addFilter(Condition::geoDistance('location', 47.3769, 8.5417, 5000))
+            ->addSortBy('rating', 'desc')
+            ->limit(20)
+            ->offset(40)
+            ->highlight(['title', 'article'])
+            ->distinct('commentsCount')
+            ->addFacet(Facet::count('tags', ['limit' => 10]))
+            ->addFacet(Facet::minMax('rating'));
+
+        $serialized = $factory->toArray($builder);
+        $deserialized = $factory->buildFromJson(
+            TestingHelper::INDEX_COMPLEX,
+            new SearchBuilderFactoryConfig(
+                filterFields: ['tags', 'rating', 'location'],
+                sortFields: ['rating'],
+                facetFields: ['tags', 'rating'],
+                distinctFields: ['commentsCount'],
+                highlightFields: ['title', 'article'],
+                allowSearch: true,
+                maxLimit: 20,
+            ),
+            $factory->toJson($builder),
+        );
+
+        $this->assertSame($serialized, $factory->toArray($deserialized));
+        $this->assertArrayNotHasKey('index', $serialized);
+    }
+
+    public function testDeserializeSearchBuilderWithValidationAllowList(): void
+    {
+        $builder = $this->createArraySearchBuilderFactory()->build(TestingHelper::INDEX_COMPLEX, new SearchBuilderFactoryConfig(
+            filterFields: ['tags'],
+            sortFields: ['rating'],
+            facetFields: ['tags'],
+            maxLimit: 20,
+        ), [
+            'filters' => [
+                [
+                    'type' => 'equal',
+                    'field' => 'tags',
+                    'value' => 'php',
+                ],
+            ],
+            'sortBys' => [
+                'rating' => 'desc',
+            ],
+            'limit' => 10,
+            'facets' => [
+                [
+                    'type' => 'count',
+                    'field' => 'tags',
+                ],
+            ],
+        ]);
+
+        $this->assertSame('tags', $builder->getSearch()->facets[0]->field);
+    }
+
+    public function testDeserializeSearchBuilderRejectsDefaultConfig(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Search conditions are not allowed by this search builder factory config.');
+
+        $this->createArraySearchBuilderFactory()->build(TestingHelper::INDEX_COMPLEX, new SearchBuilderFactoryConfig(), [
+            'filters' => [
+                [
+                    'type' => 'search',
+                    'query' => 'cms',
+                ],
+            ],
+        ]);
+    }
+
+    public function testDeserializeSearchBuilderRejectsFieldsOutsideValidationAllowList(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Search builder filter "rating" is not allowed by this config.');
+
+        $this->createArraySearchBuilderFactory()->build(TestingHelper::INDEX_COMPLEX, new SearchBuilderFactoryConfig(filterFields: ['tags']), [
+            'filters' => [
+                [
+                    'type' => 'equal',
+                    'field' => 'rating',
+                    'value' => 5,
+                ],
+            ],
+        ]);
+    }
+
+    public function testDeserializeSearchBuilderRejectsFieldsUnsupportedBySchema(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Search builder filterable field "title" is not configured as filterable');
+
+        $this->createArraySearchBuilderFactory()->build(TestingHelper::INDEX_COMPLEX, new SearchBuilderFactoryConfig(
+            filterFields: ['title'],
+        ), [
+            'filters' => [
+                [
+                    'type' => 'equal',
+                    'field' => 'title',
+                    'value' => 'cms',
+                ],
+            ],
+        ]);
+    }
+
+    public function testDeserializeSearchBuilderRejectsLimitAboveValidationMaximum(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Search builder limit "11" exceeds the allowed maximum of "10".');
+
+        $this->createArraySearchBuilderFactory()->build(TestingHelper::INDEX_COMPLEX, new SearchBuilderFactoryConfig(maxLimit: 10), [
+            'limit' => 11,
+        ]);
+    }
+
+    private function createSearchBuilder(): SearchBuilder
+    {
+        return (new SearchBuilder(TestingHelper::createSchema(), $this->createSearcher()))
+            ->index(TestingHelper::INDEX_COMPLEX);
+    }
+
+    private function createArraySearchBuilderFactory(): ArraySearchBuilderFactory
+    {
+        $engine = $this->createMock(EngineInterface::class);
+        $engine->method('createSearchBuilder')
+            ->willReturnCallback(
+                fn (string $index): SearchBuilder => (new SearchBuilder(TestingHelper::createSchema(), $this->createSearcher()))
+                    ->index($index),
+            );
+
+        return new ArraySearchBuilderFactory($engine);
+    }
+
+    private function createSearcher(): SearcherInterface
+    {
+        return new class() implements SearcherInterface {
+            public function search(Search $search): Result
+            {
+                return Result::createEmpty();
+            }
+
+            public function count(Index $index): int
+            {
+                return 0;
+            }
+        };
+    }
+}

--- a/packages/seal/tests/Search/SearchBuilderFactory/SearchBuilderFactoryConfigTest.php
+++ b/packages/seal/tests/Search/SearchBuilderFactory/SearchBuilderFactoryConfigTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS-IG SEAL project.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CmsIg\Seal\Tests\Search\SearchBuilderFactory;
+
+use CmsIg\Seal\Search\SearchBuilderFactory\SearchBuilderFactoryConfig;
+use PHPUnit\Framework\TestCase;
+
+class SearchBuilderFactoryConfigTest extends TestCase
+{
+    public function testFromArrayAndToArrayRoundTrip(): void
+    {
+        $data = [
+            'filterFields' => ['tags', 'rating'],
+            'sortFields' => ['rating'],
+            'facetFields' => ['tags'],
+            'distinctFields' => ['commentsCount'],
+            'highlightFields' => ['title', 'article'],
+            'allowSearch' => true,
+            'allowIdentifier' => true,
+            'maxLimit' => 50,
+        ];
+
+        $config = SearchBuilderFactoryConfig::fromArray($data);
+
+        $this->assertSame($data, $config->toArray());
+    }
+
+    public function testFromArrayUsesDefaults(): void
+    {
+        $config = SearchBuilderFactoryConfig::fromArray([]);
+
+        $this->assertSame((new SearchBuilderFactoryConfig())->toArray(), $config->toArray());
+    }
+
+    public function testFromArrayRejectsInvalidAllowSearchType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Value for "allowSearch" must be a boolean.');
+
+        SearchBuilderFactoryConfig::fromArray([
+            'allowSearch' => 1,
+        ]);
+    }
+}


### PR DESCRIPTION
Search UIs often need to preserve and share a complete search state: query text, filters, sorting, pagination, highlighting, distinct handling, and facets. Passing each part through separate request parameters makes controller and API code grow quickly, and it becomes harder to hand the same search state between pages, links, and clients.

This adds a JSON representation for `SearchBuilder`, so applications can pass the complete search state as one value, for example `?search=<json>`.

The index remains internal and is intentionally not part of the serialized payload. Public endpoints can also provide a `SearchBuilderValidation` instance when reading external JSON, allowing them to expose only a safe subset of internally available filters, facets, sorting, and other search features.

See documentation on how this can be used 😎 