### PR TITLE
Fix highlighting configuration without query

### DIFF
--- a/packages/seal-loupe-adapter/src/LoupeSearcher.php
+++ b/packages/seal-loupe-adapter/src/LoupeSearcher.php
@@ -158,14 +158,7 @@ final class LoupeSearcher implements SearcherInterface
             );
 
             foreach ($highlightFields as $highlightField) {
-                \assert(
-                    isset($hit['_formatted'])
-                    && \is_array($hit['_formatted'])
-                    && isset($hit['_formatted'][$highlightField]),
-                    \sprintf('Expected highlight field "%s" to be available in the search hit.', $highlightField),
-                );
-
-                $value = $hit['_formatted'][$highlightField];
+                $value = $hit['_formatted'][$highlightField] ?? null;
 
                 if (!\is_string($value)
                     || !\str_contains($value, $highlightPreTag)

--- a/packages/seal/src/Testing/AbstractSearcherTestCase.php
+++ b/packages/seal/src/Testing/AbstractSearcherTestCase.php
@@ -504,6 +504,45 @@ abstract class AbstractSearcherTestCase extends TestCase
         }
     }
 
+    public function testFilterSearchWithHighlightWithoutQuery(): void
+    {
+        $documents = TestingHelper::createComplexFixtures();
+
+        $schema = self::getSchema();
+
+        foreach ($documents as $document) {
+            self::$taskHelper->tasks[] = self::$indexer->save(
+                $schema->indexes[TestingHelper::INDEX_COMPLEX],
+                $document,
+                ['return_slow_promise_result' => true],
+            );
+        }
+        self::$taskHelper->waitForAll();
+
+        $search = new SearchBuilder($schema, self::$searcher);
+        $search->index(TestingHelper::INDEX_COMPLEX);
+        $search->addFilter(Condition::equal('locale', 'en_GB'));
+        $search->addSortBy('title', 'asc');
+        $search->highlight(['title', 'article'], '<mark>', '</mark>');
+
+        $expectedDocumentA = $documents[0];
+        $expectedDocumentA['_formatted']['title'] = null;
+        $expectedDocumentA['_formatted']['article'] = null;
+        $expectedDocumentB = $documents[2];
+        $expectedDocumentB['_formatted']['title'] = null;
+        $expectedDocumentB['_formatted']['article'] = null;
+
+        $this->assertSame([$expectedDocumentA, $expectedDocumentB], [...$search->getResult()]);
+
+        foreach ($documents as $document) {
+            self::$taskHelper->tasks[] = self::$indexer->delete(
+                $schema->indexes[TestingHelper::INDEX_COMPLEX],
+                $document['uuid'],
+                ['return_slow_promise_result' => true],
+            );
+        }
+    }
+
     public function testNoneSearchableFields(): void
     {
         $documents = TestingHelper::createComplexFixtures();


### PR DESCRIPTION
Currently, when searching without a query but e.g. filters and sorting (so a valid request), this leads to an issue if you also provide the fields to highlight configuration (at least for the Loupe adapter).
Why is that? Why not just ignore it? In most cases, the fields to highlight configuration is static and the current logic forces devs to first check if there is a query and if not, not set the fields to highlight?

Can't we just ignore that? Or automatically unset the fields to highlight setting if there is no query?