### PR TITLE
Add normalization of Facet Count Limit to 100

### DIFF
--- a/packages/seal-algolia-adapter/src/AlgoliaSearcher.php
+++ b/packages/seal-algolia-adapter/src/AlgoliaSearcher.php
@@ -130,6 +130,9 @@ final class AlgoliaSearcher implements SearcherInterface
         }
 
         $searchParams['facets'] = \array_map(static fn (AbstractFacet $facet) => $facet->field, $search->facets);
+        if ([] !== \array_filter($search->facets, static fn (AbstractFacet $facet) => $facet instanceof CountFacet)) {
+            $searchParams['maxValuesPerFacet'] = CountFacet::DEFAULT_MAX_VALUES;
+        }
 
         $data = $this->client->searchSingleIndex($indexName, $searchParams);
         \assert(\is_array($data) && isset($data['hits']) && \is_array($data['hits']), 'The "hits" array is expected to be returned by algolia client.');

--- a/packages/seal-elasticsearch-adapter/src/ElasticsearchSearcher.php
+++ b/packages/seal-elasticsearch-adapter/src/ElasticsearchSearcher.php
@@ -139,6 +139,7 @@ final class ElasticsearchSearcher implements SearcherInterface
         foreach ($search->facets as $facet) {
             if ($facet instanceof CountFacet) {
                 $body['aggs'][$facet->field . '_count']['terms']['field'] = $this->getFilterField($search->index, $facet->field);
+                $body['aggs'][$facet->field . '_count']['terms']['size'] = CountFacet::DEFAULT_MAX_VALUES;
             }
             if ($facet instanceof MinMaxFacet) {
                 $body['aggs'][$facet->field . '_min']['min']['field'] = $this->getFilterField($search->index, $facet->field);
@@ -312,7 +313,7 @@ final class ElasticsearchSearcher implements SearcherInterface
             if ($facet instanceof CountFacet && isset($aggregations[$facet->field . '_count']['buckets'])) {
                 foreach ($aggregations[$facet->field . '_count']['buckets'] as $bucket) {
                     $key = (string) ($bucket['key_as_string'] ?? $bucket['key']);
-                    $formatted[$facet->field]['count'][$key] = $bucket['doc_count']; // @phpstan-ignore-line offsetAccess.nonOffsetAccessible
+                    $formatted[$facet->field]['count'][$key] = $bucket['doc_count'];
                 }
             }
         }

--- a/packages/seal-meilisearch-adapter/src/MeilisearchSchemaManager.php
+++ b/packages/seal-meilisearch-adapter/src/MeilisearchSchemaManager.php
@@ -16,6 +16,7 @@ namespace CmsIg\Seal\Adapter\Meilisearch;
 use CmsIg\Seal\Adapter\SchemaManagerInterface;
 use CmsIg\Seal\Schema\Field\GeoPointField;
 use CmsIg\Seal\Schema\Index;
+use CmsIg\Seal\Search\Facet\CountFacet;
 use CmsIg\Seal\Task\AsyncTask;
 use CmsIg\Seal\Task\TaskInterface;
 use Meilisearch\Client;
@@ -75,6 +76,9 @@ final class MeilisearchSchemaManager implements SchemaManagerInterface
             'searchableAttributes' => $index->searchableFields,
             'filterableAttributes' => $filterableFields,
             'sortableAttributes' => $index->sortableFields,
+            'faceting' => [
+                'maxValuesPerFacet' => CountFacet::DEFAULT_MAX_VALUES,
+            ],
         ];
 
         $geoPointField = $index->getGeoPointField();

--- a/packages/seal-memory-adapter/src/MemorySearcher.php
+++ b/packages/seal-memory-adapter/src/MemorySearcher.php
@@ -556,6 +556,8 @@ final class MemorySearcher implements SearcherInterface
 
                         ++$facets[$facet->field]['count'][$value];
                     }
+
+                    $facets[$facet->field]['count'] = \array_slice($facets[$facet->field]['count'] ?? [], 0, CountFacet::DEFAULT_MAX_VALUES, true);
                 }
 
                 if ($facet instanceof MinMaxFacet) {

--- a/packages/seal-opensearch-adapter/src/OpensearchSearcher.php
+++ b/packages/seal-opensearch-adapter/src/OpensearchSearcher.php
@@ -124,6 +124,7 @@ final class OpensearchSearcher implements SearcherInterface
         foreach ($search->facets as $facet) {
             if ($facet instanceof CountFacet) {
                 $body['aggs'][$facet->field . '_count']['terms']['field'] = $this->getFilterField($search->index, $facet->field);
+                $body['aggs'][$facet->field . '_count']['terms']['size'] = CountFacet::DEFAULT_MAX_VALUES;
             }
             if ($facet instanceof MinMaxFacet) {
                 $body['aggs'][$facet->field . '_min']['min']['field'] = $this->getFilterField($search->index, $facet->field);
@@ -276,7 +277,7 @@ final class OpensearchSearcher implements SearcherInterface
             if ($facet instanceof CountFacet && isset($aggregations[$facet->field . '_count']['buckets'])) {
                 foreach ($aggregations[$facet->field . '_count']['buckets'] as $bucket) {
                     $key = (string) ($bucket['key_as_string'] ?? $bucket['key']);
-                    $formatted[$facet->field]['count'][$key] = $bucket['doc_count']; // @phpstan-ignore-line offsetAccess.nonOffsetAccessible
+                    $formatted[$facet->field]['count'][$key] = $bucket['doc_count'];
                 }
             }
         }

--- a/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
@@ -386,6 +386,7 @@ final class RediSearchSearcher implements SearcherInterface
                 $arguments = \array_merge($arguments, [
                     'GROUPBY', '1', '@' . $this->getFilterField($search->index, $facet->field),
                     'REDUCE', 'COUNT', '0', 'AS', 'count',
+                    'LIMIT', '0', (string) CountFacet::DEFAULT_MAX_VALUES,
                 ]);
 
                 $arguments[] = 'DIALECT';

--- a/packages/seal-solr-adapter/src/SolrSearcher.php
+++ b/packages/seal-solr-adapter/src/SolrSearcher.php
@@ -133,6 +133,7 @@ final class SolrSearcher implements SearcherInterface
             /** @var SolariumFacetField $facetField */
             $facetField = $facetSet->createFacetField($this->getFilterField($search->index, $facet->field));
             $facetField->setField($this->getFilterField($search->index, $facet->field));
+            $facetField->setLimit(CountFacet::DEFAULT_MAX_VALUES);
         }
 
         if ([] !== $search->highlightFields) {

--- a/packages/seal-typesense-adapter/src/TypesenseSearcher.php
+++ b/packages/seal-typesense-adapter/src/TypesenseSearcher.php
@@ -118,6 +118,9 @@ final class TypesenseSearcher implements SearcherInterface
         }
 
         $searchParams['facet_by'] = \implode(',', \array_map(static fn (AbstractFacet $facet) => $facet->field, $search->facets));
+        if ([] !== \array_filter($search->facets, static fn (AbstractFacet $facet) => $facet instanceof CountFacet)) {
+            $searchParams['max_facet_values'] = CountFacet::DEFAULT_MAX_VALUES;
+        }
 
         $data = $this->client->collections[$search->index->name]->documents->search($searchParams);
 

--- a/packages/seal/src/Search/Facet/CountFacet.php
+++ b/packages/seal/src/Search/Facet/CountFacet.php
@@ -18,4 +18,6 @@ namespace CmsIg\Seal\Search\Facet;
  */
 class CountFacet extends AbstractFacet
 {
+    /** @internal */
+    final public const DEFAULT_MAX_VALUES = 100;
 }

--- a/packages/seal/src/Testing/AbstractSearcherTestCase.php
+++ b/packages/seal/src/Testing/AbstractSearcherTestCase.php
@@ -19,6 +19,7 @@ use CmsIg\Seal\Adapter\SchemaManagerInterface;
 use CmsIg\Seal\Adapter\SearcherInterface;
 use CmsIg\Seal\Schema\Schema;
 use CmsIg\Seal\Search\Condition\Condition;
+use CmsIg\Seal\Search\Facet\CountFacet;
 use CmsIg\Seal\Search\Facet\Facet;
 use CmsIg\Seal\Search\SearchBuilder;
 use PHPUnit\Framework\TestCase;
@@ -297,6 +298,48 @@ abstract class AbstractSearcherTestCase extends TestCase
                 ['return_slow_promise_result' => true],
             );
         }
+    }
+
+    public function testCountFacetIsTrimmedToDefaultMaxValues(): void
+    {
+        $schema = self::getSchema();
+        $index = $schema->indexes[TestingHelper::INDEX_COMPLEX];
+        $documents = [];
+
+        for ($i = 1; $i <= CountFacet::DEFAULT_MAX_VALUES + 11; ++$i) {
+            $documents[] = [
+                'uuid' => 'facet-trim-' . $i,
+                'rating' => (float) $i,
+            ];
+        }
+
+        foreach ($documents as $document) {
+            self::$taskHelper->tasks[] = self::$indexer->save(
+                $index,
+                $document,
+                ['return_slow_promise_result' => true],
+            );
+        }
+        self::$taskHelper->waitForAll();
+
+        $search = new SearchBuilder($schema, self::$searcher);
+        $search->index(TestingHelper::INDEX_COMPLEX);
+        $search->addFacet(Facet::count(field: 'rating'));
+
+        /** @var array{rating: array{count: array<string, int>}} $facets */
+        $facets = $search->getResult()->facets();
+        $ratingFacetCount = $facets['rating']['count'];
+
+        $this->assertCount(CountFacet::DEFAULT_MAX_VALUES, $ratingFacetCount);
+
+        foreach ($documents as $document) {
+            self::$taskHelper->tasks[] = self::$indexer->delete(
+                $index,
+                $document['uuid'],
+                ['return_slow_promise_result' => true],
+            );
+        }
+        self::$taskHelper->waitForAll();
     }
 
     public function testCount(): void


### PR DESCRIPTION
We should be as consistent as possible between adapters. The facet counts are currently different between all of them:

Research Results currently:

| Adapter       | Default | Max-Value   | Docs
|---------------|---------|-------------|------
| Algolia       | 100     | 1000        | https://www.algolia.com/doc/api-reference/api-parameters/maxValuesPerFacet
| Meilisearch   | 100     | 100 (index setting)         |  https://www.meilisearch.com/docs/capabilities/filtering_sorting_faceting/how_to/build_faceted_navigation#tune-maxvaluesperfacet or https://www.meilisearch.com/docs/resources/help/known_limitations#facet-search-limitation
| Loupe         | 100     | 100  | Hardcoded to 100: https://github.com/loupe-php/loupe/blob/0.13.16/src/Internal/Search/Searcher.php#L413 or See comment [below](https://github.com/PHP-CMSIG/search/issues/685#issuecomment-4496289934)
| Elasticsearch | 10      | 65536       | https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-terms-aggregation#search-aggregations-bucket-terms-aggregation-size or https://www.elastic.co/docs/reference/elasticsearch/configuration-reference/search-settings#search-settings-max-buckets
| Opensearch    | 10      | 65536       | https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/search-settings/ or https://docs.opensearch.org/latest/aggregations/bucket/terms/#size-and-shard-size-parameters
| Solr          | 100     | ∞(via:-1)  | https://solr.apache.org/guide/solr/latest/query-guide/faceting.html
| Typesense     | 10      | no-docs     | https://typesense.org/docs/29.0/api/search.html#faceting-parameters
| Redis         | ∞       | ∞           | https://redis.io/docs/latest/commands/ft.aggregate/
| Memory         | ∞       | ∞           | Our own

This Pull Request normalize them to a value of `100`.

See also issue: https://github.com/PHP-CMSIG/search/issues/685