### PR TITLE
Change Redis DIALECT for AGGREGATE from 3 to 2

### DIFF
--- a/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
@@ -88,7 +88,7 @@ final class RediSearchSearcher implements SearcherInterface
         $arguments = [
             'GROUPBY', 1, $distinctField,
             'REDUCE', 'FIRST_VALUE', '1', $identifierField, 'AS', 'documentId',
-            'DIALECT', '3',
+            'DIALECT', '2',
         ];
 
         /** @var array<mixed>|false $result */


### PR DESCRIPTION
DIALECTS 3 was introduced in Distinct here: https://github.com/PHP-CMSIG/search/pull/551. We switched the DIALECTS from 3 to 2 in: https://github.com/PHP-CMSIG/search/pull/554 because Redis deprecated all other DIALECTS: https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/dialects/ but seems we just missed udpated it the already open PR at that time.