### PR TITLE
Fix highlight without search query in Loupe

### DIFF
--- a/packages/seal-loupe-adapter/src/LoupeSearcher.php
+++ b/packages/seal-loupe-adapter/src/LoupeSearcher.php
@@ -158,19 +158,12 @@ final class LoupeSearcher implements SearcherInterface
             );
 
             foreach ($highlightFields as $highlightField) {
-                \assert(
-                    isset($hit['_formatted'])
-                    && \is_array($hit['_formatted'])
-                    && isset($hit['_formatted'][$highlightField]),
-                    \sprintf('Expected highlight field "%s" to be available in the search hit.', $highlightField),
-                );
-
-                $value = $hit['_formatted'][$highlightField];
-
-                if (!\is_string($value)
-                    || !\str_contains($value, $highlightPreTag)
+                $value = null;
+                if (\is_array($hit['_formatted'] ?? null)
+                    && \is_string($hit['_formatted'][$highlightField] ?? null)
+                    && \str_contains($hit['_formatted'][$highlightField], $highlightPreTag)
                 ) {
-                    $value = null;
+                    $value = $hit['_formatted'][$highlightField];
                 }
 
                 $document['_formatted'][$highlightField] = $value;

--- a/packages/seal-redisearch-adapter/tests/RediSearchSearcherTest.php
+++ b/packages/seal-redisearch-adapter/tests/RediSearchSearcherTest.php
@@ -45,6 +45,14 @@ class RediSearchSearcherTest extends AbstractSearcherTestCase
     /**
      * @doesNotPerformAssertions
      */
+    public function testFilterSearchWithHighlightWithoutQuery(): void
+    {
+        $this->markTestSkipped('Not supported by RediSearch: https://github.com/RediSearch/RediSearch/issues/4420 or https://redis.io/docs/latest/develop/interact/search-and-query/indexing/#limitations');
+    }
+
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testCountFacetOnMultiValue(): void
     {
         $this->markTestSkipped('Not supported by RediSearch: https://github.com/PHP-CMSIG/search/issues/583');

--- a/packages/seal/src/Testing/AbstractSearcherTestCase.php
+++ b/packages/seal/src/Testing/AbstractSearcherTestCase.php
@@ -526,11 +526,15 @@ abstract class AbstractSearcherTestCase extends TestCase
         $search->highlight(['title', 'article'], '<mark>', '</mark>');
 
         $expectedDocumentA = $documents[0];
-        $expectedDocumentA['_formatted']['title'] = null;
-        $expectedDocumentA['_formatted']['article'] = null;
+        $expectedDocumentA['_formatted'] = [
+            'title' => null,
+            'article' => null,
+        ];
         $expectedDocumentB = $documents[2];
-        $expectedDocumentB['_formatted']['title'] = null;
-        $expectedDocumentB['_formatted']['article'] = null;
+        $expectedDocumentB['_formatted'] = [
+            'title' => null,
+            'article' => null,
+        ];
 
         $this->assertSame([$expectedDocumentA, $expectedDocumentB], [...$search->getResult()]);
 

--- a/packages/seal/src/Testing/AbstractSearcherTestCase.php
+++ b/packages/seal/src/Testing/AbstractSearcherTestCase.php
@@ -504,6 +504,45 @@ abstract class AbstractSearcherTestCase extends TestCase
         }
     }
 
+    public function testFilterSearchWithHighlightWithoutQuery(): void
+    {
+        $documents = TestingHelper::createComplexFixtures();
+
+        $schema = self::getSchema();
+
+        foreach ($documents as $document) {
+            self::$taskHelper->tasks[] = self::$indexer->save(
+                $schema->indexes[TestingHelper::INDEX_COMPLEX],
+                $document,
+                ['return_slow_promise_result' => true],
+            );
+        }
+        self::$taskHelper->waitForAll();
+
+        $search = new SearchBuilder($schema, self::$searcher);
+        $search->index(TestingHelper::INDEX_COMPLEX);
+        $search->addFilter(Condition::equal('locale', 'en_GB'));
+        $search->addSortBy('title', 'asc');
+        $search->highlight(['title', 'article'], '<mark>', '</mark>');
+
+        $expectedDocumentA = $documents[0];
+        $expectedDocumentA['_formatted']['title'] = null;
+        $expectedDocumentA['_formatted']['article'] = null;
+        $expectedDocumentB = $documents[2];
+        $expectedDocumentB['_formatted']['title'] = null;
+        $expectedDocumentB['_formatted']['article'] = null;
+
+        $this->assertSame([$expectedDocumentA, $expectedDocumentB], [...$search->getResult()]);
+
+        foreach ($documents as $document) {
+            self::$taskHelper->tasks[] = self::$indexer->delete(
+                $schema->indexes[TestingHelper::INDEX_COMPLEX],
+                $document['uuid'],
+                ['return_slow_promise_result' => true],
+            );
+        }
+    }
+
     public function testNoneSearchableFields(): void
     {
         $documents = TestingHelper::createComplexFixtures();


### PR DESCRIPTION
It is common that the highlight is defined always even there is no search query submitted. Currently ~Redis and~ Loupe may have issues, while Loupe issue was already fixed upstream in 0.13.19 we maybe should be less strict and relax that part. 

fixes #549, see also #698, #699