### PR TITLE
Replace deprecated opensearch-php bootstrap APIs in seal-opensearch-adapter

### DIFF
--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -688,17 +688,90 @@ It requires an instance of the ``Adapter`` which we did install before to connec
 
                 Use the following code to create a new ``Engine`` using the ``Opensearch`` adapter:
 
+                First install the adapter:
+
+                .. code-block:: bash
+
+                    composer require cmsig/seal-opensearch-adapter
+
+                Via DSN
+                ~~~~~~~
+
+                When you use the adapter via DSN, ``opensearch-php`` uses discovery to find the installed PSR implementations automatically.
+
+                Your project needs:
+
+                - a ``psr/http-client-implementation``
+                - a ``psr/http-factory-implementation``
+
+                If your framework or application already provides them, no additional HTTP client package is needed.
+
+                Example DSNs:
+
+                .. code-block:: env
+
+                    opensearch://127.0.0.1:9200
+                    opensearch://127.0.0.1:9200?tls=true
+                    opensearch://username:password@127.0.0.1:9200?tls=true
+
+                Example standalone usage via DSN:
+
                 .. code-block:: php
 
                     <?php
 
-                    use OpenSearch\ClientBuilder;
-                    use CmsIg\Seal\Adapter\Opensearch\OpensearchAdapter;
+                    use CmsIg\Seal\Adapter\AdapterFactory;
+                    use CmsIg\Seal\Adapter\Opensearch\OpensearchAdapterFactory;
                     use CmsIg\Seal\Engine;
 
-                    $client = ClientBuilder::create()->setHosts([
-                        '127.0.0.1:9200'
-                    ])->build()
+                    $adapterFactory = new AdapterFactory([
+                        OpensearchAdapterFactory::getName() => new OpensearchAdapterFactory(),
+                    ]);
+
+                    $engine = new Engine(
+                        $adapterFactory->createAdapter('opensearch://127.0.0.1:9200?tls=true'),
+                        $schema,
+                    );
+
+                Manual client creation
+                ~~~~~~~~~~~~~~~~~~~~~~
+
+                If you do not use the adapter via DSN, create an ``OpenSearch\Client`` yourself and pass it to the adapter.
+
+                For example, you can use one of these PSR-18 / PSR-17 stacks:
+
+                .. code-block:: bash
+
+                    # Symfony HTTP Client
+                    composer require symfony/http-client nyholm/psr7
+
+                    # Guzzle
+                    composer require guzzlehttp/guzzle guzzlehttp/psr7
+
+                .. code-block:: php
+
+                    <?php
+
+                    use CmsIg\Seal\Adapter\Opensearch\OpensearchAdapter;
+                    use CmsIg\Seal\Engine;
+                    use OpenSearch\Client;
+
+                    /** @var Client $client */
+                    // Manual client creation example.
+                    //
+                    // Symfony example:
+                    // composer require symfony/http-client nyholm/psr7
+                    // use OpenSearch\SymfonyClientFactory;
+                    // $client = (new SymfonyClientFactory())->create([
+                    //     'base_uri' => 'http://127.0.0.1:9200',
+                    // ]);
+                    //
+                    // Guzzle example:
+                    // composer require guzzlehttp/guzzle guzzlehttp/psr7
+                    // use OpenSearch\GuzzleClientFactory;
+                    // $client = (new GuzzleClientFactory())->create([
+                    //     'base_uri' => 'http://127.0.0.1:9200',
+                    // ]);
 
                     $engine = new Engine(
                         new OpensearchAdapter($client),

--- a/packages/seal-opensearch-adapter/README.md
+++ b/packages/seal-opensearch-adapter/README.md
@@ -33,33 +33,102 @@ The `OpensearchAdapter` write the documents into an [Opensearch](https://github.
 > **Note**:
 > This project is heavily under development and any feedback is greatly appreciated.
 
-## Usage
+## Installation
 
-The following code shows how to create an Engine using this Adapter:
+Install the adapter:
 
-```php
-<?php
-
-use OpenSearch\ClientBuilder;
-use CmsIg\Seal\Adapter\Opensearch\OpensearchAdapter;
-use CmsIg\Seal\Engine;
-
-$client = ClientBuilder::create()->setHosts([
-    '127.0.0.1:9200'
-])->build()
-
-$engine = new Engine(
-    new OpensearchAdapter($client),
-    $schema,
-);
+```bash
+composer require cmsig/seal-opensearch-adapter
 ```
 
-Via DSN for your favorite framework:
+## Usage
+
+### Via DSN
+
+When you use the adapter via DSN, `opensearch-php` uses discovery to find the installed PSR implementations automatically.
+
+Your project needs:
+
+- a `psr/http-client-implementation`
+- a `psr/http-factory-implementation`
+
+If your framework or application already provides them, no additional HTTP client package is needed.
+
+Example DSNs:
 
 ```env
 opensearch://127.0.0.1:9200
 opensearch://127.0.0.1:9200?tls=true
 opensearch://username:password@127.0.0.1:9200?tls=true
+```
+
+Example standalone usage via DSN:
+
+```php
+<?php
+
+use CmsIg\Seal\Adapter\AdapterFactory;
+use CmsIg\Seal\Adapter\Opensearch\OpensearchAdapterFactory;
+use CmsIg\Seal\Engine;
+
+$adapterFactory = new AdapterFactory([
+    OpensearchAdapterFactory::getName() => new OpensearchAdapterFactory(),
+]);
+
+$engine = new Engine(
+    $adapterFactory->createAdapter('opensearch://127.0.0.1:9200?tls=true'),
+    $schema,
+);
+```
+
+### Manual client creation
+
+If you do not use the adapter via DSN, create an `OpenSearch\Client` yourself and pass it to the adapter.
+
+For example, you can use one of these PSR-18 / PSR-17 stacks:
+
+Symfony:
+
+```bash
+composer require symfony/http-client nyholm/psr7
+```
+
+Guzzle:
+
+```bash
+composer require guzzlehttp/guzzle guzzlehttp/psr7
+```
+
+The following code shows how to create an `Engine` using this adapter:
+
+```php
+<?php
+
+use CmsIg\Seal\Adapter\Opensearch\OpensearchAdapter;
+use CmsIg\Seal\Engine;
+use OpenSearch\Client;
+
+/** @var Client $client */
+// Manual client creation example.
+//
+// Symfony example:
+// composer require symfony/http-client nyholm/psr7
+// use OpenSearch\SymfonyClientFactory;
+// $client = (new SymfonyClientFactory())->create([
+//     'base_uri' => 'http://127.0.0.1:9200',
+// ]);
+//
+// Guzzle example:
+// composer require guzzlehttp/guzzle guzzlehttp/psr7
+// use OpenSearch\GuzzleClientFactory;
+// $client = (new GuzzleClientFactory())->create([
+//     'base_uri' => 'http://127.0.0.1:9200',
+// ]);
+
+$engine = new Engine(
+    new OpensearchAdapter($client),
+    $schema,
+);
 ```
 
 ## Authors

--- a/packages/seal-opensearch-adapter/composer.json
+++ b/packages/seal-opensearch-adapter/composer.json
@@ -28,9 +28,9 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "cmsig/seal": "^0.13",
-        "opensearch-project/opensearch-php": "^2.0",
+        "opensearch-project/opensearch-php": "^2.6",
         "psr/container": "^1.0 || ^2.0"
     },
     "require-dev": {

--- a/packages/seal-opensearch-adapter/composer.lock
+++ b/packages/seal-opensearch-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1444459c3bf1eaa768ba3feaff053211",
+    "content-hash": "b24fbc0af4180c4a2826837621363364",
     "packages": [
         {
             "name": "cmsig/seal",
@@ -3892,7 +3892,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1"
+        "php": "^8.2"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/packages/seal-opensearch-adapter/src/BaseUriRequestFactory.php
+++ b/packages/seal-opensearch-adapter/src/BaseUriRequestFactory.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS-IG SEAL project.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CmsIg\Seal\Adapter\Opensearch;
+
+use OpenSearch\RequestFactory;
+use OpenSearch\RequestFactoryInterface;
+use OpenSearch\Serializers\SmartSerializer;
+use Psr\Http\Message\RequestFactoryInterface as PsrRequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\UriFactoryInterface;
+
+final class BaseUriRequestFactory implements RequestFactoryInterface
+{
+    private readonly RequestFactory $requestFactory;
+
+    private readonly string|null $authorizationHeader;
+
+    public function __construct(
+        private readonly string $baseUri,
+        PsrRequestFactoryInterface $psrRequestFactory,
+        StreamFactoryInterface $streamFactory,
+        UriFactoryInterface $uriFactory,
+        string $username = '',
+        string $password = '',
+    ) {
+        $this->requestFactory = new RequestFactory(
+            $psrRequestFactory,
+            $streamFactory,
+            $uriFactory,
+            new SmartSerializer(),
+        );
+        $this->authorizationHeader = '' !== $username || '' !== $password
+            ? 'Basic ' . \base64_encode($username . ':' . $password)
+            : null;
+    }
+
+    /**
+     * @param array{
+     *     host: string,
+     *     port?: int,
+     *     user?: string,
+     *     pass?: string,
+     *     path?: string,
+     *     query: array<string, string|string[]>,
+     * } $dsn
+     */
+    public static function fromDsn(
+        array $dsn,
+        PsrRequestFactoryInterface $psrRequestFactory,
+        StreamFactoryInterface $streamFactory,
+        UriFactoryInterface $uriFactory,
+    ): self {
+        $tlsQuery = $dsn['query']['tls'] ?? 'false';
+        \assert(\is_string($tlsQuery), 'The "tls" query param must be a string.');
+        $useTls = \filter_var($tlsQuery, \FILTER_VALIDATE_BOOLEAN, \FILTER_REQUIRE_SCALAR);
+        $scheme = $useTls ? 'https' : 'http';
+        $port = $dsn['port'] ?? ($useTls ? 443 : 9200);
+        $path = isset($dsn['path']) ? \rtrim($dsn['path'], '/') : '';
+
+        return new self(
+            $scheme . '://' . $dsn['host'] . ':' . $port . $path,
+            $psrRequestFactory,
+            $streamFactory,
+            $uriFactory,
+            $dsn['user'] ?? '',
+            $dsn['pass'] ?? '',
+        );
+    }
+
+    public function createRequest(
+        string $method,
+        string $uri,
+        array $params = [],
+        string|array|null $body = null,
+        array $headers = [],
+    ): RequestInterface {
+        $headers += [
+            'Accept' => 'application/json',
+            'Content-Type' => 'application/json',
+        ];
+
+        if (null !== $this->authorizationHeader) {
+            $headers['Authorization'] = $this->authorizationHeader;
+        }
+
+        return $this->requestFactory->createRequest(
+            $method,
+            $this->baseUri . $uri,
+            $params,
+            $body,
+            $headers,
+        );
+    }
+}

--- a/packages/seal-opensearch-adapter/src/OpensearchAdapterFactory.php
+++ b/packages/seal-opensearch-adapter/src/OpensearchAdapterFactory.php
@@ -15,8 +15,10 @@ namespace CmsIg\Seal\Adapter\Opensearch;
 
 use CmsIg\Seal\Adapter\AdapterFactoryInterface;
 use CmsIg\Seal\Adapter\AdapterInterface;
+use Http\Discovery\Psr17FactoryDiscovery;
 use OpenSearch\Client;
-use OpenSearch\ClientBuilder;
+use OpenSearch\EndpointFactory;
+use OpenSearch\TransportFactory;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -44,6 +46,7 @@ class OpensearchAdapterFactory implements AdapterFactoryInterface
      *     port?: int,
      *     user?: string,
      *     pass?: string,
+     *     path?: string,
      *     query: array<string, string|string[]>,
      * } $dsn
      */
@@ -59,24 +62,20 @@ class OpensearchAdapterFactory implements AdapterFactoryInterface
             return $client;
         }
 
-        $tlsQuery = $dsn['query']['tls'] ?? 'false';
-        \assert(\is_string($tlsQuery), 'The "tls" query param must be a string.');
-        $useTls = \filter_var($tlsQuery, \FILTER_VALIDATE_BOOLEAN, \FILTER_REQUIRE_SCALAR);
-        $scheme = $useTls ? 'https' : 'http';
-        $port = $dsn['port'] ?? ($useTls ? 443 : 9200);
+        $psrRequestFactory = Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = Psr17FactoryDiscovery::findStreamFactory();
+        $uriFactory = Psr17FactoryDiscovery::findUriFactory();
 
-        $client = ClientBuilder::create()->setHosts([
-            $scheme . '://' . $dsn['host'] . ':' . $port,
-        ]);
+        $transport = (new TransportFactory())
+            ->setRequestFactory(BaseUriRequestFactory::fromDsn(
+                $dsn,
+                $psrRequestFactory,
+                $streamFactory,
+                $uriFactory,
+            ))
+            ->create();
 
-        $user = $dsn['user'] ?? '';
-        $pass = $dsn['pass'] ?? '';
-
-        if ($user || $pass) {
-            $client->setBasicAuthentication($user, $pass);
-        }
-
-        return $client->build();
+        return new Client($transport, new EndpointFactory());
     }
 
     public static function getName(): string

--- a/packages/seal-opensearch-adapter/src/OpensearchSearcher.php
+++ b/packages/seal-opensearch-adapter/src/OpensearchSearcher.php
@@ -24,8 +24,8 @@ use CmsIg\Seal\Search\Facet\MinMaxFacet;
 use CmsIg\Seal\Search\Result;
 use CmsIg\Seal\Search\Search;
 use OpenSearch\Client;
-use OpenSearch\Common\Exceptions\Missing404Exception;
-use OpenSearch\Common\Exceptions\OpenSearchException;
+use OpenSearch\Exception\NotFoundHttpException;
+use OpenSearch\Exception\OpenSearchExceptionInterface;
 
 final class OpensearchSearcher implements SearcherInterface
 {
@@ -46,7 +46,7 @@ final class OpensearchSearcher implements SearcherInterface
     {
         try {
             return $this->client->count(['index' => $index->name])['count'] ?? 0; // @phpstan-ignore-line return-type
-        } catch (OpenSearchException) {
+        } catch (OpenSearchExceptionInterface) {
             return 0;
         }
     }
@@ -66,7 +66,7 @@ final class OpensearchSearcher implements SearcherInterface
                     'index' => $search->index->name,
                     'id' => $search->filters[0]->identifier,
                 ]);
-            } catch (Missing404Exception) {
+            } catch (NotFoundHttpException) {
                 return new Result(
                     $this->hitsToDocuments($search->index, [], []),
                     0,

--- a/packages/seal-opensearch-adapter/tests/BaseUriRequestFactoryTest.php
+++ b/packages/seal-opensearch-adapter/tests/BaseUriRequestFactoryTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS-IG SEAL project.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CmsIg\Seal\Adapter\Opensearch\Tests;
+
+use CmsIg\Seal\Adapter\Opensearch\BaseUriRequestFactory;
+use GuzzleHttp\Psr7\HttpFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(BaseUriRequestFactory::class)]
+final class BaseUriRequestFactoryTest extends TestCase
+{
+    /**
+     * @param array{
+     *     host: string,
+     *     port?: int,
+     *     user?: string,
+     *     pass?: string,
+     *     path?: string,
+     *     query: array<string, string|string[]>,
+     * } $dsn
+     */
+    #[DataProvider('provideDsn')]
+    public function testCreateRequestFromDsn(
+        array $dsn,
+        string $expectedUri,
+        bool $expectsAuthorizationHeader,
+    ): void {
+        $httpFactory = new HttpFactory();
+        $requestFactory = BaseUriRequestFactory::fromDsn(
+            $dsn,
+            $httpFactory,
+            $httpFactory,
+            $httpFactory,
+        );
+
+        $request = $requestFactory->createRequest('GET', '/_search');
+
+        $this->assertSame($expectedUri, (string) $request->getUri());
+        $this->assertSame($expectsAuthorizationHeader, $request->hasHeader('Authorization'));
+    }
+
+    public function testCreateRequestUsesBaseUriAndDefaultHeaders(): void
+    {
+        $httpFactory = new HttpFactory();
+        $requestFactory = new BaseUriRequestFactory(
+            'http://127.0.0.1:9200',
+            $httpFactory,
+            $httpFactory,
+            $httpFactory,
+        );
+
+        $request = $requestFactory->createRequest(
+            'GET',
+            '/_search',
+            ['pretty' => true, 'routing' => 'de'],
+        );
+
+        $this->assertSame(
+            'http://127.0.0.1:9200/_search?pretty=true&routing=de',
+            (string) $request->getUri(),
+        );
+        $this->assertSame(['application/json'], $request->getHeader('Accept'));
+        $this->assertSame(['application/json'], $request->getHeader('Content-Type'));
+        $this->assertFalse($request->hasHeader('Authorization'));
+    }
+
+    public function testCreateRequestAddsBasicAuthorizationHeader(): void
+    {
+        $httpFactory = new HttpFactory();
+        $requestFactory = new BaseUriRequestFactory(
+            'https://opensearch.example:443',
+            $httpFactory,
+            $httpFactory,
+            $httpFactory,
+            'user',
+            'pass',
+        );
+
+        $request = $requestFactory->createRequest(
+            'POST',
+            '/test-index/_doc/1',
+            body: ['title' => 'Example'],
+        );
+
+        $this->assertSame(
+            'https://opensearch.example/test-index/_doc/1',
+            (string) $request->getUri(),
+        );
+        $this->assertSame(['Basic dXNlcjpwYXNz'], $request->getHeader('Authorization'));
+        $this->assertSame('{"title":"Example"}', (string) $request->getBody());
+    }
+
+    /**
+     * @return \Generator<string, array{
+     *     0: array{
+     *         host: string,
+     *         port?: int,
+     *         user?: string,
+     *         pass?: string,
+     *         path?: string,
+     *         query: array<string, string|string[]>,
+     *     },
+     *     1: string,
+     *     2: bool,
+     * }>
+     */
+    public static function provideDsn(): \Generator
+    {
+        yield 'http default port' => [
+            [
+                'host' => '127.0.0.1',
+                'query' => [],
+            ],
+            'http://127.0.0.1:9200/_search',
+            false,
+        ];
+
+        yield 'https explicit tls' => [
+            [
+                'host' => '127.0.0.1',
+                'query' => ['tls' => 'true'],
+            ],
+            'https://127.0.0.1/_search',
+            false,
+        ];
+
+        yield 'https explicit port and auth' => [
+            [
+                'host' => 'opensearch.example',
+                'port' => 9443,
+                'user' => 'user',
+                'pass' => 'pass',
+                'query' => ['tls' => 'true'],
+            ],
+            'https://opensearch.example:9443/_search',
+            true,
+        ];
+
+        yield 'http with path prefix' => [
+            [
+                'host' => 'example.com',
+                'path' => '/opensearch',
+                'query' => [],
+            ],
+            'http://example.com:9200/opensearch/_search',
+            false,
+        ];
+    }
+}

--- a/packages/seal-opensearch-adapter/tests/ClientHelper.php
+++ b/packages/seal-opensearch-adapter/tests/ClientHelper.php
@@ -13,8 +13,9 @@ declare(strict_types=1);
 
 namespace CmsIg\Seal\Adapter\Opensearch\Tests;
 
+use CmsIg\Seal\Adapter\AdapterFactory;
+use CmsIg\Seal\Adapter\Opensearch\OpensearchAdapterFactory;
 use OpenSearch\Client;
-use OpenSearch\ClientBuilder;
 
 final class ClientHelper
 {
@@ -23,11 +24,67 @@ final class ClientHelper
     public static function getClient(): Client
     {
         if (!self::$client instanceof Client) {
-            self::$client = ClientBuilder::create()->setHosts([
-                $_ENV['OPENSEARCH_HOST'] ?? '127.0.0.1:9200',
-            ])->build();
+            $host = $_ENV['OPENSEARCH_HOST'] ?? '127.0.0.1:9200';
+            $host = \is_string($host) ? $host : '127.0.0.1:9200';
+
+            $adapterFactory = new AdapterFactory([
+                OpensearchAdapterFactory::getName() => new OpensearchAdapterFactory(),
+            ]);
+
+            self::$client = (new OpensearchAdapterFactory())->createClient(
+                $adapterFactory->parseDsn(self::normalizeDsn($host)),
+            );
         }
 
         return self::$client;
+    }
+
+    public static function normalizeDsn(string $host): string
+    {
+        if (\str_starts_with($host, 'opensearch://')) {
+            return $host;
+        }
+
+        if (\str_starts_with($host, 'http://') || \str_starts_with($host, 'https://')) {
+            $parsedHost = \parse_url($host);
+            \assert(false !== $parsedHost, 'Expected OPENSEARCH_HOST to be a valid URL.');
+
+            $dsn = 'opensearch://';
+
+            if (isset($parsedHost['user'])) {
+                $dsn .= $parsedHost['user'];
+
+                if (isset($parsedHost['pass'])) {
+                    $dsn .= ':' . $parsedHost['pass'];
+                }
+
+                $dsn .= '@';
+            }
+
+            $dsn .= $parsedHost['host'] ?? '';
+
+            if (isset($parsedHost['port'])) {
+                $dsn .= ':' . $parsedHost['port'];
+            }
+
+            $dsn .= $parsedHost['path'] ?? '';
+
+            $query = [];
+            if (isset($parsedHost['query'])) {
+                \parse_str($parsedHost['query'], $query);
+            }
+
+            if ('https' === ($parsedHost['scheme'] ?? '')) {
+                $query['tls'] = 'true';
+            }
+
+            if ([] !== $query) {
+                $dsn .= '?' . \http_build_query($query);
+            }
+
+            return $dsn;
+        }
+
+        return 'opensearch://' . $host;
     }
 }

--- a/packages/seal-opensearch-adapter/tests/ClientHelperTest.php
+++ b/packages/seal-opensearch-adapter/tests/ClientHelperTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS-IG SEAL project.
+ *
+ * (c) Alexander Schranz <alexander@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CmsIg\Seal\Adapter\Opensearch\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ClientHelperTest extends TestCase
+{
+    #[DataProvider('provideHosts')]
+    public function testNormalizeDsn(string $host, string $expectedDsn): void
+    {
+        $this->assertSame($expectedDsn, ClientHelper::normalizeDsn($host));
+    }
+
+    /**
+     * @return \Generator<string, array{0: string, 1: string}>
+     */
+    public static function provideHosts(): \Generator
+    {
+        yield 'host and port' => [
+            '127.0.0.1:9200',
+            'opensearch://127.0.0.1:9200',
+        ];
+
+        yield 'host and tls query' => [
+            '127.0.0.1:9200?tls=true',
+            'opensearch://127.0.0.1:9200?tls=true',
+        ];
+
+        yield 'opensearch dsn' => [
+            'opensearch://user:pass@127.0.0.1:9200?tls=true',
+            'opensearch://user:pass@127.0.0.1:9200?tls=true',
+        ];
+
+        yield 'https url' => [
+            'https://user:pass@example.com:9200',
+            'opensearch://user:pass@example.com:9200?tls=true',
+        ];
+
+        yield 'https url with path prefix' => [
+            'https://user:pass@example.com/opensearch',
+            'opensearch://user:pass@example.com/opensearch?tls=true',
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

Replace deprecated `opensearch-php` APIs in `seal-opensearch-adapter` and switch client bootstrap to the PSR-based transport path.

## Changes

- bump `opensearch-project/opensearch-php` to `^2.4`
- replace deprecated `ClientBuilder` usage in runtime code
- replace deprecated `OpenSearch\Common\Exceptions\*` imports with the new exception namespace
- add `BaseUriRequestFactory` for DSN-based request creation on top of the PSR transport stack
- preserve DSN features used by the adapter, including `tls=true`, basic auth, and optional path prefixes
- route integration tests through `OpensearchAdapterFactory::createClient()`
- add unit coverage for:
  - `BaseUriRequestFactory`
  - DSN normalization in the OpenSearch test helper
- update OpenSearch docs/examples to remove deprecated `ClientBuilder` usage
- document the required standalone client/factory packages for Symfony and Guzzle examples