### PR TITLE
Remove pull_request_target from Github CI

### DIFF
--- a/.github/workflows/callable-test.yml
+++ b/.github/workflows/callable-test.yml
@@ -10,12 +10,16 @@ on:
                 required: true
                 type: boolean
 
+permissions:
+    contents: read
+
 jobs:
     test:
         name: "PHP ${{ matrix.php-version }}"
         runs-on: ubuntu-latest
 
-        env: ${{ secrets }}
+        env:
+            ALGOLIA_DSN: ${{ vars.ALGOLIA_DSN }}
 
         strategy:
             fail-fast: false
@@ -34,6 +38,12 @@ jobs:
                       dependency-versions: 'highest'
 
         steps:
+            - name: Validate Algolia configuration
+              if: ${{ env.ALGOLIA_DSN == '' }}
+              run: |
+                  echo "::error::Missing required Actions repository variable ALGOLIA_DSN."
+                  exit 1
+
             - name: Output infos
               run: |
                   echo "${{ github.event.pull_request.merge_commit_sha }}"
@@ -41,8 +51,6 @@ jobs:
 
             - name: Checkout project
               uses: actions/checkout@v7
-              with:
-                  ref: "${{ github.event.pull_request.head.sha }}"
 
             - name: Git infos
               run: |

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -1,7 +1,10 @@
 name: Docs Test
 
 on:
-    pull_request_target:
+    pull_request:
+
+permissions:
+    contents: read
 
 jobs:
     docs-build:
@@ -15,8 +18,6 @@ jobs:
 
             - name: Checkout project
               uses: actions/checkout@v7
-              with:
-                  ref: "${{ github.event.pull_request.head.sha }}"
 
             - name: Git infos
               run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,13 @@
 name: Lint
 
 on:
-    pull_request_target:
+    pull_request:
     push:
         branches:
             - '[0-9]+.[0-9]+'
+
+permissions:
+    contents: read
 
 jobs:
     lint:
@@ -19,8 +22,6 @@ jobs:
 
             - name: Checkout project
               uses: actions/checkout@v7
-              with:
-                  ref: "${{ github.event.pull_request.head.sha }}"
 
             - name: Git infos
               run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,13 @@
 name: Test
 
 on:
-    pull_request_target:
+    pull_request:
     push:
         branches:
             - '[0-9]+.[0-9]+'
+
+permissions:
+    contents: read
 
 jobs:
     seal-core:
@@ -48,7 +51,6 @@ jobs:
         with:
             directory: 'packages/seal-algolia-adapter'
             docker: false
-        secrets: inherit
 
     loupe-adapter:
         name: Loupe Adapter
@@ -63,7 +65,6 @@ jobs:
         with:
             directory: 'packages/seal-redisearch-adapter'
             docker: true
-        secrets: inherit
 
     solr-adapter:
         name: Solr Adapter
@@ -71,7 +72,6 @@ jobs:
         with:
             directory: 'packages/seal-solr-adapter'
             docker: true
-        secrets: inherit
 
     typesense-adapter:
         name: Typesense Adapter
@@ -86,7 +86,6 @@ jobs:
         with:
             directory: '.examples/symfony'
             docker: true
-        secrets: inherit
 
     laravel-integration-example:
         name: Laravel Integration Example
@@ -94,7 +93,6 @@ jobs:
         with:
             directory: '.examples/laravel'
             docker: true
-        secrets: inherit
 
     spiral-integration-example:
         name: Spiral Integration Example
@@ -102,7 +100,6 @@ jobs:
         with:
             directory: '.examples/spiral'
             docker: true
-        secrets: inherit
 
     mezzio-integration-example:
         name: Mezzio Integration Example
@@ -110,7 +107,6 @@ jobs:
         with:
             directory: '.examples/mezzio'
             docker: true
-        secrets: inherit
 
     yii-integration-example:
         name: Yii Integration Example
@@ -118,4 +114,3 @@ jobs:
         with:
             directory: '.examples/yii'
             docker: true
-        secrets: inherit


### PR DESCRIPTION
We had updated the CI and we need refactor the ALGOLIA DSN handling so pull requests can still test against Algolia.