### PR TITLE
Fix multi word search escaping in RediSearchSearcher

### DIFF
--- a/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
@@ -268,7 +268,10 @@ final class RediSearchSearcher implements SearcherInterface
             };
 
             match (true) {
-                $filter instanceof Condition\SearchCondition => $filters[] = '%%' . \implode('%% ', \explode(' ', $this->escapeFilterValue($filter->query))) . '%%', // levenshtein of 2 per word
+                $filter instanceof Condition\SearchCondition => $filters[] = '%%' . \implode('%% %%', \array_map(
+                    $this->escapeFilterValue(...),
+                    \explode(' ', $filter->query),
+                )) . '%%', // levenshtein of 2 per word
                 $filter instanceof Condition\IdentifierCondition => $filters[] = '@' . $index->getIdentifierField()->name . ':{' . $this->escapeFilterValue($filter->identifier) . '}',
                 $filter instanceof Condition\EqualCondition => $filters[] = '@' . $this->getFilterField($index, $filter->field) . ':{' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)) . '}',
                 $filter instanceof Condition\NotEqualCondition => $filters[] = '-@' . $this->getFilterField($index, $filter->field) . ':{' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)) . '}',

--- a/packages/seal/src/Testing/AbstractSearcherTestCase.php
+++ b/packages/seal/src/Testing/AbstractSearcherTestCase.php
@@ -415,6 +415,13 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
+        $search->addFilter(Condition::search('Other Thing'));
+
+        // some search engines will find more and some less so we just search for common match
+        $this->assertContains($documents[2], [...$search->getResult()]);
+
+        $search = new SearchBuilder($schema, self::$searcher);
+        $search->index(TestingHelper::INDEX_COMPLEX);
         $search->addFilter(Condition::search('FARA25008/B'));
 
         $this->assertSame([$documents[0]], [...$search->getResult()]);


### PR DESCRIPTION
Redis when querying for a search term that contains a space, the final redis command is invalid and fails. So example `Other Thing` before ended in `%%Other%% Thing%%` instead of `%%Other%% %%Thing%%`.

fixes #693 