### PR TITLE
Fix RediSearch Adapter Filters when field not searchable ( :warning: Require Reindex )

### DIFF
--- a/packages/seal-algolia-adapter/tests/AlgoliaSchemaManagerTest.php
+++ b/packages/seal-algolia-adapter/tests/AlgoliaSchemaManagerTest.php
@@ -100,6 +100,7 @@ class AlgoliaSchemaManagerTest extends AbstractSchemaManagerTestCase
             ],
             'attributesForFaceting' => [
                 'uuid',
+                'locale',
                 'created',
                 'commentsCount',
                 'rating',

--- a/packages/seal-elasticsearch-adapter/tests/ElasticsearchSchemaManagerTest.php
+++ b/packages/seal-elasticsearch-adapter/tests/ElasticsearchSchemaManagerTest.php
@@ -178,6 +178,15 @@ class ElasticsearchSchemaManagerTest extends AbstractSchemaManagerTestCase
                 'type' => 'boolean',
                 'index' => false,
             ],
+            'locale' => [
+                'type' => 'text',
+                'index' => false,
+                'fields' => [
+                    'raw' => [
+                        'type' => 'keyword',
+                    ],
+                ],
+            ],
             'location' => [
                 'type' => 'geo_point',
                 'index' => false,

--- a/packages/seal-opensearch-adapter/tests/OpensearchSchemaManagerTest.php
+++ b/packages/seal-opensearch-adapter/tests/OpensearchSchemaManagerTest.php
@@ -166,6 +166,14 @@ class OpensearchSchemaManagerTest extends AbstractSchemaManagerTestCase
             'isSpecial' => [
                 'type' => 'boolean',
             ],
+            'locale' => [
+                'type' => 'text',
+                'fields' => [
+                    'raw' => [
+                        'type' => 'keyword',
+                    ],
+                ],
+            ],
             'location' => [
                 'type' => 'geo_point',
             ],

--- a/packages/seal-redisearch-adapter/src/RediSearchIndexer.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchIndexer.php
@@ -29,7 +29,6 @@ final class RediSearchIndexer implements IndexerInterface
     ) {
         $this->marshaller = new Marshaller(
             dateFormat: 'U',
-            addRawFilterTextField: true,
             geoPointFieldConfig: [
                 'latitude' => 1,
                 'longitude' => 0,

--- a/packages/seal-redisearch-adapter/src/RediSearchSchemaManager.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchSchemaManager.php
@@ -68,7 +68,7 @@ final class RediSearchSchemaManager implements SchemaManagerInterface
             $properties[] = \str_replace('.', '__', $name);
             $properties[] = $indexField['type'];
 
-            if (!$indexField['searchable'] && !$indexField['filterable']) { // TODO check if we can make something filterable but not searchable
+            if (!$indexField['searchable'] && !$indexField['filterable']) {
                 $properties[] = 'NOINDEX';
             }
 
@@ -117,10 +117,8 @@ final class RediSearchSchemaManager implements SchemaManagerInterface
 
         foreach ($fields as $name => $field) {
             $jsonPath = $jsonPathPrefix . '[\'' . $name . '\']';
-            $jsonPathRaw = $jsonPathPrefix . '[\'' . $name . '.raw\']';
             if ($field->multiple) {
                 $jsonPath .= '[*]';
-                $jsonPathRaw .= '[*]';
             }
             $name = $prefix . $name;
 
@@ -147,7 +145,7 @@ final class RediSearchSchemaManager implements SchemaManagerInterface
                     ],
                 ] : [], $field->filterable || $field->facet || $field->sortable ? [
                     $name . '.raw' => [
-                        'jsonPath' => $jsonPathRaw,
+                        'jsonPath' => $jsonPath,
                         'type' => 'TAG',
                         'searchable' => false,
                         'sortable' => $field->sortable,

--- a/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
@@ -32,7 +32,6 @@ final class RediSearchSearcher implements SearcherInterface
     ) {
         $this->marshaller = new Marshaller(
             dateFormat: 'U',
-            addRawFilterTextField: true,
             geoPointFieldConfig: [
                 'latitude' => 1,
                 'longitude' => 0,

--- a/packages/seal/src/Testing/AbstractSearcherTestCase.php
+++ b/packages/seal/src/Testing/AbstractSearcherTestCase.php
@@ -618,6 +618,52 @@ abstract class AbstractSearcherTestCase extends TestCase
         }
     }
 
+    public function testEqualConditionNotSearchable(): void
+    {
+        $documents = TestingHelper::createComplexFixtures();
+
+        $schema = self::getSchema();
+
+        foreach ($documents as $document) {
+            self::$taskHelper->tasks[] = self::$indexer->save(
+                $schema->indexes[TestingHelper::INDEX_COMPLEX],
+                $document,
+                ['return_slow_promise_result' => true],
+            );
+        }
+        self::$taskHelper->waitForAll();
+
+        $search = new SearchBuilder($schema, self::$searcher);
+        $search->index(TestingHelper::INDEX_COMPLEX);
+        $search->addFilter(Condition::equal('locale', 'en_GB'));
+
+        $expectedDocumentsVariantA = [
+            $documents[0],
+            $documents[2],
+        ];
+        $expectedDocumentsVariantB = [
+            $documents[2],
+            $documents[0],
+        ];
+
+        $loadedDocuments = [...$search->getResult()];
+        $this->assertCount(2, $loadedDocuments);
+
+        $this->assertTrue(
+            $expectedDocumentsVariantA === $loadedDocuments
+            || $expectedDocumentsVariantB === $loadedDocuments,
+            'Not correct documents where found.',
+        );
+
+        foreach ($documents as $document) {
+            self::$taskHelper->tasks[] = self::$indexer->delete(
+                $schema->indexes[TestingHelper::INDEX_COMPLEX],
+                $document['uuid'],
+                ['return_slow_promise_result' => true],
+            );
+        }
+    }
+
     public function testEqualConditionWithBoolean(): void
     {
         $documents = TestingHelper::createComplexFixtures();

--- a/packages/seal/src/Testing/TestingHelper.php
+++ b/packages/seal/src/Testing/TestingHelper.php
@@ -48,6 +48,7 @@ final class TestingHelper
         $complexFields = [
             'uuid' => new Field\IdentifierField('uuid'),
             'title' => new Field\TextField('title', sortable: true),
+            'locale' => new Field\TextField('locale', searchable: false, filterable: true),
             'header' => new Field\TypedField('header', 'type', [
                 'image' => [
                     'media' => new Field\IntegerField('media'),
@@ -104,6 +105,7 @@ final class TestingHelper
      * @return array<array{
      *     uuid: string,
      *     title?: string|null,
+     *     locale?: string|null,
      *     header?: array{
      *         type: string,
      *         media: int|string,
@@ -138,6 +140,7 @@ final class TestingHelper
             [
                 'uuid' => '23b30f01-d8fd-4dca-b36a-4710e360a965',
                 'title' => 'New Blog',
+                'locale' => 'en_GB',
                 'header' => [
                     'type' => 'image',
                     'media' => 1,
@@ -200,6 +203,7 @@ final class TestingHelper
             [
                 'uuid' => '79848403-c1a1-4420-bcc2-06ed537e0d4d',
                 'title' => 'Other Blog',
+                'locale' => 'en_US',
                 'header' => [
                     'type' => 'video',
                     'media' => 'https://www.youtube.com/watch?v=iYM2zFP3Zn0',
@@ -229,6 +233,7 @@ final class TestingHelper
             [
                 'uuid' => '8d90e7d9-2b56-4980-90ce-f91d020cee53',
                 'title' => 'Other Thing',
+                'locale' => 'en_GB',
                 'article' => '<article><h2>Other Thing</h2><p>A html field with some content</p></article>',
                 'footer' => [
                     'title' => 'Other Footer',

--- a/packages/seal/tests/Marshaller/MarshallerTest.php
+++ b/packages/seal/tests/Marshaller/MarshallerTest.php
@@ -73,6 +73,7 @@ class MarshallerTest extends TestCase
         return [
             'uuid' => '23b30f01-d8fd-4dca-b36a-4710e360a965',
             'title' => 'New Blog',
+            'locale' => 'en_GB',
             'header' => [
                 'image' => [
                     'media' => 1,


### PR DESCRIPTION
As reported in Sulu the `locale` filter didn't work as expected as the field is `searchable: false` but `filterable: true` and so not correctly handled.

### Requires Reindex

Run: `cmsig:seal:reindex` command to make sure the index works as expected.