### PR TITLE
Fix Redis and MemorySearcher with space behind and modify levenshtein algorithm

### DIFF
--- a/packages/seal-memory-adapter/src/MemorySearcher.php
+++ b/packages/seal-memory-adapter/src/MemorySearcher.php
@@ -165,7 +165,7 @@ final class MemorySearcher implements SearcherInterface
 
                 $text = \json_encode($searchableDocument, \JSON_THROW_ON_ERROR);
                 $query = \trim(\json_encode($filter->query, \JSON_THROW_ON_ERROR), '"');
-                $terms = \explode(' ', $query);
+                $terms = \array_filter(\explode(' ', $query), \trim(...)); // @phpstan-ignore-line argument.type
                 $searchTerms = \array_unique([...$searchTerms, ...$terms]);
 
                 $hasSomeMatch = false;

--- a/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
@@ -273,7 +273,7 @@ final class RediSearchSearcher implements SearcherInterface
                         $escapedTerm = $this->escapeFilterValue($term);
 
                         // levenshtein algorithm per word length
-                        return match (\strlen($escapedTerm)) {
+                        return match (\strlen($term)) {
                             0, 1 => $escapedTerm,
                             2 => '%' . $escapedTerm . '%',
                             default => '%%' . $escapedTerm . '%%',

--- a/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
+++ b/packages/seal-redisearch-adapter/src/RediSearchSearcher.php
@@ -268,10 +268,19 @@ final class RediSearchSearcher implements SearcherInterface
             };
 
             match (true) {
-                $filter instanceof Condition\SearchCondition => $filters[] = '%%' . \implode('%% %%', \array_map(
-                    $this->escapeFilterValue(...),
-                    \explode(' ', $filter->query),
-                )) . '%%', // levenshtein of 2 per word
+                $filter instanceof Condition\SearchCondition => $filters[] = \implode(' ', \array_map(
+                    function (string $term) {
+                        $escapedTerm = $this->escapeFilterValue($term);
+
+                        // levenshtein algorithm per word length
+                        return match (\strlen($escapedTerm)) {
+                            0, 1 => $escapedTerm,
+                            2 => '%' . $escapedTerm . '%',
+                            default => '%%' . $escapedTerm . '%%',
+                        };
+                    },
+                    \array_filter(\explode(' ', $filter->query), \trim(...)), // @phpstan-ignore-line argument.type
+                )),
                 $filter instanceof Condition\IdentifierCondition => $filters[] = '@' . $index->getIdentifierField()->name . ':{' . $this->escapeFilterValue($filter->identifier) . '}',
                 $filter instanceof Condition\EqualCondition => $filters[] = '@' . $this->getFilterField($index, $filter->field) . ':{' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)) . '}',
                 $filter instanceof Condition\NotEqualCondition => $filters[] = '-@' . $this->getFilterField($index, $filter->field) . ':{' . $this->escapeFilterValue($this->convertValue($index, $filter->field, $filter->value)) . '}',

--- a/packages/seal/src/Testing/AbstractSearcherTestCase.php
+++ b/packages/seal/src/Testing/AbstractSearcherTestCase.php
@@ -415,10 +415,11 @@ abstract class AbstractSearcherTestCase extends TestCase
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);
-        $search->addFilter(Condition::search('Other Thing'));
+        $search->addFilter(Condition::search('Other Thing ')); // test multi word and space behind
 
         // some search engines will find more and some less so we just search for common match
         $this->assertContains($documents[2], [...$search->getResult()]);
+        $this->assertLessThanOrEqual(2, \count([...$search->getResult()]));
 
         $search = new SearchBuilder($schema, self::$searcher);
         $search->index(TestingHelper::INDEX_COMPLEX);


### PR DESCRIPTION
Currently a space at end of string did error in RediSearch as it ended in something like`'%%%%'` which Redisearch don't like.

Also in MemorySearch the same term like e.g. `"Other Thing "` (with space at end) did end in all match. This is fixed in this Pull Request.

fixes #700 