### PR TITLE
Keep Redis Marshaller addRawFilterTextField for BC Reasons

### DIFF
--- a/packages/seal-redisearch-adapter/src/RediSearchIndexer.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchIndexer.php
@@ -29,6 +29,7 @@ final class RediSearchIndexer implements IndexerInterface
     ) {
         $this->marshaller = new Marshaller(
             dateFormat: 'U',
+            addRawFilterTextField: true, // remove in next bc release
             geoPointFieldConfig: [
                 'latitude' => 1,
                 'longitude' => 0,


### PR DESCRIPTION
In https://github.com/PHP-CMSIG/search/pull/689 we changed the Marshaller logic, why we not longer use the raw field older created indexes may still access them. While a drop reindex is recommended and in some cases required for better bc layer we still add the raw field for keep things working as they were before.