### PR TITLE
Update Marshaller config for Redis (BC Break ⚠️)

### DIFF
--- a/packages/seal-redisearch-adapter/src/RediSearchIndexer.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchIndexer.php
@@ -29,7 +29,6 @@ final class RediSearchIndexer implements IndexerInterface
     ) {
         $this->marshaller = new Marshaller(
             dateFormat: 'U',
-            addRawFilterTextField: true, // remove in next bc release
             geoPointFieldConfig: [
                 'latitude' => 1,
                 'longitude' => 0,


### PR DESCRIPTION
As changed in https://github.com/PHP-CMSIG/search/pull/689 for https://github.com/PHP-CMSIG/search/pull/691 the `addRawFilterTextField` is not longer required for Redis and so can be removed.

## BC Breaks

For Redis a complete [reindex with drop](https://php-cmsig.github.io/search/indexing/index.html#reindex-operations) is recommended and in some cases even required to fix #689.