### PR TITLE
Upgrade all Github CI uses actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/callable-test.yml
+++ b/.github/workflows/callable-test.yml
@@ -40,7 +40,7 @@ jobs:
                   echo "${{ github.event.pull_request.head.sha }}"
 
             - name: Checkout project
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   ref: "${{ github.event.pull_request.head.sha }}"
 
@@ -75,7 +75,7 @@ jobs:
                   fi
 
             - name: Install composer dependencies
-              uses: ramsey/composer-install@v2
+              uses: ramsey/composer-install@v4
               env:
                   COMPOSER_ROOT_VERSION: "${{ steps.composer-root-version.outputs.value }}"
               with:

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -20,7 +20,7 @@ jobs:
                   echo "${{ github.event.pull_request.head.sha }}"
 
             - name: Checkout project
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   ref: "${{ github.event.pull_request.head.sha }}"
 
@@ -29,7 +29,7 @@ jobs:
                   git rev-parse HEAD
                   git branch --show-current
 
-            - uses: actions/setup-python@v5
+            - uses: actions/setup-python@v7
               with:
                   python-version: 3.12
 
@@ -46,7 +46,7 @@ jobs:
                   sphinx-build docs docs/_build
 
             - name: Deploy
-              uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+              uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
               with:
                   publish_branch: gh-pages
                   github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -14,7 +14,7 @@ jobs:
                   echo "${{ github.event.pull_request.head.sha }}"
 
             - name: Checkout project
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   ref: "${{ github.event.pull_request.head.sha }}"
 
@@ -23,7 +23,7 @@ jobs:
                   git rev-parse HEAD
                   git branch --show-current
 
-            - uses: actions/setup-python@v5
+            - uses: actions/setup-python@v7
               with:
                   python-version: 3.12
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
                   echo "${{ github.event.pull_request.head.sha }}"
 
             - name: Checkout project
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   ref: "${{ github.event.pull_request.head.sha }}"
 
@@ -46,7 +46,7 @@ jobs:
                   fi
 
             - name: Install composer dependencies
-              uses: ramsey/composer-install@v2
+              uses: ramsey/composer-install@v4
               env:
                   COMPOSER_ROOT_VERSION: "${{ steps.composer-root-version.outputs.value }}"
               with:

--- a/.github/workflows/publish-subsplits.yml
+++ b/.github/workflows/publish-subsplits.yml
@@ -16,7 +16,7 @@ jobs:
         runs-on: ubuntu-latest
         name: Publish package sub-splits
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: '0'
                   persist-credentials: 'false'
@@ -29,7 +29,7 @@ jobs:
 
             - name: Cache splitsh-lite
               id: splitsh-cache
-              uses: actions/cache@v4
+              uses: actions/cache@v6
               with:
                   path: './.splitsh'
                   key: '${{ runner.os }}-splitsh'


### PR DESCRIPTION
Currently CI fails with:


> Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
Run actions/checkout@v4
Error: Refusing to check out fork pull request code from a 'pull_request_target' workflow. This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch cache scope, and runner access. Fetching and executing a fork's code in that trusted context commonly leads to "pwn request" vulnerabilities. To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.