### PR TITLE
Add documentation for SEAL use cases

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,6 +69,7 @@ Contents
     indexing/index
     search-and-filters/index
     cookbooks/index
+    use-cases/index
     research/index
 
 ..

--- a/docs/use-cases/index.rst
+++ b/docs/use-cases/index.rst
@@ -1,0 +1,48 @@
+Use cases
+=========
+
+SEAL is used by data-processing frameworks and content management systems that
+need one API for multiple search engines.
+
+Flow PHP
+--------
+
+`Flow PHP <https://flow-php.com/>`__ uses the ``flow-php/etl-adapter-seal``
+package to write rows from its data pipelines to search indexes. Flow replaced
+its dedicated Elasticsearch adapter with SEAL so the same pipeline can target
+Elasticsearch, OpenSearch, Meilisearch, Solr, Typesense, Algolia, RediSearch,
+or Loupe.
+
+- `SEAL DSL reference in Flow PHP <https://flow-php.com/documentation/dsl/seal/>`__
+- `Flow PHP migration guide <https://flow-php.com/documentation/upgrading/#removal-of-elasticsearch-adapter>`__
+
+Other systems
+-------------
+
+Contao CMS
+~~~~~~~~~~
+
+`Contao CMS <https://contao.org/>`__ uses SEAL for its back end search.
+Administrators can select a search engine through a DSN, while the
+``contao/loupe-bridge`` package provides a local option that does not require a
+separate search server.
+
+See the `Contao back end search documentation <https://docs.contao.org/5.x/manual/en/installation/system-requirements/backend-search/>`__.
+
+Sulu CMS
+~~~~~~~~
+
+`Sulu CMS <https://sulu.io/>`__ uses the SEAL bundle for search in both its
+administration interface and websites since Sulu 3.0.
+
+See the `Sulu search documentation <https://docs.sulu.io/en/3.0/cookbook/using-elasticsearch.html>`__.
+
+TYPO3
+~~~~~
+
+The `TYPO3 SEAL extension <https://github.com/lochmueller/seal>`__ connects
+TYPO3's indexing system to SEAL. It provides front end search, autocomplete,
+schema management, and DSN-based selection of search engine adapters.
+
+Are you using SEAL? Share your project and setup in the
+`SEAL usage discussion <https://github.com/PHP-CMSIG/search/discussions/416>`__.

--- a/docs/use-cases/index.rst
+++ b/docs/use-cases/index.rst
@@ -16,8 +16,8 @@ or Loupe.
 - `SEAL DSL reference in Flow PHP <https://flow-php.com/documentation/dsl/seal/>`__
 - `Flow PHP migration guide <https://flow-php.com/documentation/upgrading/#removal-of-elasticsearch-adapter>`__
 
-Other systems
--------------
+Content management systems
+--------------------------
 
 Contao CMS
 ~~~~~~~~~~

--- a/docs/use-cases/index.rst
+++ b/docs/use-cases/index.rst
@@ -10,7 +10,7 @@ Flow PHP
 `Flow PHP <https://flow-php.com/>`__ uses the ``flow-php/etl-adapter-seal``
 package to write rows from its data pipelines to search indexes. Flow replaced
 its dedicated Elasticsearch adapter with SEAL so the same pipeline can target
-Elasticsearch, OpenSearch, Meilisearch, Solr, Typesense, Algolia, RediSearch,
+Elasticsearch, Opensearch, Meilisearch, Solr, Typesense, Algolia, RediSearch,
 or Loupe.
 
 - `SEAL DSL reference in Flow PHP <https://flow-php.com/documentation/dsl/seal/>`__


### PR DESCRIPTION
Adds a use-cases page showing how Flow PHP, Contao, Sulu, and TYPO3 use SEAL, with links to each project’s documentation.

Closes #703

Tests: `sphinx-build -W --keep-going docs docs/_build`